### PR TITLE
fix(ui): add dark mode scrollbar styles for settings panel

### DIFF
--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -412,6 +412,10 @@ input[type="range"] {
   .provider-badge.local { background: rgba(52,199,89,0.2); color: #30d158; }
   .provider-badge.remote { background: rgba(100,149,237,0.2); color: #6ca0f6; }
   .config-path { color: #98989d; }
+  .content::-webkit-scrollbar { width: 8px; }
+  .content::-webkit-scrollbar-track { background: transparent; }
+  .content::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.2); border-radius: 4px; }
+  .content::-webkit-scrollbar-thumb:hover { background: rgba(255,255,255,0.35); }
 }
 </style>
 </head>


### PR DESCRIPTION
Add webkit scrollbar styling in dark mode media query so the scrollbar blends with the dark background instead of using the default light appearance.