### PR TITLE
fix(ui): remove dead checkAppearance_ method

### DIFF
--- a/src/wenzi/ui/live_transcription_overlay.py
+++ b/src/wenzi/ui/live_transcription_overlay.py
@@ -176,10 +176,6 @@ class LiveTranscriptionOverlay:
         except Exception:
             logger.error("Failed to show live transcription overlay", exc_info=True)
 
-    def checkAppearance_(self, timer) -> None:
-        """NSTimer callback: check if appearance changed and refresh colors."""
-        self._refresh_colors_if_changed()
-
     def set_active(self) -> None:
         """Switch the overlay from faded to full opacity.
 


### PR DESCRIPTION
## Summary

- Remove unused `checkAppearance_` method from `LiveTranscriptionOverlay` — it was never called
- The appearance timer uses `refresh:` selector on `_LiveBgView`, not this method
- Color refresh logic is already handled directly in `update_text()` via `_refresh_colors_if_changed()`

Closes #54

## Test plan

- [x] Lint passes (`ruff check` — 0 errors)
- [x] All 2734 tests pass
- [x] 3 rounds of `/simplify` review confirmed no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)