### PR TITLE
fix(scripting): eliminate timer callback race condition

### DIFF
--- a/src/wenzi/scripting/api/timer.py
+++ b/src/wenzi/scripting/api/timer.py
@@ -19,19 +19,18 @@ class TimerAPI:
 
     def after(self, seconds: float, callback: Callable) -> str:
         """Execute callback once after a delay. Returns timer_id."""
-        timer_id = self._registry.register_timer(seconds, callback, repeating=False)
-        entry = self._registry.timers[timer_id]
-        t = threading.Timer(seconds, self._fire_once, args=(timer_id,))
+        entry = self._registry.register_timer(seconds, callback, repeating=False)
+        t = threading.Timer(seconds, self._fire_once, args=(entry.timer_id,))
         t.daemon = True
         entry._timer = t
         t.start()
-        return timer_id
+        return entry.timer_id
 
     def every(self, seconds: float, callback: Callable) -> str:
         """Execute callback repeatedly at interval. Returns timer_id."""
-        timer_id = self._registry.register_timer(seconds, callback, repeating=True)
-        self._schedule_repeat(timer_id)
-        return timer_id
+        entry = self._registry.register_timer(seconds, callback, repeating=True)
+        self._schedule_repeat(entry.timer_id)
+        return entry.timer_id
 
     def cancel(self, timer_id: str) -> None:
         """Cancel a timer."""
@@ -39,18 +38,17 @@ class TimerAPI:
 
     def _fire_once(self, timer_id: str) -> None:
         """Fire a one-shot timer and remove it."""
-        entry = self._registry.timers.get(timer_id)
+        entry = self._registry.pop_timer(timer_id)
         if entry is None:
             return
         try:
             entry.callback()
         except Exception as exc:
             logger.error("Timer callback error: %s", exc)
-        self._registry.cancel_timer(timer_id)
 
     def _schedule_repeat(self, timer_id: str) -> None:
         """Schedule the next tick of a repeating timer."""
-        entry = self._registry.timers.get(timer_id)
+        entry = self._registry.get_timer(timer_id)
         if entry is None:
             return
         t = threading.Timer(entry.interval, self._fire_repeat, args=(timer_id,))
@@ -60,7 +58,7 @@ class TimerAPI:
 
     def _fire_repeat(self, timer_id: str) -> None:
         """Fire a repeating timer and reschedule."""
-        entry = self._registry.timers.get(timer_id)
+        entry = self._registry.get_timer(timer_id)
         if entry is None:
             return
         try:

--- a/src/wenzi/scripting/registry.py
+++ b/src/wenzi/scripting/registry.py
@@ -116,8 +116,8 @@ class ScriptingRegistry:
 
     def register_timer(
         self, interval: float, callback: Callable, repeating: bool = False
-    ) -> str:
-        """Register a timer. Returns a unique timer_id."""
+    ) -> TimerEntry:
+        """Register a timer. Returns the TimerEntry."""
         timer_id = str(uuid.uuid4())
         entry = TimerEntry(
             timer_id=timer_id,
@@ -133,12 +133,21 @@ class ScriptingRegistry:
             interval,
             repeating,
         )
-        return timer_id
+        return entry
+
+    def get_timer(self, timer_id: str) -> Optional[TimerEntry]:
+        """Thread-safe lookup of a timer entry."""
+        with self._lock:
+            return self._timers.get(timer_id)
+
+    def pop_timer(self, timer_id: str) -> Optional[TimerEntry]:
+        """Atomically remove and return a timer entry without cancelling."""
+        with self._lock:
+            return self._timers.pop(timer_id, None)
 
     def cancel_timer(self, timer_id: str) -> None:
         """Cancel and remove a timer."""
-        with self._lock:
-            entry = self._timers.pop(timer_id, None)
+        entry = self.pop_timer(timer_id)
         if entry and entry._timer:
             entry._timer.cancel()
             logger.info("Cancelled timer %s", timer_id[:8])

--- a/tests/scripting/test_api_timer.py
+++ b/tests/scripting/test_api_timer.py
@@ -57,3 +57,60 @@ class TestTimerAPI:
         reg = ScriptingRegistry()
         api = TimerAPI(reg)
         api.cancel("nonexistent")  # Should not raise
+
+    def test_fire_once_cancel_race(self):
+        """Fire and cancel racing on the same timer should not raise or deadlock."""
+        reg = ScriptingRegistry()
+        api = TimerAPI(reg)
+        result = []
+
+        timer_id = api.after(0.02, lambda: result.append(1))
+        time.sleep(0.01)
+        api.cancel(timer_id)
+        # Wait for the timer thread to settle
+        time.sleep(0.05)
+        # pop_timer is atomic with cancel_timer, so either cancel won
+        # (callback never runs) or fire won (callback runs and pops first).
+        # In either case the entry should be gone and no exception raised.
+        assert timer_id not in reg.timers
+
+    def test_concurrent_cancel_fire_once(self):
+        """Many concurrent cancel+fire cycles should not raise."""
+        reg = ScriptingRegistry()
+        api = TimerAPI(reg)
+        errors = []
+
+        def run_cycle():
+            try:
+                result = []
+                tid = api.after(0.01, lambda: result.append(1))
+                time.sleep(0.005)
+                api.cancel(tid)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=run_cycle) for _ in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5.0)
+        assert errors == []
+
+    def test_get_timer_thread_safe(self):
+        """Registry.get_timer returns entry under lock."""
+        reg = ScriptingRegistry()
+        entry = reg.register_timer(1.0, lambda: None, repeating=False)
+        looked_up = reg.get_timer(entry.timer_id)
+        assert looked_up is entry
+        assert reg.get_timer("nonexistent") is None
+
+    def test_pop_timer_thread_safe(self):
+        """Registry.pop_timer atomically removes and returns entry."""
+        reg = ScriptingRegistry()
+        entry = reg.register_timer(1.0, lambda: None, repeating=False)
+        tid = entry.timer_id
+        popped = reg.pop_timer(tid)
+        assert popped is entry
+        # Second pop should return None
+        assert reg.pop_timer(tid) is None
+        assert tid not in reg.timers

--- a/tests/scripting/test_registry.py
+++ b/tests/scripting/test_registry.py
@@ -40,23 +40,22 @@ class TestScriptingRegistry:
 
     def test_register_timer(self):
         reg = ScriptingRegistry()
-        timer_id = reg.register_timer(1.0, _noop, repeating=False)
-        assert timer_id in reg.timers
-        assert reg.timers[timer_id].interval == 1.0
-        assert reg.timers[timer_id].repeating is False
+        entry = reg.register_timer(1.0, _noop, repeating=False)
+        assert entry.timer_id in reg.timers
+        assert entry.interval == 1.0
+        assert entry.repeating is False
 
     def test_cancel_timer(self):
         reg = ScriptingRegistry()
-        timer_id = reg.register_timer(10.0, _noop)
+        entry = reg.register_timer(10.0, _noop)
         # Set a real timer to verify cancel
-        entry = reg.timers[timer_id]
         t = threading.Timer(10.0, _noop)
         t.daemon = True
         entry._timer = t
         t.start()
 
-        reg.cancel_timer(timer_id)
-        assert timer_id not in reg.timers
+        reg.cancel_timer(entry.timer_id)
+        assert entry.timer_id not in reg.timers
         # Timer.cancel() prevents firing but thread may still be alive briefly
         t.join(timeout=1.0)
         assert not t.is_alive()
@@ -69,11 +68,10 @@ class TestScriptingRegistry:
         reg = ScriptingRegistry()
         reg.register_leader("cmd_r", [LeaderMapping(key="w", app="WeChat")])
         reg.register_hotkey("ctrl+v", _noop)
-        timer_id = reg.register_timer(10.0, _noop)
+        entry = reg.register_timer(10.0, _noop)
         reg.register_event("test_event", _noop)
 
         # Add a real timer
-        entry = reg.timers[timer_id]
         t = threading.Timer(10.0, _noop)
         t.daemon = True
         entry._timer = t


### PR DESCRIPTION
## Summary
- Add thread-safe `get_timer`/`pop_timer` methods to `ScriptingRegistry`, replacing direct `_timers` dict access in `TimerAPI`
- `_fire_once` uses `pop_timer` to atomically claim the entry — either fire wins or cancel wins, eliminating the TOCTOU race
- `register_timer` returns `TimerEntry` directly, avoiding redundant lock acquisition in `after()`
- `cancel_timer` delegates to `pop_timer` to remove duplicated pop-under-lock logic

Closes #43

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 2728 passed
- [x] New tests: `test_fire_once_cancel_race`, `test_concurrent_cancel_fire_once`, `test_get_timer_thread_safe`, `test_pop_timer_thread_safe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)