### PR TITLE
feat(audio): show input device name and use current device

### DIFF
--- a/src/voicetext/audio/recorder.py
+++ b/src/voicetext/audio/recorder.py
@@ -50,6 +50,7 @@ class Recorder:
         self._total_bytes = 0
         self._current_rms: float = 0.0
         self._on_audio_chunk: Optional[callable] = None
+        self._last_device_name: Optional[str] = None  # track last used device name
 
     @property
     def is_recording(self) -> bool:
@@ -64,14 +65,37 @@ class Recorder:
         """
         return min(1.0, self._current_rms / self._LEVEL_REFERENCE_RMS)
 
-    def start(self) -> None:
-        """Start recording."""
+    def start(self) -> Optional[str]:
+        """Start recording. Returns the input device name, or None."""
         with self._lock:
             if self._recording:
-                return
+                return self._last_device_name
 
             self._flush()
             self._total_bytes = 0
+
+            device = self.device
+            current_name = self._query_device_name(device)
+
+            # Re-initialize PortAudio only when the device has changed
+            # (e.g. user plugged in a different mic) to avoid the cost
+            # of terminate/initialize on every recording.
+            if current_name != self._last_device_name:
+                try:
+                    sd._terminate()
+                    sd._initialize()
+                except Exception:
+                    logger.debug("PortAudio re-init failed, continuing", exc_info=True)
+                current_name = self._query_device_name(device)
+
+            if current_name != self._last_device_name:
+                logger.info(
+                    "Input device changed: %s -> %s",
+                    self._last_device_name or "(none)",
+                    current_name or "unknown",
+                )
+            else:
+                logger.debug("Reusing input device: %s", current_name)
 
             try:
                 self._stream = sd.RawInputStream(
@@ -80,7 +104,7 @@ class Recorder:
                     dtype="int16",
                     channels=1,
                     callback=self._callback,
-                    device=self.device,
+                    device=device,
                 )
                 self._stream.start()
             except Exception:
@@ -95,7 +119,9 @@ class Recorder:
                 self._stream.start()
 
             self._recording = True
+            self._last_device_name = current_name
             logger.info("Recording started (sr=%d)", self.sample_rate)
+            return current_name
 
     def stop(self) -> Optional[bytes]:
         """Stop recording and return WAV data as bytes, or None if nothing recorded."""
@@ -193,6 +219,15 @@ class Recorder:
                 cb(copied)
             except Exception:
                 logger.debug("Audio chunk callback error", exc_info=True)
+
+    @staticmethod
+    def _query_device_name(device: Optional[str]) -> Optional[str]:
+        """Return the name of the given input device, or None on failure."""
+        try:
+            info = sd.query_devices(device=device, kind="input")
+            return info.get("name")
+        except Exception:
+            return None
 
     def _flush(self) -> None:
         while not self._queue.empty():

--- a/src/voicetext/audio/recording_indicator.py
+++ b/src/voicetext/audio/recording_indicator.py
@@ -15,6 +15,7 @@ _EMA_ALPHA = 0.3
 # Panel dimensions
 _PANEL_WIDTH = 120
 _PANEL_HEIGHT = 50
+_PANEL_HEIGHT_WITH_LABEL = 68
 
 # Animation refresh interval in seconds (~20Hz)
 _REFRESH_INTERVAL = 0.05
@@ -43,10 +44,12 @@ class RecordingIndicatorView:
 
     _view: object = None
 
-    def __init__(self) -> None:
+    def __init__(self, device_name: Optional[str] = None) -> None:
         self._level: float = 0.0
         self._start_time: float = 0.0
         self._view = None
+        self._device_name: Optional[str] = device_name
+        self._label_attrs: Optional[dict] = None  # cached for draw loop
 
     def create_view(self, width: int, height: int) -> object:
         """Create and return the NSView instance."""
@@ -80,10 +83,22 @@ class RecordingIndicatorView:
 
     def draw(self, rect: object) -> None:
         """Draw the indicator contents."""
-        from AppKit import NSBezierPath
-        from Foundation import NSMakeRect
+        from AppKit import (
+            NSBezierPath,
+            NSFont,
+            NSFontAttributeName,
+            NSForegroundColorAttributeName,
+            NSParagraphStyleAttributeName,
+            NSMutableParagraphStyle,
+        )
+        from Foundation import NSMakeRect, NSString
 
-        height = rect.size.height
+        width = rect.size.width
+
+        # When a device label is shown, the animation area is the top
+        # portion and the label sits at the bottom.
+        label_height = (_PANEL_HEIGHT_WITH_LABEL - _PANEL_HEIGHT) if self._device_name else 0
+        anim_center_y = label_height + _PANEL_HEIGHT / 2.0
 
         # Semi-transparent rounded background (adapts to light/dark mode)
         bg_color = self._dynamic_color(
@@ -100,7 +115,7 @@ class RecordingIndicatorView:
 
         # Pulsing red dot on the left
         dot_x = 18.0
-        dot_y = height / 2.0
+        dot_y = anim_center_y
         pulse = math.sin(elapsed * _DOT_PULSE_SPEED) * _DOT_PULSE_AMPLITUDE
         dot_radius = _DOT_BASE_RADIUS + pulse
 
@@ -118,7 +133,7 @@ class RecordingIndicatorView:
 
         # Audio level bars on the right
         bars_start_x = 38.0
-        bar_y_base = (height - _BAR_MAX_HEIGHT) / 2.0
+        bar_y_base = anim_center_y - _BAR_MAX_HEIGHT / 2.0
 
         bar_color = self._dynamic_color(
             light_rgba=(0.2, 0.65, 0.2, 0.9),
@@ -144,6 +159,27 @@ class RecordingIndicatorView:
                 bar_rect, _BAR_CORNER_RADIUS, _BAR_CORNER_RADIUS
             )
             bar_path.fill()
+
+        # Device name label at the bottom (single line, truncate tail)
+        if self._device_name:
+            if self._label_attrs is None:
+                label_color = self._dynamic_color(
+                    light_rgba=(0.3, 0.3, 0.3, 0.8),
+                    dark_rgba=(0.7, 0.7, 0.7, 0.8),
+                )
+                para = NSMutableParagraphStyle.alloc().init()
+                para.setAlignment_(1)  # NSTextAlignmentCenter
+                para.setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
+                self._label_attrs = {
+                    NSFontAttributeName: NSFont.systemFontOfSize_(9),
+                    NSForegroundColorAttributeName: label_color,
+                    NSParagraphStyleAttributeName: para,
+                }
+                self._label_ns_str = NSString.stringWithString_(self._device_name)
+            label_rect = NSMakeRect(4, 4, width - 8, label_height)
+            self._label_ns_str.drawInRect_withAttributes_(
+                label_rect, self._label_attrs,
+            )
 
 
 # PyObjC subclass for custom drawing
@@ -189,7 +225,7 @@ class RecordingIndicatorPanel:
         if not value:
             self.hide()
 
-    def show(self) -> None:
+    def show(self, device_name: Optional[str] = None) -> None:
         """Create and show the floating indicator panel."""
         if not self._enabled:
             return
@@ -207,11 +243,13 @@ class RecordingIndicatorPanel:
                 self.hide()
 
             self._smoothed_level = 0.0
-            self._indicator_view = RecordingIndicatorView()
+            self._indicator_view = RecordingIndicatorView(device_name=device_name)
+
+            panel_height = _PANEL_HEIGHT_WITH_LABEL if device_name else _PANEL_HEIGHT
 
             # Create borderless panel
             panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
-                NSMakeRect(0, 0, _PANEL_WIDTH, _PANEL_HEIGHT),
+                NSMakeRect(0, 0, _PANEL_WIDTH, panel_height),
                 0,  # NSBorderlessWindowMask
                 2,  # NSBackingStoreBuffered
                 False,
@@ -230,11 +268,11 @@ class RecordingIndicatorPanel:
             if screen:
                 screen_frame = screen.visibleFrame()
                 x = screen_frame.origin.x + (screen_frame.size.width - _PANEL_WIDTH) / 2
-                y = screen_frame.origin.y + (screen_frame.size.height - _PANEL_HEIGHT) / 2
+                y = screen_frame.origin.y + (screen_frame.size.height - panel_height) / 2
                 panel.setFrameOrigin_((x, y))
 
             # Set content view
-            content_view = self._indicator_view.create_view(_PANEL_WIDTH, _PANEL_HEIGHT)
+            content_view = self._indicator_view.create_view(_PANEL_WIDTH, panel_height)
             panel.setContentView_(content_view)
 
             panel.orderFront_(None)

--- a/src/voicetext/controllers/recording_controller.py
+++ b/src/voicetext/controllers/recording_controller.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from voicetext.app import VoiceTextApp
@@ -41,17 +41,17 @@ class RecordingController:
             import time
             time.sleep(0.35)
             if not app._busy:
-                app._recorder.start()
+                dev_name = app._recorder.start()
                 self._start_streaming_if_supported()
-                self.start_recording_indicator()
+                self.start_recording_indicator(dev_name)
             app._recording_started.set()
 
         if app._sound_manager.enabled:
             threading.Thread(target=_delayed_start, daemon=True).start()
         else:
-            app._recorder.start()
+            dev_name = app._recorder.start()
             self._start_streaming_if_supported()
-            self.start_recording_indicator()
+            self.start_recording_indicator(dev_name)
             app._recording_started.set()
 
     def on_restart_recording(self) -> None:
@@ -90,17 +90,17 @@ class RecordingController:
             import time
             time.sleep(0.35)
             if not app._busy:
-                app._recorder.start()
+                dev_name = app._recorder.start()
                 self._start_streaming_if_supported()
-                self.start_recording_indicator()
+                self.start_recording_indicator(dev_name)
             app._recording_started.set()
 
         if app._sound_manager.enabled:
             threading.Thread(target=_delayed_start, daemon=True).start()
         else:
-            app._recorder.start()
+            dev_name = app._recorder.start()
             self._start_streaming_if_supported()
-            self.start_recording_indicator()
+            self.start_recording_indicator(dev_name)
             app._recording_started.set()
 
     def on_preview_history(self) -> None:
@@ -357,12 +357,12 @@ class RecordingController:
 
         AppHelper.callAfter(_close)
 
-    def start_recording_indicator(self) -> None:
+    def start_recording_indicator(self, device_name: Optional[str] = None) -> None:
         """Show visual indicator and start polling audio level."""
         from PyObjCTools import AppHelper
 
         app = self._app
-        AppHelper.callAfter(app._recording_indicator.show)
+        AppHelper.callAfter(app._recording_indicator.show, device_name)
 
         # Stop any existing poll thread
         if app._level_poll_stop is not None:


### PR DESCRIPTION
- Recorder.start() returns device name, only re-initializes PortAudio when the input device has changed (detected by name comparison)
- Recording indicator panel displays device name label at the bottom
- Label attrs cached to avoid object recreation in 20Hz draw loop