### PR TITLE
fix: address all ai-code-review findings (#58–#64, #67)

### DIFF
--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -572,8 +572,8 @@ class RecordingIndicatorPanel:
                 if completion:
                     completion()
 
-            ctx = NSAnimationContext.currentContext()
             NSAnimationContext.beginGrouping()
+            ctx = NSAnimationContext.currentContext()
             ctx.setDuration_(0.2)
             ctx.setCompletionHandler_(_on_complete)
             panel.animator().setAlphaValue_(0.0)

--- a/src/wenzi/scripting/engine.py
+++ b/src/wenzi/scripting/engine.py
@@ -147,11 +147,9 @@ class ScriptEngine:
         self._wz.pasteboard._set_monitor(None)
         self._wz.snippets._set_store(None)
 
-        # Clear all registered sources
+        # Clear all registered sources and trackers
         panel = self._wz.chooser._get_panel()
-        panel._sources.clear()
-        panel._usage_tracker = None
-        panel._query_history = None
+        panel.reset()
 
         logger.info("Chooser disabled at runtime")
 
@@ -238,6 +236,11 @@ class ScriptEngine:
             if self._snippet_expander is not None:
                 self._snippet_expander.stop()
                 self._snippet_expander = None
+            chooser_config = self._config.get("chooser", {})
+            snippet_hotkey = chooser_config.get("new_snippet_hotkey", "")
+            if snippet_hotkey:
+                self._wz.hotkey.unbind(snippet_hotkey)
+            self._snippet_source = None
             self._snippet_store = None
             self._wz.snippets._set_store(None)
             self._wz.chooser.unregister_source(source_name)

--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -28,6 +28,9 @@ _VK_DELETE = 51
 # Maximum buffer length — keywords longer than this are not supported
 _MAX_BUFFER = 128
 
+# UTF-16 buffer size for CGEventKeyboardGetUnicodeString
+_KEYBOARD_BUF_SIZE = 16
+
 # Keycodes that should clear the character buffer (navigation / control)
 _CLEAR_KEYCODES = {
     36,  # return
@@ -51,16 +54,17 @@ def _get_unicode_string(event) -> str:
     import objc
 
     length = ctypes.c_uint32(0)
-    buf = (ctypes.c_uint16 * 4)()
+    buf = (ctypes.c_uint16 * _KEYBOARD_BUF_SIZE)()
     _carbon.CGEventKeyboardGetUnicodeString(
         ctypes.c_void_p(objc.pyobjc_id(event)),
-        ctypes.c_uint32(4),
+        ctypes.c_uint32(_KEYBOARD_BUF_SIZE),
         ctypes.byref(length),
         buf,
     )
     if length.value == 0:
         return ""
-    return "".join(chr(buf[i]) for i in range(length.value))
+    n = min(length.value, _KEYBOARD_BUF_SIZE)
+    return "".join(chr(buf[i]) for i in range(n))
 
 
 class SnippetExpander:
@@ -281,6 +285,17 @@ class SnippetExpander:
             )
         except Exception:
             logger.exception("Failed to expand snippet %r", keyword)
+            try:
+                from wenzi.statusbar import send_notification
+
+                send_notification(
+                    "Snippet Expansion Failed",
+                    f"Keyword: {keyword}",
+                    "Paste (Cmd+V) did not complete. "
+                    "The snippet content is still on your clipboard.",
+                )
+            except Exception:
+                pass
         finally:
             self._expanding = False
 

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -262,6 +262,12 @@ class ChooserPanel:
         """Remove a data source by name."""
         self._sources.pop(name, None)
 
+    def reset(self) -> None:
+        """Clear all sources and reset trackers."""
+        self._sources.clear()
+        self._usage_tracker = None
+        self._query_history = None
+
     # ------------------------------------------------------------------
     # Event helpers
     # ------------------------------------------------------------------

--- a/src/wenzi/ui/live_transcription_overlay.py
+++ b/src/wenzi/ui/live_transcription_overlay.py
@@ -17,24 +17,28 @@ _SCREEN_Y_OFFSET = 80  # offset below center (below recording indicator)
 
 # Module-level NSView subclass for drawRect_-based background
 try:
+    from AppKit import NSAppearanceNameAqua as _AQUA
+    from AppKit import NSAppearanceNameDarkAqua as _DARK_AQUA
     from AppKit import NSBezierPath as _BP
     from AppKit import NSColor as _NC
     from AppKit import NSView as _NV
+
+    def _make_bg_color():
+        def _provider(appearance):
+            name = appearance.bestMatchFromAppearancesWithNames_([_AQUA, _DARK_AQUA])
+            if name == _DARK_AQUA:
+                return _NC.colorWithSRGBRed_green_blue_alpha_(0.15, 0.15, 0.15, 0.85)
+            return _NC.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 0.85)
+        return _NC.colorWithName_dynamicProvider_("WenZiLiveBg", _provider)
+
+    _BG_COLOR = _make_bg_color()
 
     class _LiveBgView(_NV):
         def isOpaque(self):
             return False
 
         def drawRect_(self, rect):
-            def _provider(appearance):
-                name = appearance.bestMatchFromAppearancesWithNames_(
-                    ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-                )
-                if name and "Dark" in str(name):
-                    return _NC.colorWithSRGBRed_green_blue_alpha_(0.15, 0.15, 0.15, 0.85)
-                return _NC.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 0.85)
-
-            _NC.colorWithName_dynamicProvider_(None, _provider).setFill()
+            _BG_COLOR.setFill()
             _BP.bezierPathWithRoundedRect_xRadius_yRadius_(
                 rect, _CORNER_RADIUS, _CORNER_RADIUS
             ).fill()
@@ -44,15 +48,6 @@ try:
 
 except Exception:
     _LiveBgView = None
-
-
-def _is_dark_mode() -> bool:
-    """Detect whether the system is currently in dark mode."""
-    try:
-        from AppKit import NSApp
-        return "Dark" in str(NSApp.effectiveAppearance().name())
-    except Exception:
-        return False
 
 
 class LiveTranscriptionOverlay:
@@ -70,24 +65,29 @@ class LiveTranscriptionOverlay:
         self._text_field: object = None
         self._content_view: object = None
         self._screen_center_y: float = 0  # cached for repositioning
-        self._last_dark: bool = False
         self._appearance_timer: object = None
         self._active: bool = True
 
-    @staticmethod
-    def _dynamic_text_color():
-        """Create a dynamic text color that contrasts with the background."""
-        from AppKit import NSColor
+    _TEXT_COLOR = None
 
-        def _provider(appearance):
-            name = appearance.bestMatchFromAppearancesWithNames_(
-                ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
+    @classmethod
+    def _dynamic_text_color(cls):
+        """Return a cached dynamic text color that contrasts with the background."""
+        if cls._TEXT_COLOR is None:
+            from AppKit import NSAppearanceNameAqua, NSAppearanceNameDarkAqua, NSColor
+
+            def _provider(appearance):
+                name = appearance.bestMatchFromAppearancesWithNames_(
+                    [NSAppearanceNameAqua, NSAppearanceNameDarkAqua]
+                )
+                if name == NSAppearanceNameDarkAqua:
+                    return NSColor.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 1.0)
+                return NSColor.colorWithSRGBRed_green_blue_alpha_(0.1, 0.1, 0.1, 1.0)
+
+            cls._TEXT_COLOR = NSColor.colorWithName_dynamicProvider_(
+                "WenZiLiveText", _provider
             )
-            if name and "Dark" in str(name):
-                return NSColor.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 1.0)
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.1, 0.1, 0.1, 1.0)
-
-        return NSColor.colorWithName_dynamicProvider_(None, _provider)
+        return cls._TEXT_COLOR
 
     def show(self, active: bool = True) -> None:
         """Create and show the overlay panel. Must be called on the main thread.
@@ -162,8 +162,6 @@ class LiveTranscriptionOverlay:
 
             panel.orderFront_(None)
             self._panel = panel
-            self._last_dark = _is_dark_mode()
-
             # Refresh timer for dynamic background (same as recording indicator)
             from Foundation import NSTimer
             self._appearance_timer = (
@@ -202,21 +200,11 @@ class LiveTranscriptionOverlay:
         except Exception as e:
             logger.warning("Failed to hide live transcription overlay: %s", e)
 
-    def _refresh_colors_if_changed(self) -> None:
-        """Check if appearance changed and update text color."""
-        dark = _is_dark_mode()
-        if dark == self._last_dark:
-            return
-        self._last_dark = dark
-        if self._text_field is not None:
-            self._text_field.setTextColor_(self._dynamic_text_color())
-
     def update_text(self, text: str) -> None:
         """Update the displayed partial transcription text. Must be called on the main thread."""
         if self._text_field is None or self._panel is None:
             return
 
-        self._refresh_colors_if_changed()
         self._text_field.setStringValue_(text)
         self._resize_panel()
 

--- a/src/wenzi/ui/settings_window.py
+++ b/src/wenzi/ui/settings_window.py
@@ -1324,7 +1324,7 @@ class SettingsPanel:
         )
 
         y -= (self._CONTROL_HEIGHT + self._ROW_GAP)
-        self._make_switch(
+        self._launcher_usage_learning_check = self._make_switch(
             "Usage Learning", pad + 12, y, content_w - 24,
             launcher_state.get("usage_learning", True), small_font,
             b"launcherUsageLearningToggled:", doc_view,
@@ -1380,6 +1380,7 @@ class SettingsPanel:
             self._launcher_enabled_check,
             self._launcher_hotkey_btn,
             self._launcher_switch_english_check,
+            self._launcher_usage_learning_check,
             refresh_btn,
         ]
         for check in self._launcher_source_checks.values():

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -48,6 +48,19 @@ class TestSourceRegistration:
         panel = _make_panel()
         panel.unregister_source("nope")  # Should not raise
 
+    def test_reset_clears_sources_and_trackers(self):
+        panel = _make_panel()
+        panel.register_source(_make_source("apps"))
+        panel.register_source(_make_source("files"))
+        panel._usage_tracker = MagicMock()
+        panel._query_history = MagicMock()
+
+        panel.reset()
+
+        assert len(panel._sources) == 0
+        assert panel._usage_tracker is None
+        assert panel._query_history is None
+
 
 class TestSearchLogic:
     def test_empty_query_returns_no_results(self):

--- a/tests/scripting/test_snippet_expander.py
+++ b/tests/scripting/test_snippet_expander.py
@@ -281,6 +281,75 @@ class TestRandomExpansion:
         assert args[1] == "user@example.com"
 
 
+class TestGetUnicodeString:
+    """Test _get_unicode_string buffer safety."""
+
+    def test_length_exceeding_buffer_is_clamped(self):
+        """Ensure out-of-bounds read is prevented when length > buf_size."""
+        from wenzi.scripting.snippet_expander import _get_unicode_string
+
+        mock_event = MagicMock()
+        mock_objc = MagicMock()
+        mock_objc.pyobjc_id.return_value = 0
+        with (
+            patch("wenzi.scripting.snippet_expander._carbon") as mock_carbon,
+            patch.dict("sys.modules", {"objc": mock_objc}),
+        ):
+            def fake_get(event_ptr, max_len, length_ptr, buf):
+                # Simulate the API reporting a length larger than buffer
+                length_ptr._obj.value = 32  # larger than buf_size (16)
+                for i in range(16):
+                    buf[i] = ord("A") + (i % 26)
+
+            mock_carbon.CGEventKeyboardGetUnicodeString.side_effect = fake_get
+            result = _get_unicode_string(mock_event)
+
+        # Should return at most 16 chars (buf_size), not 32
+        assert len(result) <= 16
+
+    def test_empty_event_returns_empty_string(self):
+        from wenzi.scripting.snippet_expander import _get_unicode_string
+
+        mock_event = MagicMock()
+        mock_objc = MagicMock()
+        mock_objc.pyobjc_id.return_value = 0
+        with (
+            patch("wenzi.scripting.snippet_expander._carbon") as mock_carbon,
+            patch.dict("sys.modules", {"objc": mock_objc}),
+        ):
+            def fake_get(event_ptr, max_len, length_ptr, buf):
+                length_ptr._obj.value = 0
+
+            mock_carbon.CGEventKeyboardGetUnicodeString.side_effect = fake_get
+            result = _get_unicode_string(mock_event)
+
+        assert result == ""
+
+
+class TestExpandNotification:
+    """Test that expansion failure sends a notification."""
+
+    def test_notification_sent_on_paste_failure(self):
+        store = _make_store()
+        expander = SnippetExpander(store)
+
+        with (
+            patch.object(expander, "_send_backspaces"),
+            patch(
+                "wenzi.scripting.sources.snippet_source._expand_placeholders",
+                return_value="content",
+            ),
+            patch("wenzi.input._set_pasteboard_concealed"),
+            patch("subprocess.run", side_effect=Exception("osascript failed")),
+            patch("wenzi.statusbar.send_notification") as mock_notify,
+        ):
+            expander._expand(";;test", "content")
+
+        mock_notify.assert_called_once()
+        assert "Failed" in mock_notify.call_args[0][0]
+        assert expander._expanding is False
+
+
 class TestEngineIntegration:
     """Test that the engine wires up the expander correctly."""
 

--- a/tests/ui/test_live_transcription_overlay.py
+++ b/tests/ui/test_live_transcription_overlay.py
@@ -18,10 +18,7 @@ def _mock_overlay_internals():
     mock_view = MagicMock()
     mock_cls = MagicMock()
     mock_cls.alloc.return_value.initWithFrame_.return_value = mock_view
-    with (
-        patch("wenzi.ui.live_transcription_overlay._is_dark_mode", return_value=False),
-        patch("wenzi.ui.live_transcription_overlay._LiveBgView", mock_cls),
-    ):
+    with patch("wenzi.ui.live_transcription_overlay._LiveBgView", mock_cls):
         yield
 
 


### PR DESCRIPTION
## Summary

- **#63** Fix NSAnimationContext order in `recording_indicator.py` — `currentContext()` must be called after `beginGrouping()`
- **#58 + #60** Cache dynamic colors at module/class level in `live_transcription_overlay.py`; replace fragile `"Dark" in str(name)` with `NSAppearanceNameDarkAqua` constant; remove dead `_is_dark_mode` / `_refresh_colors_if_changed` polling
- **#64** Store Usage Learning switch reference and add to `all_launcher_controls` list in `settings_window.py`
- **#62** Unbind `new_snippet_hotkey` and clear `_snippet_source` when disabling snippets in `engine.py`
- **#67** Add `ChooserPanel.reset()` public method to encapsulate source/tracker cleanup, replacing direct private attribute access in `disable_chooser()`
- **#59** Enlarge UTF-16 buffer from 4 to 16 code units and add `min()` guard against out-of-bounds reads in `_get_unicode_string()`
- **#61** Send user notification when snippet expansion fails (osascript timeout/error)

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3003 passed
- [x] New tests: `TestGetUnicodeString` (buffer clamping, empty event), `TestExpandNotification` (failure notification), `test_reset_clears_sources_and_trackers`

Closes #58, Closes #59, Closes #60, Closes #61, Closes #62, Closes #63, Closes #64, Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)