### PR TITLE
docs(tests): document white-box imports in combo hotkey tests

### DIFF
--- a/tests/test_combo_hotkey.py
+++ b/tests/test_combo_hotkey.py
@@ -1,4 +1,11 @@
-"""Tests for combo hotkey recording helpers."""
+"""Tests for combo hotkey recording helpers.
+
+White-box tests: _MOD_CANONICAL, _MOD_DISPLAY_ORDER, _SPECIAL_VK, and
+_VK_TO_NAME are private mapping tables imported intentionally to verify
+internal consistency (e.g. every modifier key has a canonical form, every
+keycode has a reverse lookup). These invariants cannot be tested through
+public APIs alone.
+"""
 
 from wenzi.app import (
     _MOD_CANONICAL,


### PR DESCRIPTION
## Summary
- Add module docstring explaining why private symbols (`_MOD_CANONICAL`, `_MOD_DISPLAY_ORDER`, `_SPECIAL_VK`, `_VK_TO_NAME`) are imported in `test_combo_hotkey.py`
- These are intentional white-box tests verifying internal mapping table consistency that cannot be tested through public APIs alone

Closes #50

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 2734 passed
- [x] Documentation-only change, no behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)