### PR TITLE
feat(settings): add right-side modifier keys to restart/cancel dropdowns

### DIFF
--- a/src/voicetext/ui/settings_window.py
+++ b/src/voicetext/ui/settings_window.py
@@ -360,8 +360,10 @@ class SettingsPanel:
 
         # Restart / Cancel key dropdowns
         _key_choices = [
-            ("space", "Space"), ("cmd", "Command"), ("ctrl", "Control"),
-            ("alt", "Option"), ("shift", "Shift"), ("esc", "Esc"),
+            ("space", "Space"), ("cmd", "Command"), ("cmd_r", "Command (Right)"),
+            ("ctrl", "Control"), ("ctrl_r", "Control (Right)"),
+            ("alt", "Option"), ("alt_r", "Option (Right)"),
+            ("shift", "Shift"), ("shift_r", "Shift (Right)"), ("esc", "Esc"),
         ]
         label_w = 80
         popup_w = 140


### PR DESCRIPTION
Add Command (Right), Control (Right), Option (Right), and Shift (Right) options to the hotkey restart/cancel key selection dropdowns. The hotkey backend already supports these keys via _MOD_VK.