### PR TITLE
feat(statusbar): replace text labels with SF Symbol icons

### DIFF
--- a/src/voicetext/app.py
+++ b/src/voicetext/app.py
@@ -396,13 +396,17 @@ class VoiceTextApp(rumps.App):
         if cached is not None:
             return cached
         try:
-            from AppKit import NSImage
+            from AppKit import NSImage, NSImageSymbolConfiguration
             if not hasattr(NSImage, "imageWithSystemSymbolName_accessibilityDescription_"):
                 return None
             img = NSImage.imageWithSystemSymbolName_accessibilityDescription_(
                 name, description or name
             )
             if img is not None:
+                config = NSImageSymbolConfiguration.configurationWithPointSize_weight_(
+                    17.0, 0  # 0 = NSFontWeightRegular
+                )
+                img = img.imageWithSymbolConfiguration_(config)
                 img.setTemplate_(True)
                 _sf_symbol_cache[name] = img
             return img


### PR DESCRIPTION
## Summary
- Replace text status labels ("VT", "Recording...", "Transcribing...", etc.) with SF Symbol icons in the macOS menu bar for better visual UX
- Add `_sf_symbol_image()` helper with image caching and macOS < 11 fallback
- Fix thread-safety bug: vocab build was mutating `self.title` from background thread; now uses `_set_status()` with proper main-thread dispatch

## Icon Mapping
| Status | SF Symbol | Icon |
|--------|-----------|------|
| Idle (VT) | `mic.fill` | 🎤 |
| Recording | `waveform` | 〰️ |
| Transcribing | `text.bubble` | 💬 |
| Enhancing | `sparkles` | ✨ |
| Preview | `eye` | 👁️ |
| Empty | `mic.slash` | 🚫 |
| Error | `exclamationmark.triangle` | ⚠️ |
| Loading | `cpu` | 🖥️ |
| Downloading | `arrow.down.circle` | ⬇️ |
| Vocab Build | `book.fill` | 📖 |

## Test plan
- [x] `uv run pytest tests/` — 658 passed (pre-existing `test_version` failures excluded)
- [ ] Manual: launch app, verify icons for idle/recording/transcribing/enhancing/preview/error states
- [ ] Manual: toggle light/dark mode, verify icons adapt (template mode)
- [ ] Manual: verify dropdown menu still shows descriptive text
- [ ] Manual: trigger model download, verify progress percentage shows next to icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)