### PR TITLE
refactor(app): replace rumps with pure PyObjC statusbar framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## UI Dialogs
 
-This is a macOS statusbar (accessory) app. Standard `rumps.alert()` / `rumps.notification()` dialogs will not appear on screen because the app has no foreground presence.
+This is a macOS statusbar (accessory) app built with pure PyObjC (via `statusbar.py`). Standard modal dialogs will not appear on screen because the app has no foreground presence.
 
 When you need to show a user-facing dialog (error, warning, confirmation), use `self._topmost_alert()` instead. It activates the app, sets `NSStatusWindowLevel`, and runs a modal `NSAlert` so the dialog is always visible. Call `self._restore_accessory()` afterward to return to statusbar-only mode.
 
@@ -11,11 +11,11 @@ self._topmost_alert(title="...", message="...")
 self._restore_accessory()
 ```
 
-`rumps.notification()` will crash with `Info.plist` / `CFBundleIdentifier` errors when running directly from the terminal (`uv run`) without app bundling. This is expected during development — wrap calls in try/except and log the error instead of crashing. In a packaged app `rumps.notification()` works normally, so it is fine to use for non-critical user feedback.
+`send_notification()` (from `statusbar.py`) may fail with `Info.plist` / `CFBundleIdentifier` errors when running directly from the terminal (`uv run`) without app bundling. This is expected during development — the function catches exceptions internally and logs them. In a packaged app notifications work normally.
 
 ## Showing NSPanel / NSWindow from Menu Callbacks
 
-When showing an NSPanel from a rumps menu callback (e.g. clicking "Settings..."), the window must be created and displayed **synchronously within the callback**. Do NOT use `AppHelper.callAfter()` to defer the `show()` call.
+When showing an NSPanel from a menu callback (e.g. clicking "Settings..."), the window must be created and displayed **synchronously within the callback**. Do NOT use `AppHelper.callAfter()` to defer the `show()` call.
 
 **Why:** In a statusbar app (`NSApplicationActivationPolicyAccessory`), clicking a menu item briefly activates the app for menu tracking. When the menu callback returns, the app falls back to accessory mode. If `show()` is deferred via `callAfter`, it runs after the app has deactivated — the window is created but never appears on screen.
 

--- a/debug_scripts/test_rumps_window.py
+++ b/debug_scripts/test_rumps_window.py
@@ -1,17 +1,21 @@
-"""Minimal test to debug rumps.Window in menu callbacks."""
+"""Minimal test to debug statusbar window/alert in menu callbacks."""
 
-import rumps
-from AppKit import NSApp, NSApplication
+from AppKit import NSAlert, NSApp, NSApplication
+from voicetext.statusbar import (
+    InputWindow,
+    StatusBarApp,
+    StatusMenuItem,
+)
 
 
-class TestApp(rumps.App):
+class TestApp(StatusBarApp):
     def __init__(self):
         super().__init__("Test", title="T")
 
         self.menu = [
-            rumps.MenuItem("Alert (no fix)", callback=self._on_alert_raw),
-            rumps.MenuItem("Alert (with policy)", callback=self._on_alert_fix),
-            rumps.MenuItem("Window (with policy)", callback=self._on_window_fix),
+            StatusMenuItem("Alert (no fix)", callback=self._on_alert_raw),
+            StatusMenuItem("Alert (with policy)", callback=self._on_alert_fix),
+            StatusMenuItem("Window (with policy)", callback=self._on_window_fix),
         ]
 
     def _activate_for_dialog(self):
@@ -25,20 +29,26 @@ class TestApp(rumps.App):
 
     def _on_alert_raw(self, _):
         print("[raw] callback fired", flush=True)
-        result = rumps.alert("Test", "No fix applied")
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("Test")
+        alert.setInformativeText_("No fix applied")
+        result = alert.runModal()
         print(f"[raw] result: {result}", flush=True)
 
     def _on_alert_fix(self, _):
         print("[fix] callback fired", flush=True)
         self._activate_for_dialog()
-        result = rumps.alert("Test", "With activation policy fix")
+        alert = NSAlert.alloc().init()
+        alert.setMessageText_("Test")
+        alert.setInformativeText_("With activation policy fix")
+        result = alert.runModal()
         self._restore_accessory()
         print(f"[fix] result: {result}", flush=True)
 
     def _on_window_fix(self, _):
         print("[window] callback fired", flush=True)
         self._activate_for_dialog()
-        w = rumps.Window("Test Window", "Enter text:", "hello", ok="OK", cancel="Cancel")
+        w = InputWindow("Enter text:", "Test Window", "hello", ok="OK", cancel="Cancel")
         resp = w.run()
         self._restore_accessory()
         print(f"[window] clicked={resp.clicked}, text={resp.text}", flush=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.0.4"
 description = "macOS menubar app: hold hotkey to record, release to transcribe and type"
 requires-python = ">=3.13"
 dependencies = [
-    "rumps>=0.4.0",
+    "pyobjc-framework-Cocoa>=10.0",
     "sounddevice>=0.5.0",
     "soundfile>=0.13.0",
     "numpy>=1.24.0",

--- a/src/voicetext/app.py
+++ b/src/voicetext/app.py
@@ -13,7 +13,6 @@ import threading
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-import rumps
 from ApplicationServices import AXIsProcessTrusted, AXIsProcessTrustedWithOptions
 from CoreFoundation import kCFBooleanTrue
 
@@ -48,6 +47,13 @@ from .model_registry import (
 from .recorder import Recorder
 from .recording_indicator import RecordingIndicatorPanel
 from .sound_manager import SoundManager
+from .statusbar import (
+    InputWindow,
+    StatusBarApp,
+    StatusMenuItem,
+    quit_application,
+    send_notification,
+)
 from .streaming_overlay import StreamingOverlayPanel
 from .transcriber import create_transcriber
 
@@ -93,7 +99,7 @@ _STATUS_ICONS: Dict[str, str] = {
 _sf_symbol_cache: Dict[str, Any] = {}
 
 
-class VoiceTextApp(rumps.App):
+class VoiceTextApp(StatusBarApp):
     """Menubar app: hold hotkey to record, release to transcribe and type."""
 
     def __init__(self, config_path: Optional[str] = None) -> None:
@@ -197,25 +203,25 @@ class VoiceTextApp(rumps.App):
                 )
 
         # Menu items
-        self._status_item = rumps.MenuItem("Ready")
+        self._status_item = StatusMenuItem("Ready")
         self._status_item.set_callback(None)
         # Hotkey submenu
-        self._hotkey_menu = rumps.MenuItem("Hotkey")
-        self._hotkey_menu_items: Dict[str, rumps.MenuItem] = {}
-        self._hotkey_record_item = rumps.MenuItem(
+        self._hotkey_menu = StatusMenuItem("Hotkey")
+        self._hotkey_menu_items: Dict[str, StatusMenuItem] = {}
+        self._hotkey_record_item = StatusMenuItem(
             "Record Hotkey...", callback=self._on_record_hotkey
         )
         self._build_hotkey_menu()
 
         # STT Model submenu
-        self._model_menu = rumps.MenuItem("STT Model")
-        self._model_menu_items: Dict[str, rumps.MenuItem] = {}
-        self._remote_asr_menu_items: Dict[Tuple[str, str], rumps.MenuItem] = {}
-        self._asr_add_provider_item = rumps.MenuItem(
+        self._model_menu = StatusMenuItem("STT Model")
+        self._model_menu_items: Dict[str, StatusMenuItem] = {}
+        self._remote_asr_menu_items: Dict[Tuple[str, str], StatusMenuItem] = {}
+        self._asr_add_provider_item = StatusMenuItem(
             "Add ASR Provider...", callback=self._on_asr_add_provider
         )
-        self._asr_remove_provider_menu = rumps.MenuItem("Remove ASR Provider")
-        self._asr_remove_provider_items: Dict[str, rumps.MenuItem] = {}
+        self._asr_remove_provider_menu = StatusMenuItem("Remove ASR Provider")
+        self._asr_remove_provider_items: Dict[str, StatusMenuItem] = {}
         self._build_model_menu()
 
         # AI Enhance
@@ -238,11 +244,11 @@ class VoiceTextApp(rumps.App):
             self._auto_vocab_builder.set_enhancer(self._enhancer)
 
         # AI Enhance submenu (mode selection only)
-        self._enhance_menu = rumps.MenuItem("AI Enhance")
-        self._enhance_menu_items: Dict[str, rumps.MenuItem] = {}
+        self._enhance_menu = StatusMenuItem("AI Enhance")
+        self._enhance_menu_items: Dict[str, StatusMenuItem] = {}
 
         # Fixed "Off" item
-        off_item = rumps.MenuItem("Off")
+        off_item = StatusMenuItem("Off")
         off_item._enhance_mode = MODE_OFF
         off_item.set_callback(self._on_enhance_mode_select)
         if self._enhance_mode == MODE_OFF:
@@ -253,7 +259,7 @@ class VoiceTextApp(rumps.App):
         # Dynamic mode items from enhancer
         if self._enhancer:
             for mode_id, label in self._enhancer.available_modes:
-                item = rumps.MenuItem(label)
+                item = StatusMenuItem(label)
                 item._enhance_mode = mode_id
                 item.set_callback(self._on_enhance_mode_select)
                 if mode_id == self._enhance_mode:
@@ -262,45 +268,45 @@ class VoiceTextApp(rumps.App):
                 self._enhance_menu.add(item)
 
         # Add Mode item
-        self._enhance_menu.add(rumps.separator)
-        self._enhance_add_mode_item = rumps.MenuItem(
+        self._enhance_menu.add(None)
+        self._enhance_add_mode_item = StatusMenuItem(
             "Add Mode...", callback=self._on_enhance_add_mode
         )
         self._enhance_menu.add(self._enhance_add_mode_item)
 
         # Top-level toggle items (promoted from AI Enhance)
         vocab_enabled = ai_cfg.get("vocabulary", {}).get("enabled", False)
-        self._enhance_vocab_item = rumps.MenuItem(
+        self._enhance_vocab_item = StatusMenuItem(
             "Vocabulary", callback=self._on_vocab_toggle
         )
         self._enhance_vocab_item.state = 1 if vocab_enabled else 0
         self._update_vocab_title()
 
         history_enabled = ai_cfg.get("conversation_history", {}).get("enabled", False)
-        self._enhance_history_item = rumps.MenuItem(
+        self._enhance_history_item = StatusMenuItem(
             "Conversation History", callback=self._on_history_toggle
         )
         self._enhance_history_item.state = 1 if history_enabled else 0
 
-        self._browse_history_item = rumps.MenuItem(
+        self._browse_history_item = StatusMenuItem(
             "Browse History...", callback=self._on_browse_history
         )
 
         # LLM Model top-level submenu
-        self._llm_model_menu = rumps.MenuItem("LLM Model")
-        self._llm_model_menu_items: Dict[Tuple[str, str], rumps.MenuItem] = {}
-        self._llm_add_provider_item = rumps.MenuItem(
+        self._llm_model_menu = StatusMenuItem("LLM Model")
+        self._llm_model_menu_items: Dict[Tuple[str, str], StatusMenuItem] = {}
+        self._llm_add_provider_item = StatusMenuItem(
             "Add Provider...", callback=self._on_enhance_add_provider
         )
-        self._llm_remove_provider_menu = rumps.MenuItem("Remove Provider")
-        self._llm_remove_provider_items: Dict[str, rumps.MenuItem] = {}
+        self._llm_remove_provider_menu = StatusMenuItem("Remove Provider")
+        self._llm_remove_provider_items: Dict[str, StatusMenuItem] = {}
         self._build_llm_model_menu()
 
         # AI Settings submenu (low-frequency AI configuration)
-        self._ai_settings_menu = rumps.MenuItem("AI Settings")
+        self._ai_settings_menu = StatusMenuItem("AI Settings")
 
         # Thinking toggle
-        self._enhance_thinking_item = rumps.MenuItem(
+        self._enhance_thinking_item = StatusMenuItem(
             "Thinking", callback=self._on_enhance_thinking_toggle
         )
         if self._enhancer and self._enhancer.thinking:
@@ -308,71 +314,71 @@ class VoiceTextApp(rumps.App):
         self._ai_settings_menu.add(self._enhance_thinking_item)
 
         # Build vocabulary action
-        self._ai_settings_menu.add(rumps.separator)
-        self._enhance_vocab_build_item = rumps.MenuItem(
+        self._ai_settings_menu.add(None)
+        self._enhance_vocab_build_item = StatusMenuItem(
             "Build Vocabulary...", callback=self._on_vocab_build
         )
         self._ai_settings_menu.add(self._enhance_vocab_build_item)
 
-        self._enhance_auto_build_item = rumps.MenuItem(
+        self._enhance_auto_build_item = StatusMenuItem(
             "Auto Build Vocabulary", callback=self._on_auto_build_toggle
         )
         self._enhance_auto_build_item.state = 1 if vocab_cfg.get("auto_build", True) else 0
         self._ai_settings_menu.add(self._enhance_auto_build_item)
 
-        self._ai_settings_menu.add(rumps.separator)
-        self._enhance_edit_config_item = rumps.MenuItem(
+        self._ai_settings_menu.add(None)
+        self._enhance_edit_config_item = StatusMenuItem(
             "Edit Config...", callback=self._on_enhance_edit_config
         )
         self._ai_settings_menu.add(self._enhance_edit_config_item)
 
-        self._preview_item = rumps.MenuItem(
+        self._preview_item = StatusMenuItem(
             "Preview", callback=self._on_preview_toggle
         )
         self._preview_item.state = 1 if self._preview_enabled else 0
 
-        self._clipboard_enhance_item = rumps.MenuItem(
+        self._clipboard_enhance_item = StatusMenuItem(
             "Enhance Clipboard", callback=self._on_clipboard_enhance
         )
 
         # Feedback toggle items
-        self._sound_feedback_item = rumps.MenuItem(
+        self._sound_feedback_item = StatusMenuItem(
             "Sound Feedback", callback=self._on_sound_feedback_toggle
         )
         self._sound_feedback_item.state = 1 if self._sound_manager.enabled else 0
 
-        self._visual_indicator_item = rumps.MenuItem(
+        self._visual_indicator_item = StatusMenuItem(
             "Visual Indicator", callback=self._on_visual_indicator_toggle
         )
         self._visual_indicator_item.state = 1 if self._recording_indicator.enabled else 0
 
         # View Logs top-level item (replaces Debug submenu)
-        self._view_logs_item = rumps.MenuItem(
+        self._view_logs_item = StatusMenuItem(
             "View Logs...", callback=self._on_view_logs
         )
 
         # Show Config / Reload Config items
-        self._show_config_item = rumps.MenuItem(
+        self._show_config_item = StatusMenuItem(
             "Show Config...", callback=self._on_show_config
         )
-        self._reload_config_item = rumps.MenuItem(
+        self._reload_config_item = StatusMenuItem(
             "Reload Config", callback=self._on_reload_config
         )
 
         # Usage Stats item
-        self._usage_stats_item = rumps.MenuItem(
+        self._usage_stats_item = StatusMenuItem(
             "Usage Stats", callback=self._on_show_usage_stats
         )
 
         # About item
-        self._about_item = rumps.MenuItem("About VoiceText", callback=self._on_about)
+        self._about_item = StatusMenuItem("About VoiceText", callback=self._on_about)
 
         # History browser (lazy-created)
         self._history_browser: Optional[HistoryBrowserPanel] = None
 
         # Settings panel
         self._settings_panel = SettingsPanel()
-        self._settings_item = rumps.MenuItem(
+        self._settings_item = StatusMenuItem(
             "Settings...", callback=self._on_open_settings
         )
 
@@ -455,10 +461,7 @@ class VoiceTextApp(rumps.App):
         nsimage = self._sf_symbol_image(symbol_name, text)
         if nsimage is not None:
             self._icon_nsimage = nsimage
-            try:
-                self._nsapp.setStatusBarIcon()
-            except AttributeError:
-                pass
+            self._update_status_bar_icon()
             self.title = bar_title  # clear text when icon is set
         else:
             self.title = text  # fallback to text-only if SF Symbols unavailable
@@ -626,13 +629,13 @@ class VoiceTextApp(rumps.App):
 
         hotkeys: Dict[str, bool] = self._config.get("hotkeys", {"fn": True})
         for key_name, enabled in hotkeys.items():
-            item = rumps.MenuItem(key_name, callback=self._on_hotkey_item_click)
+            item = StatusMenuItem(key_name, callback=self._on_hotkey_item_click)
             item.state = 1 if enabled else 0
             item._hotkey_name = key_name
             self._hotkey_menu_items[key_name] = item
             self._hotkey_menu.add(item)
 
-        self._hotkey_menu.add(rumps.separator)
+        self._hotkey_menu.add(None)
         self._hotkey_menu.add(self._hotkey_record_item)
 
     def _start_hotkey_listeners(self) -> None:
@@ -2264,7 +2267,7 @@ Output only the processed text without any explanation."""
         # Re-add from enhancer, inserting before "Add Mode..."
         if self._enhancer:
             for mode_id, label in self._enhancer.available_modes:
-                item = rumps.MenuItem(label)
+                item = StatusMenuItem(label)
                 item._enhance_mode = mode_id
                 item.set_callback(self._on_enhance_mode_select)
                 if mode_id == self._enhance_mode:
@@ -2488,14 +2491,14 @@ Output only the processed text without any explanation."""
                 )
                 progress_panel.update_status(f"{status}: {msg}")
                 try:
-                    rumps.notification("VoiceText", f"Vocabulary {status}", msg)
+                    send_notification("VoiceText", f"Vocabulary {status}", msg)
                 except Exception:
                     logger.debug("Notification center unavailable, skipping notification")
             except Exception as e:
                 logger.error("Vocabulary build failed: %s", e)
                 progress_panel.update_status(f"Failed: {e}")
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText", "Vocabulary Build Failed", str(e)
                     )
                 except Exception:
@@ -2528,7 +2531,7 @@ Output only the processed text without any explanation."""
             for mname in models:
                 key = (pname, mname)
                 title = f"{pname} / {mname}"
-                item = rumps.MenuItem(title)
+                item = StatusMenuItem(title)
                 item._llm_provider = pname
                 item._llm_model = mname
                 item.set_callback(self._on_llm_model_select)
@@ -2547,7 +2550,7 @@ Output only the processed text without any explanation."""
         self._llm_remove_provider_items.clear()
 
         for pname in providers:
-            item = rumps.MenuItem(pname)
+            item = StatusMenuItem(pname)
             item._provider_name = pname
             item.set_callback(self._on_enhance_remove_provider)
             self._llm_remove_provider_items[pname] = item
@@ -2578,7 +2581,7 @@ Output only the processed text without any explanation."""
                 title = preset.display_name
             else:
                 title = f"{preset.display_name} (N/A)"
-            item = rumps.MenuItem(title)
+            item = StatusMenuItem(title)
             item._preset_id = preset.id
             if backend_ok:
                 item.set_callback(self._on_model_select)
@@ -2598,7 +2601,7 @@ Output only the processed text without any explanation."""
             self._model_menu.add(None)  # separator
             for rm in remote_models:
                 key = (rm.provider, rm.model)
-                item = rumps.MenuItem(rm.display_name)
+                item = StatusMenuItem(rm.display_name)
                 item._remote_asr = rm
                 item.set_callback(self._on_remote_asr_select)
                 if key == self._current_remote_asr:
@@ -2615,7 +2618,7 @@ Output only the processed text without any explanation."""
             self._asr_remove_provider_menu.clear()
         self._asr_remove_provider_items.clear()
         for pname in providers:
-            item = rumps.MenuItem(pname)
+            item = StatusMenuItem(pname)
             item._provider_name = pname
             item.set_callback(self._on_asr_remove_provider)
             self._asr_remove_provider_items[pname] = item
@@ -2633,7 +2636,7 @@ Output only the processed text without any explanation."""
             return
 
         if self._busy:
-            rumps.notification(
+            send_notification(
                 "VoiceText",
                 "Cannot switch model",
                 "Please wait for current operation to finish.",
@@ -2672,7 +2675,7 @@ Output only the processed text without any explanation."""
                 self._set_status("VT")
                 logger.info("Switched to remote ASR: %s", rm.display_name)
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText",
                         "Model switched",
                         f"Now using: {rm.display_name}",
@@ -2684,7 +2687,7 @@ Output only the processed text without any explanation."""
                 logger.error("Remote ASR switch failed: %s", e)
                 self._set_status("Error")
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText",
                         "Model switch failed",
                         str(e)[:100],
@@ -2850,7 +2853,7 @@ models:
 
             self._build_model_menu()
 
-            rumps.notification(
+            send_notification(
                 "VoiceText", "ASR Provider added", f"{name} ({', '.join(models)})"
             )
             logger.info("Added ASR provider: %s", name)
@@ -2951,7 +2954,7 @@ models:
             self._build_model_menu()
             self._update_model_checkmarks()
 
-            rumps.notification("VoiceText", "ASR Provider removed", pname)
+            send_notification("VoiceText", "ASR Provider removed", pname)
             logger.info("Removed ASR provider: %s", pname)
         except Exception as e:
             logger.error("Remove ASR provider failed: %s", e, exc_info=True)
@@ -3074,7 +3077,7 @@ models:
     def _run_window(title: str, message: str, default_text: str = "",
                     ok: str = "OK", cancel: str = "Cancel",
                     dimensions: tuple = (320, 22), secure: bool = False):
-        """Run a rumps.Window with proper app activation.
+        """Run an InputWindow with proper app activation.
 
         Safe to call from any thread — dispatches to main thread if needed.
         Returns Response or None on cancel.
@@ -3088,13 +3091,13 @@ models:
             from AppKit import NSStatusWindowLevel
 
             VoiceTextApp._activate_for_dialog()
-            w = rumps.Window(
+            w = InputWindow(
                 title=title, message=message, default_text=default_text,
                 ok=ok, cancel=cancel, dimensions=dimensions, secure=secure,
             )
-            w._alert.window().setLevel_(NSStatusWindowLevel)
-            w._alert.window().setFloatingPanel_(True)
-            w._alert.window().setHidesOnDeactivate_(False)
+            w.alert.window().setLevel_(NSStatusWindowLevel)
+            w.alert.window().setFloatingPanel_(True)
+            w.alert.window().setHidesOnDeactivate_(False)
             resp = w.run()
             result_holder["resp"] = resp if resp.clicked == 1 else None
             done_event.set()
@@ -3443,7 +3446,7 @@ models:
 
             self._build_llm_model_menu()
 
-            rumps.notification(
+            send_notification(
                 "VoiceText", "Provider added", f"{name} ({', '.join(models)})"
             )
             logger.info("Added AI provider: %s", name)
@@ -3546,7 +3549,7 @@ models:
             # Rebuild LLM model menu
             self._build_llm_model_menu()
 
-            rumps.notification("VoiceText", "Provider removed", pname)
+            send_notification("VoiceText", "Provider removed", pname)
             logger.info("Removed AI provider: %s", pname)
         except Exception as e:
             logger.error("Remove provider failed: %s", e, exc_info=True)
@@ -3631,7 +3634,7 @@ models:
 
         # Reject if busy (transcribing or switching)
         if self._busy:
-            rumps.notification(
+            send_notification(
                 "VoiceText",
                 "Cannot switch model",
                 "Please wait for current operation to finish.",
@@ -3706,7 +3709,7 @@ models:
                 self._set_status("VT")
                 logger.info("Switched to model: %s", preset.display_name)
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText",
                         "Model switched",
                         f"Now using: {preset.display_name}",
@@ -3722,7 +3725,7 @@ models:
                 logger.error("Model switch failed: %s", e)
                 self._set_status("Error")
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText",
                         "Model switch failed",
                         str(e)[:100],
@@ -3911,7 +3914,7 @@ models:
             new_config = load_config(self._config_path)
         except Exception as e:
             logger.error("Failed to reload config: %s", e)
-            rumps.notification("VoiceText", "Reload Failed", str(e))
+            send_notification("VoiceText", "Reload Failed", str(e))
             return
 
         self._config = new_config
@@ -4000,7 +4003,7 @@ models:
                 self._clipboard_hotkey_listener.start()
 
         logger.info("Configuration reloaded successfully")
-        rumps.notification("VoiceText", "Config Reloaded", "Configuration has been reloaded.")
+        send_notification("VoiceText", "Config Reloaded", "Configuration has been reloaded.")
 
     def _on_browse_history(self, _=None) -> None:
         """Open the conversation history browser panel."""
@@ -4361,7 +4364,7 @@ models:
                 self._set_status("VT")
                 logger.info("Switched to model: %s (from settings)", preset.display_name)
                 try:
-                    rumps.notification("VoiceText", "Model switched",
+                    send_notification("VoiceText", "Model switched",
                                       f"Now using: {preset.display_name}")
                 except Exception:
                     logger.debug("Notification unavailable, skipping")
@@ -4571,7 +4574,7 @@ models:
             self._clipboard_hotkey_listener.stop()
         if self._settings_panel.is_visible:
             self._settings_panel.close()
-        rumps.quit_application()
+        quit_application()
 
     @staticmethod
     def _ensure_accessibility() -> bool:
@@ -4674,7 +4677,7 @@ def main() -> None:
     """Entry point."""
     import signal
 
-    signal.signal(signal.SIGINT, lambda *_: rumps.quit_application())
+    signal.signal(signal.SIGINT, lambda *_: quit_application())
 
     config_path = sys.argv[1] if len(sys.argv) > 1 else None
     app = VoiceTextApp(config_path=config_path)  # None uses default path

--- a/src/voicetext/auto_vocab_builder.py
+++ b/src/voicetext/auto_vocab_builder.py
@@ -7,7 +7,7 @@ import logging
 import threading
 from typing import Any, Callable, Dict, Optional
 
-import rumps
+from .statusbar import send_notification
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class AutoVocabBuilder:
 
             if new_entries > 0:
                 try:
-                    rumps.notification(
+                    send_notification(
                         "VoiceText",
                         "Vocabulary Auto-Built",
                         f"{new_entries} new entries ({total_entries} total)",

--- a/src/voicetext/statusbar.py
+++ b/src/voicetext/statusbar.py
@@ -1,0 +1,444 @@
+"""Pure PyObjC statusbar application framework replacing rumps."""
+
+from __future__ import annotations
+
+import collections
+import logging
+from typing import Any, Callable, Dict, Optional, Tuple
+
+import AppKit
+from AppKit import (
+    NSAlert,
+    NSApplication,
+    NSImage,
+    NSMakeRect,
+    NSMenu,
+    NSMenuItem,
+    NSSecureTextField,
+    NSStatusBar,
+    NSTextField,
+    NSUserNotification,
+    NSUserNotificationCenter,
+)
+from Foundation import NSObject
+from PyObjCTools import AppHelper
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Callback routing
+# ---------------------------------------------------------------------------
+
+
+class _MenuCallbackTarget(NSObject):
+    """Singleton ObjC target that receives all menu item actions."""
+
+    def menuItemClicked_(self, nsmenuitem) -> None:
+        entry = _ns_to_callback.get(id(nsmenuitem))
+        if entry is not None:
+            smitem, callback = entry
+            try:
+                callback(smitem)
+            except Exception:
+                logger.exception("Menu callback error")
+
+
+# Singleton handler instance, created lazily
+_callback_handler: Optional[_MenuCallbackTarget] = None
+# Map id(NSMenuItem) -> (StatusMenuItem, callable)
+_ns_to_callback: Dict[int, Tuple["StatusMenuItem", Callable]] = {}
+
+
+def _get_callback_handler() -> _MenuCallbackTarget:
+    global _callback_handler
+    if _callback_handler is None:
+        _callback_handler = _MenuCallbackTarget.alloc().init()
+    return _callback_handler
+
+
+# ---------------------------------------------------------------------------
+# SeparatorMenuItem
+# ---------------------------------------------------------------------------
+
+class SeparatorMenuItem:
+    """A visual separator in the menu."""
+
+    def __init__(self) -> None:
+        self._menuitem = NSMenuItem.separatorItem()
+
+
+# Module-level sentinel (mirrors rumps.separator)
+separator = object()
+
+
+# ---------------------------------------------------------------------------
+# StatusMenuItem
+# ---------------------------------------------------------------------------
+
+class StatusMenuItem:
+    """Python-friendly wrapper around NSMenuItem with dict-like submenu management.
+
+    Supports arbitrary Python attributes (e.g. item._enhance_mode = "translate")
+    since this is a pure Python class, unlike real AppKit objects.
+    """
+
+    def __init__(
+        self,
+        title: str = "",
+        callback: Optional[Callable] = None,
+        key: str = "",
+    ) -> None:
+        if isinstance(title, StatusMenuItem):
+            return
+        self._menuitem = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+            str(title), None, key or ""
+        )
+        self._menu: Optional[NSMenu] = None  # lazy submenu
+        self._items: collections.OrderedDict[str, Any] = collections.OrderedDict()
+        self._sep_count = 0
+        if callback is not None:
+            self.set_callback(callback)
+
+    # -- Properties ---------------------------------------------------------
+
+    @property
+    def title(self) -> str:
+        return str(self._menuitem.title())
+
+    @title.setter
+    def title(self, value: str) -> None:
+        self._menuitem.setTitle_(str(value))
+
+    @property
+    def state(self) -> int:
+        return int(self._menuitem.state())
+
+    @state.setter
+    def state(self, value: int) -> None:
+        self._menuitem.setState_(int(value))
+
+    def set_callback(self, callback: Optional[Callable], key: Optional[str] = None) -> None:
+        """Set or clear the click callback."""
+        if key is not None:
+            self._menuitem.setKeyEquivalent_(key)
+        handler = _get_callback_handler()
+        self._menuitem.setTarget_(handler)
+        if callback is not None:
+            _ns_to_callback[id(self._menuitem)] = (self, callback)
+            self._menuitem.setAction_("menuItemClicked:")
+        else:
+            _ns_to_callback.pop(id(self._menuitem), None)
+            self._menuitem.setAction_(None)
+
+    # -- Submenu management -------------------------------------------------
+
+    def _ensure_submenu(self) -> NSMenu:
+        if self._menu is None:
+            self._menu = NSMenu.alloc().init()
+            self._menu.setAutoenablesItems_(False)
+            self._menuitem.setSubmenu_(self._menu)
+        return self._menu
+
+    def _process_value(self, value: Any) -> Tuple[str, Any]:
+        """Convert raw value to (key, item) pair."""
+        if value is None or value is separator:
+            item = SeparatorMenuItem()
+            self._sep_count += 1
+            return (f"_sep_{self._sep_count}", item)
+        if isinstance(value, str):
+            value = StatusMenuItem(value)
+        if isinstance(value, (StatusMenuItem, SeparatorMenuItem)):
+            key = value.title if hasattr(value, "title") else f"_sep_{self._sep_count}"
+            return (key, value)
+        raise TypeError(f"Cannot add {type(value)} to menu")
+
+    def add(self, item: Any) -> None:
+        """Add item to submenu. None creates a separator."""
+        key, value = self._process_value(item)
+        menu = self._ensure_submenu()
+        menu.addItem_(value._menuitem)
+        self._items[key] = value
+
+    def pop(self, title: str) -> Any:
+        """Remove and return item by title."""
+        value = self._items.pop(title)
+        if self._menu is not None:
+            self._menu.removeItem_(value._menuitem)
+        return value
+
+    def insert_before(self, existing_title: str, item: Any) -> None:
+        """Insert item before the item with existing_title."""
+        key, value = self._process_value(item)
+        existing = self._items[existing_title]
+        menu = self._ensure_submenu()
+        index = menu.indexOfItem_(existing._menuitem)
+        menu.insertItem_atIndex_(value._menuitem, index)
+        # Rebuild OrderedDict to maintain insertion order
+        new_items: collections.OrderedDict = collections.OrderedDict()
+        for k, v in self._items.items():
+            if k == existing_title:
+                new_items[key] = value
+            new_items[k] = v
+        self._items = new_items
+
+    def clear(self) -> None:
+        """Remove all items from submenu."""
+        if self._menu is not None:
+            self._menu.removeAllItems()
+        self._items.clear()
+        self._sep_count = 0
+
+    def keys(self):
+        return self._items.keys()
+
+    def __getitem__(self, key: str) -> Any:
+        return self._items[key]
+
+    def __delitem__(self, key: str) -> None:
+        value = self._items.pop(key)
+        if self._menu is not None:
+            self._menu.removeItem_(value._menuitem)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._items
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def update(self, iterable) -> None:
+        """Parse iterable of items (like rumps menu setter)."""
+        self._parse_menu(iterable)
+
+    def _parse_menu(self, iterable) -> None:
+        if isinstance(iterable, StatusMenuItem):
+            self.add(iterable)
+            return
+        for ele in iterable:
+            if isinstance(ele, StatusMenuItem):
+                self.add(ele)
+            elif isinstance(ele, (type(None), type(separator))):
+                self.add(None)
+            elif isinstance(ele, (list, tuple)) and len(ele) == 2:
+                menuitem, submenu = ele
+                if isinstance(menuitem, str):
+                    menuitem = StatusMenuItem(menuitem)
+                self.add(menuitem)
+                menuitem._parse_menu(submenu)
+            else:
+                self.add(ele)
+
+
+# ---------------------------------------------------------------------------
+# StatusBarApp
+# ---------------------------------------------------------------------------
+
+class StatusBarApp:
+    """Pure PyObjC statusbar application base class."""
+
+    def __init__(
+        self,
+        name: str,
+        icon: Optional[str] = None,
+        title: Optional[str] = None,
+        quit_button: str = "Quit",
+    ) -> None:
+        self._name = name
+        self._title = title
+        self._icon = icon
+        self._icon_nsimage: Optional[NSImage] = None
+        self._menu = StatusMenuItem(name)
+        self._quit_button = StatusMenuItem(quit_button) if quit_button else None
+        self._nsstatusitem = None
+
+    # -- Properties ---------------------------------------------------------
+
+    @property
+    def title(self) -> Optional[str]:
+        return self._title
+
+    @title.setter
+    def title(self, value: Optional[str]) -> None:
+        self._title = value
+        if self._nsstatusitem is not None:
+            self._nsstatusitem.setTitle_(value or "")
+
+    @property
+    def menu(self) -> StatusMenuItem:
+        return self._menu
+
+    @menu.setter
+    def menu(self, iterable) -> None:
+        self._menu.update(iterable)
+
+    @property
+    def quit_button(self) -> Optional[StatusMenuItem]:
+        return self._quit_button
+
+    # -- Status bar ---------------------------------------------------------
+
+    def _setup_status_bar(self) -> None:
+        self._nsstatusitem = NSStatusBar.systemStatusBar().statusItemWithLength_(-1)
+        self._nsstatusitem.setHighlightMode_(True)
+        self._update_status_bar_icon()
+        self._update_status_bar_title()
+
+        # Append quit button at the end
+        if self._quit_button is not None:
+            if self._quit_button._menuitem.action() is None:
+                # No custom callback set — use default quit
+                self._quit_button.set_callback(lambda _: quit_application())
+            self._menu.add(self._quit_button)
+
+        self._nsstatusitem.setMenu_(self._menu._ensure_submenu())
+
+    def _update_status_bar_icon(self) -> None:
+        if self._nsstatusitem is not None:
+            self._nsstatusitem.setImage_(self._icon_nsimage)
+            self._fallback_on_name()
+
+    def _update_status_bar_title(self) -> None:
+        if self._nsstatusitem is not None:
+            self._nsstatusitem.setTitle_(self._title or "")
+            self._fallback_on_name()
+
+    def _fallback_on_name(self) -> None:
+        si = self._nsstatusitem
+        if si is not None and not si.title() and not si.image():
+            si.setTitle_(self._name)
+
+    # -- Run loop -----------------------------------------------------------
+
+    def run(self, **kwargs) -> None:
+        """Start the application run loop."""
+        nsapp = NSApplication.sharedApplication()
+        nsapp.activateIgnoringOtherApps_(True)
+
+        nsapp.setActivationPolicy_(
+            AppKit.NSApplicationActivationPolicyAccessory
+        )
+
+        self._setup_status_bar()
+
+        AppHelper.installMachInterrupt()
+        AppHelper.runEventLoop()
+
+
+# ---------------------------------------------------------------------------
+# Notifications
+# ---------------------------------------------------------------------------
+
+def send_notification(title: str, subtitle: str, message: str) -> None:
+    """Send a macOS notification. Gracefully fails in unbundled mode."""
+    try:
+        notification = NSUserNotification.alloc().init()
+        notification.setTitle_(title)
+        notification.setSubtitle_(subtitle)
+        notification.setInformativeText_(message)
+        center = NSUserNotificationCenter.defaultUserNotificationCenter()
+        center.deliverNotification_(notification)
+    except Exception:
+        logger.debug("Notification center unavailable", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Quit
+# ---------------------------------------------------------------------------
+
+def quit_application(sender=None) -> None:
+    """Quit the application."""
+    NSApplication.sharedApplication().terminate_(sender)
+
+
+# ---------------------------------------------------------------------------
+# InputWindow
+# ---------------------------------------------------------------------------
+
+class Response:
+    """Result from an InputWindow interaction."""
+
+    def __init__(self, clicked: int, text: str) -> None:
+        self._clicked = clicked
+        self._text = text
+
+    @property
+    def clicked(self) -> int:
+        """1 for OK, 0 for Cancel."""
+        return self._clicked
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+    def __repr__(self) -> str:
+        short = self._text if len(self._text) < 21 else self._text[:17] + "..."
+        return f"<Response: [clicked: {self._clicked}, text: {short!r}]>"
+
+
+class InputWindow:
+    """Modal input dialog using NSAlert + text field."""
+
+    def __init__(
+        self,
+        message: str = "",
+        title: str = "",
+        default_text: str = "",
+        ok: Optional[str] = None,
+        cancel: Optional[str] = None,
+        dimensions: Tuple[int, int] = (320, 160),
+        secure: bool = False,
+    ) -> None:
+        self._alert = NSAlert.alloc().init()
+        self._alert.setMessageText_(title)
+        self._alert.setInformativeText_(message)
+        self._alert.addButtonWithTitle_(ok or "OK")
+        self._has_cancel = bool(cancel)
+        if cancel:
+            cancel_title = cancel if isinstance(cancel, str) else "Cancel"
+            self._alert.addButtonWithTitle_(cancel_title)
+        self._alert.setAlertStyle_(0)  # NSInformationalAlertStyle
+
+        if secure:
+            self._textfield = NSSecureTextField.alloc().initWithFrame_(
+                NSMakeRect(0, 0, *dimensions)
+            )
+        else:
+            self._textfield = NSTextField.alloc().initWithFrame_(
+                NSMakeRect(0, 0, *dimensions)
+            )
+        self._textfield.setSelectable_(True)
+        self._textfield.setStringValue_(default_text or "")
+        self._alert.setAccessoryView_(self._textfield)
+        self._default_text = default_text
+
+    @property
+    def alert(self) -> NSAlert:
+        """Access the underlying NSAlert for customization."""
+        return self._alert
+
+    # Keep _alert accessible for backward compat with rumps.Window hack pattern
+    # (code does w._alert.window().setLevel_(...))
+
+    def run(self) -> Response:
+        """Show the dialog and return user input."""
+        # Apply dark mode appearance if needed
+        try:
+            from Foundation import NSUserDefaults
+            if NSUserDefaults.standardUserDefaults().stringForKey_("AppleInterfaceStyle") == "Dark":
+                self._alert.window().setAppearance_(
+                    AppKit.NSAppearance.appearanceNamed_("NSAppearanceNameVibrantDark")
+                )
+        except Exception:
+            pass
+
+        result = self._alert.runModal()
+        # NSAlertFirstButtonReturn = 1000, NSAlertSecondButtonReturn = 1001
+        clicked = 1 if result == 1000 else 0
+        self._textfield.validateEditing()
+        text = str(self._textfield.stringValue())
+        # Reset default text for reuse
+        self._textfield.setStringValue_(self._default_text or "")
+        return Response(clicked, text)

--- a/tests/test_auto_vocab_builder.py
+++ b/tests/test_auto_vocab_builder.py
@@ -116,8 +116,8 @@ class TestBuildingFlag:
 
 
 class TestBuildExecution:
-    @patch("voicetext.auto_vocab_builder.rumps")
-    def test_build_success_with_new_entries(self, mock_rumps, config):
+    @patch("voicetext.auto_vocab_builder.send_notification")
+    def test_build_success_with_new_entries(self, mock_notify, config):
         """Test that a successful build reloads index and sends notification."""
         async def fake_build(**kwargs):
             return {"new_entries": 5, "total_entries": 20}
@@ -139,11 +139,11 @@ class TestBuildExecution:
             builder._build()
 
         mock_enhancer.vocab_index.reload.assert_called_once()
-        mock_rumps.notification.assert_called_once()
+        mock_notify.assert_called_once()
         assert builder._building is False
 
-    @patch("voicetext.auto_vocab_builder.rumps")
-    def test_build_success_no_new_entries(self, mock_rumps, config):
+    @patch("voicetext.auto_vocab_builder.send_notification")
+    def test_build_success_no_new_entries(self, mock_notify, config):
         """Test that no notification is sent when there are no new entries."""
         async def fake_build(**kwargs):
             return {"new_entries": 0, "total_entries": 10}
@@ -160,7 +160,7 @@ class TestBuildExecution:
         ):
             builder._build()
 
-        mock_rumps.notification.assert_not_called()
+        mock_notify.assert_not_called()
         assert builder._building is False
 
     def test_build_failure_clears_building_flag(self, config):
@@ -186,8 +186,8 @@ class TestSetEnhancer:
 
 
 class TestOnBuildDoneCallback:
-    @patch("voicetext.auto_vocab_builder.rumps")
-    def test_on_build_done_called(self, mock_rumps, config):
+    @patch("voicetext.auto_vocab_builder.send_notification")
+    def test_on_build_done_called(self, mock_notify, config):
         """Test that on_build_done callback is invoked after successful build."""
         async def fake_build(**kwargs):
             return {"new_entries": 3, "total_entries": 15}

--- a/tests/test_statusbar.py
+++ b/tests/test_statusbar.py
@@ -1,0 +1,263 @@
+"""Tests for the statusbar module (pure PyObjC replacement for rumps)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from voicetext.statusbar import (
+    InputWindow,
+    Response,
+    StatusBarApp,
+    StatusMenuItem,
+    quit_application,
+    send_notification,
+)
+
+
+# ---------------------------------------------------------------------------
+# StatusMenuItem
+# ---------------------------------------------------------------------------
+
+
+class TestStatusMenuItem:
+    def test_create_with_title(self):
+        item = StatusMenuItem("Hello")
+        assert item.title == "Hello"
+
+    def test_title_setter(self):
+        item = StatusMenuItem("Old")
+        item.title = "New"
+        assert item.title == "New"
+
+    def test_state_default(self):
+        item = StatusMenuItem("Item")
+        assert item.state == 0
+
+    def test_state_setter(self):
+        item = StatusMenuItem("Item")
+        item.state = 1
+        assert item.state == 1
+
+    def test_callback_set(self):
+        cb = MagicMock()
+        item = StatusMenuItem("Click", callback=cb)
+        assert item._menuitem.action() == "menuItemClicked:"
+
+    def test_callback_clear(self):
+        item = StatusMenuItem("Click", callback=lambda _: None)
+        item.set_callback(None)
+        assert item._menuitem.action() is None
+
+    def test_custom_attributes(self):
+        """StatusMenuItem allows arbitrary Python attributes."""
+        item = StatusMenuItem("Item")
+        item._enhance_mode = "translate"
+        item._preset_id = "whisper-large"
+        assert item._enhance_mode == "translate"
+        assert item._preset_id == "whisper-large"
+
+    def test_add_submenu_items(self):
+        parent = StatusMenuItem("Parent")
+        child1 = StatusMenuItem("Child1")
+        child2 = StatusMenuItem("Child2")
+        parent.add(child1)
+        parent.add(child2)
+        assert list(parent.keys()) == ["Child1", "Child2"]
+        assert parent["Child1"] is child1
+        assert len(parent) == 2
+
+    def test_add_separator(self):
+        parent = StatusMenuItem("Parent")
+        parent.add(StatusMenuItem("A"))
+        parent.add(None)
+        parent.add(StatusMenuItem("B"))
+        assert len(parent) == 3
+
+    def test_pop(self):
+        parent = StatusMenuItem("Parent")
+        child = StatusMenuItem("Child")
+        parent.add(child)
+        removed = parent.pop("Child")
+        assert removed is child
+        assert len(parent) == 0
+
+    def test_pop_missing_raises(self):
+        parent = StatusMenuItem("Parent")
+        with pytest.raises(KeyError):
+            parent.pop("Missing")
+
+    def test_clear(self):
+        parent = StatusMenuItem("Parent")
+        parent.add(StatusMenuItem("A"))
+        parent.add(StatusMenuItem("B"))
+        parent.clear()
+        assert len(parent) == 0
+
+    def test_delitem(self):
+        parent = StatusMenuItem("Parent")
+        parent.add(StatusMenuItem("A"))
+        del parent["A"]
+        assert "A" not in parent
+
+    def test_contains(self):
+        parent = StatusMenuItem("Parent")
+        parent.add(StatusMenuItem("X"))
+        assert "X" in parent
+        assert "Y" not in parent
+
+    def test_insert_before(self):
+        parent = StatusMenuItem("Parent")
+        parent.add(StatusMenuItem("A"))
+        parent.add(StatusMenuItem("C"))
+        parent.insert_before("C", StatusMenuItem("B"))
+        assert list(parent.keys()) == ["A", "B", "C"]
+
+    def test_update_from_list(self):
+        parent = StatusMenuItem("Root")
+        items = [
+            StatusMenuItem("Item1"),
+            None,
+            StatusMenuItem("Item2"),
+        ]
+        parent.update(items)
+        assert "Item1" in parent
+        assert "Item2" in parent
+        assert len(parent) == 3  # Item1, separator, Item2
+
+    def test_keys_del_rebuild_menu(self):
+        """Simulate the hotkey menu rebuild pattern from app.py."""
+        menu = StatusMenuItem("Hotkey")
+        menu.add(StatusMenuItem("right_cmd"))
+        menu.add(StatusMenuItem("fn"))
+        # Clear using keys + del (like app.py line 619-620)
+        for key in list(menu.keys()):
+            del menu[key]
+        assert len(menu) == 0
+
+    def test_lazy_submenu_creation(self):
+        item = StatusMenuItem("Item")
+        assert item._menu is None
+        item.add(StatusMenuItem("Child"))
+        assert item._menu is not None
+
+    def test_menu_check_pattern(self):
+        """Test the pattern `if item._menu is not None` used in app.py."""
+        item = StatusMenuItem("Item")
+        assert item._menu is None
+        item.add(StatusMenuItem("Child"))
+        assert item._menu is not None
+        item.clear()
+        # After clear, _menu still exists but is empty
+        assert item._menu is not None
+        assert len(item) == 0
+
+
+# ---------------------------------------------------------------------------
+# StatusBarApp
+# ---------------------------------------------------------------------------
+
+
+class TestStatusBarApp:
+    def test_init(self):
+        app = StatusBarApp("TestApp", title="TA")
+        assert app._name == "TestApp"
+        assert app.title == "TA"
+
+    def test_quit_button(self):
+        app = StatusBarApp("TestApp")
+        assert app.quit_button is not None
+        assert app.quit_button.title == "Quit"
+
+    def test_no_quit_button(self):
+        app = StatusBarApp("TestApp", quit_button=None)
+        assert app.quit_button is None
+
+    def test_menu_setter(self):
+        app = StatusBarApp("TestApp")
+        item1 = StatusMenuItem("Item1")
+        item2 = StatusMenuItem("Item2")
+        app.menu = [item1, None, item2]
+        assert "Item1" in app.menu
+        assert "Item2" in app.menu
+
+    def test_title_property(self):
+        app = StatusBarApp("TestApp", title="V1")
+        app.title = "V2"
+        assert app.title == "V2"
+
+    def test_icon_nsimage_property(self):
+        app = StatusBarApp("TestApp")
+        assert app._icon_nsimage is None
+        mock_image = MagicMock()
+        app._icon_nsimage = mock_image
+        assert app._icon_nsimage is mock_image
+
+
+# ---------------------------------------------------------------------------
+# Response
+# ---------------------------------------------------------------------------
+
+
+class TestResponse:
+    def test_clicked_ok(self):
+        r = Response(1, "hello")
+        assert r.clicked == 1
+        assert r.text == "hello"
+
+    def test_clicked_cancel(self):
+        r = Response(0, "")
+        assert r.clicked == 0
+
+    def test_repr(self):
+        r = Response(1, "short")
+        assert "clicked: 1" in repr(r)
+
+    def test_repr_long_text(self):
+        r = Response(1, "a" * 30)
+        assert "..." in repr(r)
+
+
+# ---------------------------------------------------------------------------
+# send_notification
+# ---------------------------------------------------------------------------
+
+
+class TestSendNotification:
+    @patch("voicetext.statusbar.NSUserNotificationCenter")
+    @patch("voicetext.statusbar.NSUserNotification")
+    def test_send_notification(self, mock_notif_cls, mock_center_cls):
+        mock_notif = MagicMock()
+        mock_notif_cls.alloc.return_value.init.return_value = mock_notif
+        mock_center = MagicMock()
+        mock_center_cls.defaultUserNotificationCenter.return_value = mock_center
+
+        send_notification("Title", "Sub", "Msg")
+
+        mock_notif.setTitle_.assert_called_once_with("Title")
+        mock_notif.setSubtitle_.assert_called_once_with("Sub")
+        mock_notif.setInformativeText_.assert_called_once_with("Msg")
+        mock_center.deliverNotification_.assert_called_once_with(mock_notif)
+
+    def test_send_notification_graceful_failure(self):
+        """Should not raise even when notification center is unavailable."""
+        with patch(
+            "voicetext.statusbar.NSUserNotification",
+            side_effect=Exception("unavailable"),
+        ):
+            send_notification("T", "S", "M")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# quit_application
+# ---------------------------------------------------------------------------
+
+
+class TestQuitApplication:
+    @patch("voicetext.statusbar.NSApplication")
+    def test_quit(self, mock_nsapp_cls):
+        mock_nsapp = MagicMock()
+        mock_nsapp_cls.sharedApplication.return_value = mock_nsapp
+        quit_application()
+        mock_nsapp.terminate_.assert_called_once()


### PR DESCRIPTION
## Summary

- Remove the `rumps` dependency entirely, replacing it with a new pure PyObjC module `src/voicetext/statusbar.py`
- The new module provides `StatusBarApp`, `StatusMenuItem`, `InputWindow`, `send_notification`, and `quit_application` — all backed by native AppKit APIs (NSStatusBar, NSMenu, NSMenuItem, NSAlert, NSUserNotification)
- Update `app.py` (~80 references), `auto_vocab_builder.py`, tests, `pyproject.toml`, and `CLAUDE.md` to use the new API

## Motivation

The project was already heavily bypassing rumps internals (`_icon_nsimage`, `_nsapp`, `_alert`, `_menuitem`) to access underlying AppKit objects. Removing rumps eliminates this abstraction leak and gives full control over the native APIs.

## Test plan

- [x] All 831 existing tests pass (`uv run pytest tests/`)
- [x] 32 new tests added for `statusbar.py` covering `StatusMenuItem` CRUD, `StatusBarApp` init, `Response`, `send_notification`, and `quit_application`
- [ ] Manual verification: launch app, verify statusbar icon, menus, submenus, notifications, settings panel, quit

🤖 Generated with [Claude Code](https://claude.com/claude-code)