### PR TITLE
fix: resolve cancel/restart race conditions that orphan recordings

### DIFF
--- a/src/wenzi/controllers/recording_controller.py
+++ b/src/wenzi/controllers/recording_controller.py
@@ -179,9 +179,11 @@ class RecordingController:
         def _delayed_start():
             import time
             time.sleep(0.35)
-            if not app._busy and not self._cancel_delayed.is_set():
-                self._start_recording_and_update_indicator()
-            app._recording_started.set()
+            try:
+                if not app._busy and not self._cancel_delayed.is_set():
+                    self._start_recording_and_update_indicator()
+            finally:
+                app._recording_started.set()
 
         if app._sound_manager.enabled:
             # Show indicator immediately in grayscale while sound plays
@@ -349,12 +351,15 @@ class RecordingController:
 
     def on_restart_recording(self) -> None:
         """Called when restart key (space) is pressed during recording."""
-        self._cancel_recording_watchdog()
         with self._release_lock:
             self._release_done = False
         app = self._app
         if not app._recorder.is_recording:
             return
+        # Only cancel the watchdog after confirming recording is active,
+        # so a restart during the sound-feedback delay doesn't orphan the
+        # watchdog while recorder.start() is still in progress.
+        self._cancel_recording_watchdog()
         logger.info("Restart key pressed, restarting recording")
 
         # Stop streaming if active
@@ -386,9 +391,11 @@ class RecordingController:
         def _delayed_start():
             import time
             time.sleep(0.35)
-            if not app._busy and not self._cancel_delayed.is_set():
-                self._start_recording_and_update_indicator()
-            app._recording_started.set()
+            try:
+                if not app._busy and not self._cancel_delayed.is_set():
+                    self._start_recording_and_update_indicator()
+            finally:
+                app._recording_started.set()
 
         if app._sound_manager.enabled:
             initial_dev = app._recorder.last_device_name if app._recording_indicator.show_device_name else None
@@ -410,20 +417,35 @@ class RecordingController:
         # Show last preview history record
         self._app._preview_controller.on_show_last_preview()
 
+    def _reset_to_idle(self) -> None:
+        """Common cleanup: hide overlays/indicator and restore idle status."""
+        self._hide_live_overlay()
+        self.stop_recording_indicator()
+        self._app._set_status("WZ")
+        self._restore_mode()
+
     def on_cancel_recording(self) -> None:
         """Called when cancel key (cmd) is pressed during recording — discard and stop."""
-        self._cancel_recording_watchdog()
+        self._cancel_delayed.set()
         app = self._app
+
+        # Wait for _delayed_start to finish so is_recording reflects the
+        # true final state — prevents a race where cancel sees
+        # is_recording=False while recorder.start() is still blocking,
+        # cancels the watchdog, and leaves the recording orphaned.
+        if not app._recording_started.wait(timeout=1.0):  # 1s > 350ms delay + start()
+            self._cancel_recording_watchdog()
+            self._reset_to_idle()
+            return
+
+        # A new recording cycle clears _cancel_delayed; if so, this
+        # cancel is stale — abandon it so we don't kill the new recording.
+        if not self._cancel_delayed.is_set():
+            return
+
+        self._cancel_recording_watchdog()
         if not app._recorder.is_recording:
-            # Recording hasn't started yet (e.g. still in sound feedback
-            # delay).  Signal _delayed_start to skip recorder.start(),
-            # then clean up indicator and overlays.
-            self._cancel_delayed.set()
-            self._hide_live_overlay()
-            self.stop_recording_indicator()
-            app._recording_started.set()
-            app._set_status("WZ")
-            self._restore_mode()
+            self._reset_to_idle()
             return
         logger.info("Cancel key pressed, cancelling recording")
 

--- a/tests/controllers/test_recording_controller.py
+++ b/tests/controllers/test_recording_controller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -825,6 +826,124 @@ class TestRecordingWatchdog:
         ctrl.on_hotkey_press()
         assert ctrl._recording_watchdog is not None
         assert ctrl._recording_watchdog.interval == 120
+        ctrl._cancel_recording_watchdog()
+
+
+class TestCancelRaceCondition:
+    """Tests for the cancel / delayed-start race condition fix."""
+
+    @patch("PyObjCTools.AppHelper")
+    def test_cancel_waits_for_recording_started(self, mock_apphelper, ctrl, mock_app):
+        """Cancel should wait for recording_started before checking is_recording."""
+        mock_apphelper.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+        # recording_started not yet set — simulates being inside _delayed_start
+        mock_app._recording_started = threading.Event()
+        mock_app._recorder.is_recording = False
+
+        # Set recording_started from another thread after a short delay
+        def _set_later():
+            time.sleep(0.05)
+            mock_app._recording_started.set()
+
+        threading.Thread(target=_set_later, daemon=True).start()
+        ctrl.on_cancel_recording()
+
+        # Cancel should have waited and then taken the clean-exit path
+        mock_app._set_status.assert_called_with("WZ")
+
+    @patch("PyObjCTools.AppHelper")
+    def test_cancel_stops_recording_after_race(self, mock_apphelper, ctrl, mock_app):
+        """If recorder starts during cancel wait, cancel should take full path."""
+        mock_apphelper.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+        mock_app._recording_started = threading.Event()
+        # Recorder is NOT recording initially; it becomes recording when set
+        mock_app._recorder.is_recording = False
+
+        def _start_and_signal():
+            time.sleep(0.05)
+            mock_app._recorder.is_recording = True
+            mock_app._recording_started.set()
+
+        threading.Thread(target=_start_and_signal, daemon=True).start()
+        ctrl.on_cancel_recording()
+
+        # Cancel should detect is_recording=True and stop the recorder
+        mock_app._recorder.stop.assert_called_once()
+
+    @patch("PyObjCTools.AppHelper")
+    def test_cancel_aborts_if_new_cycle_starts(self, mock_apphelper, ctrl, mock_app):
+        """Cancel should abort if a new recording cycle clears _cancel_delayed."""
+        mock_apphelper.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+        mock_app._recording_started = threading.Event()
+        mock_app._recorder.is_recording = True
+
+        def _new_cycle():
+            time.sleep(0.05)
+            # Simulate on_hotkey_press clearing _cancel_delayed
+            ctrl._cancel_delayed.clear()
+            mock_app._recording_started.set()
+
+        threading.Thread(target=_new_cycle, daemon=True).start()
+        ctrl.on_cancel_recording()
+
+        # Cancel should detect stale _cancel_delayed and NOT stop the recorder
+        mock_app._recorder.stop.assert_not_called()
+
+    def test_cancel_timeout_cleans_up(self, ctrl, mock_app):
+        """Cancel should clean up on timeout if recording_started never fires."""
+        mock_app._recording_started = threading.Event()  # never set
+        mock_app._recorder.is_recording = False
+
+        # Use a very short timeout by patching wait
+        original_wait = mock_app._recording_started.wait
+        mock_app._recording_started.wait = lambda timeout=None: original_wait(0.01)
+
+        ctrl.on_cancel_recording()
+
+        mock_app._set_status.assert_called_with("WZ")
+
+
+class TestRestartWatchdogSafety:
+    """Restart during sound delay should not orphan the watchdog."""
+
+    def test_restart_not_recording_preserves_watchdog(self, ctrl, mock_app):
+        """Restart while is_recording=False should not cancel the watchdog."""
+        mock_app._sound_manager.enabled = False
+        ctrl.on_hotkey_press()
+        watchdog = ctrl._recording_watchdog
+        assert watchdog is not None
+
+        # Simulate restart arriving when is_recording happens to be False
+        mock_app._recorder.is_recording = False
+        ctrl.on_restart_recording()
+
+        # Watchdog must NOT have been cancelled
+        assert ctrl._recording_watchdog is watchdog
+
+
+class TestDelayedStartExceptionSafety:
+    """_delayed_start must set recording_started even if start raises."""
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("PyObjCTools.AppHelper")
+    def test_recording_started_set_on_start_exception(
+        self, mock_apphelper, ctrl, mock_app
+    ):
+        """recording_started is set via finally even when start raises."""
+        mock_apphelper.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+
+        mock_app._sound_manager.enabled = True
+        mock_app._recording_started.clear()
+        mock_app._recorder.start.side_effect = RuntimeError("device error")
+
+        ctrl.on_hotkey_press()
+        # Wait for _delayed_start to complete (350ms sleep + start attempt)
+        time.sleep(0.6)
+
+        # recording_started must be set despite the exception (via finally)
+        assert mock_app._recording_started.is_set()
         ctrl._cancel_recording_watchdog()
 
 


### PR DESCRIPTION
## Summary

- **on_cancel_recording**: wait for `recording_started` event before checking `is_recording`, preventing a race where cancel arrives while `recorder.start()` is blocking — the watchdog was cancelled but the recording was never stopped (ran 191s in the reported case)
- **on_restart_recording**: move `_cancel_recording_watchdog()` after the `is_recording` check so an early return during the sound-feedback delay doesn't orphan the watchdog
- **_delayed_start (both sites)**: wrap in `try/finally` so `recording_started` is always set even if `_start_recording_and_update_indicator()` raises
- Extract `_reset_to_idle()` helper to deduplicate cleanup sequences
- Add a stale-cancel guard (`_cancel_delayed.is_set()`) to prevent cross-cycle mis-cancellation

## Test plan

- [x] `TestCancelRaceCondition` — 4 tests covering: cancel waits for recording_started, cancel stops recording after race, cancel aborts if new cycle starts, cancel timeout cleanup
- [x] `TestRestartWatchdogSafety` — restart while not recording preserves the watchdog
- [x] `TestDelayedStartExceptionSafety` — recording_started is set via finally even when start raises
- [x] All 3009 existing tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)