### PR TITLE
fix(config): reload enhancement mode files on Reload Config

### DIFF
--- a/src/voicetext/app.py
+++ b/src/voicetext/app.py
@@ -3602,6 +3602,10 @@ models:
                 for key, item in self._llm_model_menu_items.items():
                     item.state = 1 if key == current_key else 0
 
+            # Reload enhancement mode definitions from disk
+            self._enhancer.reload_modes()
+            self._rebuild_enhance_mode_menu()
+
         # Feedback settings
         fb_cfg = new_config.get("feedback", {})
         self._sound_manager.enabled = fb_cfg.get("sound_enabled", True)


### PR DESCRIPTION
## Summary
- `_on_reload_config` 之前只重载了 `config.toml` 中的设置，但没有重新读取 `~/.config/VoiceText/enhance_modes/` 下的 `.md` mode 文件
- 编辑 prompt 文件（如 `proofread.md`）后，必须重启应用才能生效
- 现在点击菜单栏 **Reload Config** 会同时调用 `reload_modes()` 并重建模式菜单

## Test plan
- [ ] 编辑 `~/.config/VoiceText/enhance_modes/proofread.md`，修改 prompt 内容
- [ ] 点击菜单栏 Reload Config
- [ ] 验证增强模式使用的是更新后的 prompt
- [ ] 验证新增/删除 `.md` 文件后 Reload Config 能正确更新菜单项

🤖 Generated with [Claude Code](https://claude.com/claude-code)