### PR TITLE
feat(settings): add model timeout config to LLM tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ htmlcov/
 .idea/
 .vscode/
 *.swp
+*~
+*.un~
 
 # Logs
 logs/

--- a/src/wenzi/controllers/settings_controller.py
+++ b/src/wenzi/controllers/settings_controller.py
@@ -113,6 +113,7 @@ class SettingsController:
             "stt_remote_models": stt_remote,
             "llm_models": llm_models,
             "current_llm": current_llm,
+            "model_timeout": app._config.get("ai_enhance", {}).get("connection_timeout", 10),
             "enhance_modes": enhance_modes,
             "current_enhance_mode": app._enhance_mode,
             "thinking": bool(app._enhancer and app._enhancer.thinking),
@@ -155,6 +156,7 @@ class SettingsController:
             "on_llm_select": self.llm_select,
             "on_llm_add_provider": lambda: app._model_controller.on_enhance_add_provider(None),
             "on_llm_remove_provider": self.llm_remove_provider,
+            "on_model_timeout": self.model_timeout_change,
             "on_enhance_mode_select": self.enhance_mode_select,
             "on_enhance_mode_edit": self.enhance_mode_edit,
             "on_enhance_add_mode": lambda: app._on_enhance_add_mode(None),
@@ -656,6 +658,16 @@ class SettingsController:
                 item = app._llm_remove_provider_items.get(first_name)
                 if item:
                     app._model_controller.on_enhance_remove_provider(item)
+
+    def model_timeout_change(self, value: int) -> None:
+        """Handle model timeout change from Settings panel."""
+        app = self._app
+        if app._enhancer:
+            app._enhancer._connection_timeout = value
+        app._config.setdefault("ai_enhance", {})
+        app._config["ai_enhance"]["connection_timeout"] = value
+        self._save_and_reload()
+        logger.info("Model connection timeout set to: %ds (from settings)", value)
 
     def enhance_mode_edit(self, mode_id: str) -> None:
         """Open the enhance mode markdown file in TextEdit."""

--- a/src/wenzi/ui/settings_window.py
+++ b/src/wenzi/ui/settings_window.py
@@ -157,6 +157,7 @@ class SettingsPanel:
                 - on_llm_select: (provider, model) -> None
                 - on_llm_add_provider: () -> None
                 - on_llm_remove_provider: (provider) -> None
+                - on_model_timeout: (value) -> None
                 - on_enhance_mode_select: (mode_id) -> None
                 - on_enhance_add_mode: () -> None
                 - on_thinking_toggle: (enabled) -> None
@@ -731,7 +732,7 @@ class SettingsPanel:
         llm_models = state.get("llm_models", [])
         current_llm = state.get("current_llm")
 
-        n_rows = len(llm_models) + 4
+        n_rows = len(llm_models) + 7
         total_h = max(content_h, n_rows * (self._CONTROL_HEIGHT + self._ROW_GAP) + 80)
 
         doc_view = NSView.alloc().initWithFrame_(
@@ -785,6 +786,25 @@ class SettingsPanel:
         remove_btn.setTarget_(self)
         remove_btn.setAction_(b"llmRemoveProviderClicked:")
         doc_view.addSubview_(remove_btn)
+
+        # --- Model Timeout section ---
+        y -= self._SECTION_GAP
+        y -= self._LABEL_HEIGHT
+        timeout_label = self._make_label("Model Timeout", pad, y, content_w, label_font)
+        doc_view.addSubview_(timeout_label)
+
+        y -= (self._CONTROL_HEIGHT + self._ROW_GAP)
+        timeout_items = [(v, f"{v}s") for v in (5, 10, 15, 20, 30, 45, 60)]
+        current_timeout = state.get("model_timeout", 10)
+        self._model_timeout_popup = self._make_popup(
+            timeout_items, current_timeout,
+            pad + 12, y, 80, small_font,
+            b"modelTimeoutChanged:", doc_view,
+        )
+        y = self._add_hint(
+            "Maximum time to wait for a model response before giving up",
+            pad + 12, y, content_w - 24, doc_view,
+        )
 
         scroll.setDocumentView_(doc_view)
         tab_item.setView_(scroll)
@@ -1692,6 +1712,11 @@ class SettingsPanel:
 
     def llmRemoveProviderClicked_(self, sender):
         self._call("on_llm_remove_provider")
+
+    def modelTimeoutChanged_(self, sender):
+        value = sender.selectedItem().representedObject()
+        if value is not None:
+            self._call("on_model_timeout", int(value))
 
     def enhanceModeEditClicked_(self, sender):
         meta = self._get_meta(sender)

--- a/tests/controllers/test_settings_controller.py
+++ b/tests/controllers/test_settings_controller.py
@@ -302,6 +302,21 @@ class TestHistoryToggle:
         ctrl.history_toggle(True)  # Should not raise
 
 
+class TestModelTimeoutChange:
+    @patch("wenzi.controllers.settings_controller.save_config")
+    def test_change_timeout(self, mock_save, ctrl, mock_app):
+        ctrl.model_timeout_change(20)
+
+        assert mock_app._enhancer._connection_timeout == 20
+        assert mock_app._config["ai_enhance"]["connection_timeout"] == 20
+
+    @patch("wenzi.controllers.settings_controller.save_config")
+    def test_no_enhancer(self, mock_save, ctrl, mock_app):
+        mock_app._enhancer = None
+        ctrl.model_timeout_change(20)  # Should not raise
+        assert mock_app._config["ai_enhance"]["connection_timeout"] == 20
+
+
 class TestEnhanceModeEdit:
     def test_opens_textedit(self, ctrl):
         with patch("subprocess.Popen") as mock_popen:

--- a/tests/ui/test_settings_window.py
+++ b/tests/ui/test_settings_window.py
@@ -59,6 +59,7 @@ def _make_callbacks():
         "on_stt_select",
         "on_stt_remote_select", "on_stt_add_provider", "on_stt_remove_provider",
         "on_llm_select", "on_llm_add_provider", "on_llm_remove_provider",
+        "on_model_timeout",
         "on_enhance_mode_select", "on_enhance_add_mode", "on_enhance_mode_edit",
         "on_thinking_toggle", "on_vocab_toggle", "on_auto_build_toggle",
         "on_history_toggle", "on_vocab_build",
@@ -304,6 +305,15 @@ class TestSettingsCallbacks:
         panel.enhanceModeEditClicked_(sender)
 
         cbs["on_enhance_mode_edit"].assert_called_once_with("proofread")
+
+    def test_model_timeout_calls_callback(self):
+        panel, cbs = self._make_panel()
+
+        sender = MagicMock()
+        sender.selectedItem().representedObject.return_value = 60
+        panel.modelTimeoutChanged_(sender)
+
+        cbs["on_model_timeout"].assert_called_once_with(60)
 
 
 class TestEnhanceModeOrder:


### PR DESCRIPTION
## Summary
- Add a Model Timeout dropdown (5–60s) to the Settings LLM tab, controlling `ai_enhance.connection_timeout`
- Add vim backup/undo file patterns (`*~`, `*.un~`) to `.gitignore`

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 2572 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)