### PR TITLE
fix(statusbar): use identity check for separator sentinel

### DIFF
--- a/src/wenzi/statusbar.py
+++ b/src/wenzi/statusbar.py
@@ -220,7 +220,7 @@ class StatusMenuItem:
         for ele in iterable:
             if isinstance(ele, StatusMenuItem):
                 self.add(ele)
-            elif isinstance(ele, (type(None), type(separator))):
+            elif ele is None or ele is separator:
                 self.add(None)
             elif isinstance(ele, (list, tuple)) and len(ele) == 2:
                 menuitem, submenu = ele

--- a/tests/test_statusbar.py
+++ b/tests/test_statusbar.py
@@ -8,10 +8,12 @@ import pytest
 
 from wenzi.statusbar import (
     Response,
+    SeparatorMenuItem,
     StatusBarApp,
     StatusMenuItem,
     quit_application,
     send_notification,
+    separator,
 )
 
 
@@ -124,6 +126,35 @@ class TestStatusMenuItem:
         assert "Item1" in parent
         assert "Item2" in parent
         assert len(parent) == 3  # Item1, separator, Item2
+
+    def test_parse_menu_separator_sentinel(self):
+        """The `separator` sentinel object should create a separator."""
+        parent = StatusMenuItem("Root")
+        parent.update([StatusMenuItem("A"), separator, StatusMenuItem("B")])
+        assert "A" in parent
+        assert "B" in parent
+        assert len(parent) == 3
+        # The middle item should be a SeparatorMenuItem
+        values = list(parent._items.values())
+        assert isinstance(values[1], SeparatorMenuItem)
+
+    def test_parse_menu_string_element(self):
+        """Plain strings should become StatusMenuItems, not separators."""
+        parent = StatusMenuItem("Root")
+        parent.update(["Hello", "World"])
+        assert "Hello" in parent
+        assert "World" in parent
+        assert len(parent) == 2
+        assert isinstance(parent["Hello"], StatusMenuItem)
+
+    def test_parse_menu_submenu_tuple(self):
+        """A (str, list) tuple should create a submenu."""
+        parent = StatusMenuItem("Root")
+        parent.update([("Parent", [StatusMenuItem("Child")])])
+        assert "Parent" in parent
+        assert isinstance(parent["Parent"], StatusMenuItem)
+        # Child should be nested under Parent
+        assert "Child" in parent["Parent"]
 
     def test_keys_del_rebuild_menu(self):
         """Simulate the hotkey menu rebuild pattern from app.py."""


### PR DESCRIPTION
## Summary
- Replace misleading `isinstance(ele, (type(None), type(separator)))` with `ele is None or ele is separator` in `_parse_menu()`
- `type(separator)` evaluates to `object`, making the old check match **any** Python object — string elements and submenu tuples were silently treated as separators
- Add 3 tests covering separator sentinel, string elements, and submenu tuple parsing

Closes #42

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 2724 passed
- [x] New tests: `test_parse_menu_separator_sentinel`, `test_parse_menu_string_element`, `test_parse_menu_submenu_tuple`

🤖 Generated with [Claude Code](https://claude.com/claude-code)