### PR TITLE
fix(apple-speech): preflight Siri/Dictation check before model switch

### DIFF
--- a/src/voicetext/app.py
+++ b/src/voicetext/app.py
@@ -23,6 +23,7 @@ from .ui.result_window_web import ResultPreviewPanel as WebResultPreviewPanel
 from .ui.settings_window import SettingsPanel
 from .hotkey import MultiHotkeyListener, TapHotkeyListener, _is_fn_key
 from .transcription.model_registry import (
+    find_fallback_preset,
     resolve_preset_from_config,
 )
 from .audio.recorder import Recorder
@@ -807,6 +808,42 @@ class VoiceTextApp(StatusBarApp):
         # Load models in background
         def _init_models():
             try:
+                # For Apple Speech, verify Siri/Dictation before initializing
+                asr_cfg = self._config["asr"]
+                if (
+                    not self._current_remote_asr
+                    and asr_cfg.get("backend") == "apple"
+                ):
+                    from .transcription.apple import check_siri_available
+
+                    self._set_status("Checking...")
+                    siri_ok, _ = check_siri_available(
+                        language=asr_cfg.get("language") or "zh",
+                        on_device=(asr_cfg.get("model") == "on-device"),
+                    )
+                    if not siri_ok:
+                        fallback = find_fallback_preset()
+                        if fallback:
+                            logger.warning(
+                                "Siri/Dictation disabled, using %s for this session",
+                                fallback.display_name,
+                            )
+                            self._transcriber = create_transcriber(
+                                backend=fallback.backend,
+                                use_vad=asr_cfg.get("use_vad", True),
+                                use_punc=asr_cfg.get("use_punc", True),
+                                language=fallback.language
+                                or asr_cfg.get("language"),
+                                model=fallback.model,
+                                temperature=asr_cfg.get("temperature"),
+                            )
+                            self._current_preset_id = fallback.id
+                            self._menu_builder.update_model_checkmarks()
+                        else:
+                            logger.warning(
+                                "Siri/Dictation disabled and no fallback available"
+                            )
+
                 if not self._config_degraded:
                     self._set_status("Loading...")
                 self._transcriber.initialize()

--- a/src/voicetext/controllers/model_controller.py
+++ b/src/voicetext/controllers/model_controller.py
@@ -331,6 +331,25 @@ models:
             monitor_thread = None
 
             try:
+                # For Apple Speech, verify Siri/Dictation is enabled first
+                if preset.backend == "apple":
+                    from voicetext.transcription.apple import (
+                        check_siri_available,
+                        prompt_enable_siri,
+                    )
+
+                    app._set_status("Checking...")
+                    ok, err = check_siri_available(
+                        language=preset.language
+                        or app._config.get("asr", {}).get("language", "zh"),
+                        on_device=(preset.model == "on-device"),
+                    )
+                    if not ok:
+                        logger.warning("Apple Speech preflight failed: %s", err)
+                        prompt_enable_siri()
+                        app._set_status("VT")
+                        return
+
                 app._set_status("Unloading...")
                 old_transcriber.cleanup()
 

--- a/src/voicetext/controllers/settings_controller.py
+++ b/src/voicetext/controllers/settings_controller.py
@@ -284,6 +284,33 @@ class SettingsController:
             stop_event = threading.Event()
             monitor_thread = None
             try:
+                # For Apple Speech, verify Siri/Dictation is enabled first
+                if preset.backend == "apple":
+                    from voicetext.transcription.apple import (
+                        check_siri_available,
+                        prompt_enable_siri,
+                    )
+
+                    app._set_status("Checking...")
+                    ok, err = check_siri_available(
+                        language=preset.language
+                        or app._config.get("asr", {}).get("language", "zh"),
+                        on_device=(preset.model == "on-device"),
+                    )
+                    if not ok:
+                        logger.warning("Apple Speech preflight failed: %s", err)
+                        prompt_enable_siri()
+                        # Revert settings panel radio back to the previous model
+                        from PyObjCTools import AppHelper
+
+                        AppHelper.callAfter(
+                            app._settings_panel.update_stt_model,
+                            old_preset_id,
+                            app._current_remote_asr,
+                        )
+                        app._set_status("VT")
+                        return
+
                 app._set_status("Unloading...")
                 old_transcriber.cleanup()
 

--- a/src/voicetext/transcription/apple.py
+++ b/src/voicetext/transcription/apple.py
@@ -30,6 +30,115 @@ _LANG_TO_LOCALE = {
 RECOGNITION_TIMEOUT = 30  # seconds
 STREAMING_FINAL_TIMEOUT = 10  # seconds to wait for final result after endAudio
 
+# macOS System Settings deep link for Siri / Dictation
+SIRI_SETTINGS_URL = "x-apple.systempreferences:com.apple.Siri-Settings.extension"
+
+
+def check_siri_available(language="zh", on_device=True):
+    """Quick check whether Siri/Dictation is enabled for Apple Speech.
+
+    Starts a recognition request and watches for an immediate
+    "Siri and Dictation are disabled" error.  Must be called from a
+    background thread (drives the RunLoop while waiting).
+
+    Returns ``(True, None)`` when Siri is available, or
+    ``(False, error_message)`` when it is disabled.
+    Non-Siri errors (auth, availability) return ``(True, None)`` so that
+    the normal ``initialize()`` path can surface them instead.
+    """
+    import Speech
+    from Foundation import NSLocale
+    from CoreFoundation import CFRunLoopRunInMode, kCFRunLoopDefaultMode
+
+    # -- authorization (fast if already granted) --
+    auth_event = threading.Event()
+    auth_status = [None]
+
+    def _on_auth(status):
+        auth_status[0] = status
+        auth_event.set()
+
+    Speech.SFSpeechRecognizer.requestAuthorization_(_on_auth)
+
+    deadline = time.monotonic() + 5
+    while not auth_event.is_set() and time.monotonic() < deadline:
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.1, False)
+
+    if not auth_event.is_set():
+        return True, None  # can't determine — let initialize() handle it
+
+    if auth_status[0] != Speech.SFSpeechRecognizerAuthorizationStatusAuthorized:
+        return True, None  # not a Siri issue — let initialize() handle it
+
+    # -- create recognizer --
+    locale_id = _resolve_locale(language or "zh")
+    locale = NSLocale.alloc().initWithLocaleIdentifier_(locale_id)
+    recognizer = Speech.SFSpeechRecognizer.alloc().initWithLocale_(locale)
+
+    if recognizer is None or not recognizer.isAvailable():
+        return True, None  # not a Siri issue
+
+    # -- quick recognition test --
+    request = Speech.SFSpeechAudioBufferRecognitionRequest.alloc().init()
+    if on_device and recognizer.supportsOnDeviceRecognition():
+        request.setRequiresOnDeviceRecognition_(True)
+
+    error_holder = [None]
+    error_event = threading.Event()
+
+    def _handler(result, error):
+        if error is not None:
+            error_holder[0] = (
+                str(error.localizedDescription())
+                if hasattr(error, "localizedDescription")
+                else str(error)
+            )
+            error_event.set()
+
+    task = recognizer.recognitionTaskWithRequest_resultHandler_(request, _handler)
+    request.endAudio()
+
+    # Siri-disabled errors fire within milliseconds; 0.3 s is plenty.
+    deadline = time.monotonic() + 0.3
+    while not error_event.is_set() and time.monotonic() < deadline:
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.05, False)
+
+    if task is not None:
+        try:
+            task.cancel()
+        except Exception:
+            pass
+
+    err = error_holder[0]
+    if err and "Siri" in err:
+        logger.warning("Siri/Dictation check failed: %s", err)
+        return False, err
+
+    return True, None
+
+
+def prompt_enable_siri():
+    """Show a dialog prompting the user to enable Siri, with an Open Settings button.
+
+    Safe to call from any thread (dispatches to main thread internally).
+    """
+    from voicetext.ui_helpers import restore_accessory, topmost_alert
+
+    result = topmost_alert(
+        title="Siri and Dictation Disabled",
+        message=(
+            "Apple Speech requires Siri and Dictation to be enabled.\n\n"
+            "Please enable it in System Settings > Apple Intelligence & Siri."
+        ),
+        ok="Open Settings",
+        cancel="Cancel",
+    )
+    if result == 1:
+        import subprocess
+
+        subprocess.Popen(["open", SIRI_SETTINGS_URL])
+    restore_accessory()
+
 
 _audio_fmt = None  # Cached AVAudioFormat (created once per sample rate)
 _audio_fmt_sr = None

--- a/src/voicetext/transcription/model_registry.py
+++ b/src/voicetext/transcription/model_registry.py
@@ -217,6 +217,27 @@ def get_model_size(preset: ModelPreset) -> Optional[int]:
     return total
 
 
+def find_fallback_preset() -> Optional[ModelPreset]:
+    """Find the best non-Apple preset to fall back to.
+
+    Prefers already-cached models (no download), then any available backend.
+    Returns None if no alternative is available.
+    """
+    # First pass: cached models (no download needed)
+    for preset in PRESETS:
+        if preset.backend == "apple":
+            continue
+        if is_backend_available(preset.backend) and is_model_cached(preset):
+            return preset
+    # Second pass: any available backend (may require download)
+    for preset in PRESETS:
+        if preset.backend == "apple":
+            continue
+        if is_backend_available(preset.backend):
+            return preset
+    return None
+
+
 def build_remote_asr_models(providers: Dict[str, Any]) -> List[RemoteASRModel]:
     """Build a list of RemoteASRModel from the asr.providers config section."""
     result = []

--- a/tests/transcription/test_apple.py
+++ b/tests/transcription/test_apple.py
@@ -1,11 +1,14 @@
 """Tests for the Apple Speech transcriber module."""
 
+import sys
 from unittest.mock import MagicMock
 
+import pytest
 
 from voicetext.transcription.base import BaseTranscriber
 from voicetext.transcription.apple import (
     AppleSpeechTranscriber,
+    SIRI_SETTINGS_URL,
     _LANG_TO_LOCALE,
     _resolve_locale,
 )
@@ -140,3 +143,133 @@ class TestAppleSpeechTranscriberLanguageMapping:
     def test_full_locale_preserved(self):
         t = AppleSpeechTranscriber(language="en-GB")
         assert t._locale_id == "en-GB"
+
+
+class TestSiriSettingsUrl:
+    def test_url_is_string(self):
+        assert isinstance(SIRI_SETTINGS_URL, str)
+        assert SIRI_SETTINGS_URL.startswith("x-apple.systempreferences:")
+
+
+class TestCheckSiriAvailable:
+    """Tests for check_siri_available() with mocked Apple frameworks."""
+
+    @pytest.fixture(autouse=True)
+    def _mock_apple_frameworks(self, monkeypatch):
+        self.mock_speech = MagicMock()
+        self.mock_foundation = MagicMock()
+        self.mock_corefoundation = MagicMock()
+
+        monkeypatch.setitem(sys.modules, "Speech", self.mock_speech)
+        monkeypatch.setitem(sys.modules, "Foundation", self.mock_foundation)
+        monkeypatch.setitem(sys.modules, "CoreFoundation", self.mock_corefoundation)
+
+        self.mock_corefoundation.CFRunLoopRunInMode = MagicMock()
+        self.mock_corefoundation.kCFRunLoopDefaultMode = "default"
+
+        # Default: authorization granted
+        self.mock_speech.SFSpeechRecognizerAuthorizationStatusAuthorized = 3
+
+        def _fake_request_auth(callback):
+            callback(3)  # authorized
+
+        self.mock_speech.SFSpeechRecognizer.requestAuthorization_ = _fake_request_auth
+
+        # Default: recognizer available
+        mock_recognizer = MagicMock()
+        mock_recognizer.isAvailable.return_value = True
+        mock_recognizer.supportsOnDeviceRecognition.return_value = True
+        self.mock_recognizer = mock_recognizer
+        self.mock_speech.SFSpeechRecognizer.alloc.return_value.initWithLocale_.return_value = (
+            mock_recognizer
+        )
+
+    def test_siri_available_no_error(self):
+        """When no error fires within timeout, check returns True."""
+        # recognition task handler is never called (no error)
+        self.mock_recognizer.recognitionTaskWithRequest_resultHandler_ = MagicMock(
+            return_value=MagicMock()
+        )
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language="zh", on_device=True)
+        assert ok is True
+        assert err is None
+
+    def test_siri_disabled_returns_false(self):
+        """When recognition fires a 'Siri' error, check returns False."""
+        mock_task = MagicMock()
+
+        def _start_recognition(request, handler):
+            # Simulate immediate Siri error
+            mock_error = MagicMock()
+            mock_error.localizedDescription.return_value = (
+                "Siri and Dictation are disabled"
+            )
+            handler(None, mock_error)
+            return mock_task
+
+        self.mock_recognizer.recognitionTaskWithRequest_resultHandler_ = (
+            _start_recognition
+        )
+
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language="zh", on_device=True)
+        assert ok is False
+        assert "Siri" in err
+
+    def test_non_siri_error_returns_true(self):
+        """Non-Siri errors are ignored (let initialize() handle them)."""
+        mock_task = MagicMock()
+
+        def _start_recognition(request, handler):
+            mock_error = MagicMock()
+            mock_error.localizedDescription.return_value = "No speech detected"
+            handler(None, mock_error)
+            return mock_task
+
+        self.mock_recognizer.recognitionTaskWithRequest_resultHandler_ = (
+            _start_recognition
+        )
+
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language="zh", on_device=True)
+        assert ok is True
+
+    def test_auth_not_granted_returns_true(self):
+        """Auth denied is not a Siri issue — return True to let init handle it."""
+
+        def _fake_request_auth(callback):
+            callback(2)  # denied
+
+        self.mock_speech.SFSpeechRecognizer.requestAuthorization_ = (
+            _fake_request_auth
+        )
+
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language="zh", on_device=True)
+        assert ok is True  # not a Siri issue
+
+    def test_language_none_does_not_crash(self):
+        """Passing language=None should not raise TypeError."""
+        self.mock_recognizer.recognitionTaskWithRequest_resultHandler_ = MagicMock(
+            return_value=MagicMock()
+        )
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language=None, on_device=True)
+        assert ok is True
+
+    def test_recognizer_unavailable_returns_true(self):
+        """Unavailable recognizer is not a Siri issue."""
+        self.mock_speech.SFSpeechRecognizer.alloc.return_value.initWithLocale_.return_value = (
+            None
+        )
+
+        from voicetext.transcription.apple import check_siri_available
+
+        ok, err = check_siri_available(language="zh", on_device=True)
+        assert ok is True

--- a/tests/transcription/test_model_registry.py
+++ b/tests/transcription/test_model_registry.py
@@ -3,9 +3,12 @@
 from pathlib import Path
 
 
+from unittest.mock import patch
+
 from voicetext.transcription.model_registry import (
     PRESET_BY_ID,
     PRESETS,
+    find_fallback_preset,
     get_model_cache_dir,
     get_model_size,
     is_backend_available,
@@ -182,6 +185,59 @@ class TestIsBackendAvailable:
         r1 = is_backend_available("funasr")
         r2 = is_backend_available("funasr")
         assert r1 == r2
+
+
+class TestFindFallbackPreset:
+    def test_skips_apple_presets(self):
+        result = find_fallback_preset()
+        if result is not None:
+            assert result.backend != "apple"
+
+    def test_returns_none_when_nothing_available(self):
+        with patch(
+            "voicetext.transcription.model_registry.is_backend_available",
+            return_value=False,
+        ):
+            assert find_fallback_preset() is None
+
+    def test_prefers_cached_model(self):
+        def _available(backend):
+            return backend in ("funasr", "mlx-whisper")
+
+        def _cached(preset):
+            return preset.backend == "mlx-whisper"
+
+        with (
+            patch(
+                "voicetext.transcription.model_registry.is_backend_available",
+                side_effect=_available,
+            ),
+            patch(
+                "voicetext.transcription.model_registry.is_model_cached",
+                side_effect=_cached,
+            ),
+        ):
+            result = find_fallback_preset()
+            assert result is not None
+            assert result.backend == "mlx-whisper"
+
+    def test_falls_back_to_available_if_none_cached(self):
+        def _available(backend):
+            return backend == "funasr"
+
+        with (
+            patch(
+                "voicetext.transcription.model_registry.is_backend_available",
+                side_effect=_available,
+            ),
+            patch(
+                "voicetext.transcription.model_registry.is_model_cached",
+                return_value=False,
+            ),
+        ):
+            result = find_fallback_preset()
+            assert result is not None
+            assert result.backend == "funasr"
 
 
 class TestIsModelCached:


### PR DESCRIPTION
When selecting Apple Speech (On-Device or Server), perform a quick recognition test to detect if Siri and Dictation is disabled before switching the model. If disabled, show a dialog with an option to open System Settings directly, and revert the settings panel selection to the previous model.

Previously the error only surfaced after recording started, causing a silent failure with empty transcription results.