### PR TITLE
fix(app): dispatch AppKit UI updates to main thread

### DIFF
--- a/src/voicetext/app.py
+++ b/src/voicetext/app.py
@@ -364,7 +364,12 @@ class VoiceTextApp(rumps.App):
         )
 
     def _set_status(self, text: str) -> None:
-        """Update menu bar title and status menu item."""
+        """Update menu bar title and status menu item (thread-safe)."""
+        import Foundation
+        if not Foundation.NSThread.isMainThread():
+            from PyObjCTools import AppHelper
+            AppHelper.callAfter(self._set_status, text)
+            return
         self.title = text
         self._status_item.title = text
 
@@ -2915,7 +2920,12 @@ models:
         return None
 
     def _update_model_checkmarks(self) -> None:
-        """Update checkmark state on all model menu items (local + remote)."""
+        """Update checkmark state on all model menu items (thread-safe)."""
+        import Foundation
+        if not Foundation.NSThread.isMainThread():
+            from PyObjCTools import AppHelper
+            AppHelper.callAfter(self._update_model_checkmarks)
+            return
         for pid, item in self._model_menu_items.items():
             item.state = 1 if pid == self._current_preset_id else 0
         for key, item in self._remote_asr_menu_items.items():


### PR DESCRIPTION
Add thread-safety guards to _set_status and _update_model_checkmarks using Foundation.NSThread.isMainThread() + AppHelper.callAfter to prevent IMKCFRunLoopWakeUpReliable mach port errors and hangs.