### PR TITLE
fix(audio): prevent recorder hang after stream close timeout

### DIFF
--- a/src/wenzi/audio/recorder.py
+++ b/src/wenzi/audio/recorder.py
@@ -6,6 +6,7 @@ import io
 import logging
 import queue
 import threading
+import time
 from typing import Optional
 
 import numpy as np
@@ -25,8 +26,12 @@ class Recorder:
     # Reference RMS for normalizing current_level to 0.0-1.0 range.
     # Normal speech (~1000-3000 RMS) maps to roughly 0.5-1.0.
     _LEVEL_REFERENCE_RMS = 800.0
-    # Timeout for stream stop/close to prevent blocking on hung PortAudio.
-    _STREAM_CLOSE_TIMEOUT = 2.0
+    # Brief grace period for a pending background stream close to finish
+    # before forcing a PortAudio re-init in start().
+    _CLOSE_WAIT_TIMEOUT = 0.5
+    # Max seconds _starting may remain True before it is considered stuck
+    # and forcibly reset, allowing a new start() to proceed.
+    _STARTING_STALE_SECS = 10.0
 
     def __init__(
         self,
@@ -47,11 +52,17 @@ class Recorder:
         self._stream: Optional[sd.RawInputStream] = None
         self._lock = threading.Lock()
         self._recording = False
+        # Non-None while start() is in progress (value = monotonic timestamp).
+        self._starting_since: Optional[float] = None
         self._total_bytes = 0
         self._current_rms: float = 0.0
         self._on_audio_chunk: Optional[callable] = None
         self._last_device_name: Optional[str] = None  # track last used device name
         self._query_device_name_enabled: bool = True
+        # Signalled when the background stream-close thread finishes (or
+        # on init when there is no pending close).
+        self._close_done = threading.Event()
+        self._close_done.set()
 
     @property
     def is_recording(self) -> bool:
@@ -66,87 +77,121 @@ class Recorder:
     def current_level(self) -> float:
         """Return current audio level normalized to 0.0-1.0.
 
-        Uses 2000 as reference so normal speech (~1000-3000 RMS) maps
-        to roughly 0.5-1.0.
+        Uses ``_LEVEL_REFERENCE_RMS`` (800) as reference so normal
+        speech (~1000-3000 RMS) maps to roughly 0.5-1.0.
         """
         return min(1.0, self._current_rms / self._LEVEL_REFERENCE_RMS)
 
     def start(self) -> Optional[str]:
-        """Start recording. Returns the input device name, or None."""
+        """Start recording. Returns the input device name, or None.
+
+        Stream creation happens **outside** the lock so that a hung
+        PortAudio call cannot deadlock subsequent ``stop()`` /
+        ``is_recording`` calls.  ``_starting_since`` prevents
+        concurrent ``start()`` calls from racing.
+        """
+        # --- Phase 0: wait for any pending background stream-close ------
+        if not self._close_done.wait(timeout=self._CLOSE_WAIT_TIMEOUT):
+            logger.warning(
+                "Previous stream close still pending, forcing PortAudio re-init"
+            )
+            self._reinit_portaudio()
+            self._close_done.set()
+
+        # --- Phase 1: claim the "starting" slot (lock held briefly) -----
         with self._lock:
             if self._recording:
                 return self._last_device_name
-
+            if self._starting_since is not None:
+                elapsed = time.monotonic() - self._starting_since
+                if elapsed > self._STARTING_STALE_SECS:
+                    logger.warning(
+                        "Previous start() appears stuck (%.0fs), resetting",
+                        elapsed,
+                    )
+                    self._starting_since = None
+                else:
+                    return self._last_device_name
+            self._starting_since = time.monotonic()
             self._flush()
             self._total_bytes = 0
-
             device = self.device
-            current_name: Optional[str] = None
+            last_name = self._last_device_name
 
-            if self._query_device_name_enabled:
+        # --- Phase 2: device query & PortAudio re-init (lock free) ------
+        current_name: Optional[str] = None
+        if self._query_device_name_enabled:
+            current_name = self._query_device_name(device)
+
+            # Re-initialize PortAudio only when the device has changed
+            # (e.g. user plugged in a different mic) to avoid the cost
+            # of terminate/initialize on every recording.
+            if current_name != last_name:
+                self._reinit_portaudio()
                 current_name = self._query_device_name(device)
 
-                # Re-initialize PortAudio only when the device has changed
-                # (e.g. user plugged in a different mic) to avoid the cost
-                # of terminate/initialize on every recording.
-                if current_name != self._last_device_name:
-                    try:
-                        sd._terminate()
-                        sd._initialize()
-                    except Exception:
-                        logger.debug("PortAudio re-init failed, continuing", exc_info=True)
-                    current_name = self._query_device_name(device)
+            if current_name != last_name:
+                logger.info(
+                    "Input device changed: %s -> %s",
+                    last_name or "(none)",
+                    current_name or "unknown",
+                )
+            else:
+                logger.debug("Reusing input device: %s", current_name)
 
-                if current_name != self._last_device_name:
-                    logger.info(
-                        "Input device changed: %s -> %s",
-                        self._last_device_name or "(none)",
-                        current_name or "unknown",
-                    )
-                else:
-                    logger.debug("Reusing input device: %s", current_name)
-
+        # --- Phase 3: create & start stream (lock free) -----------------
+        base_kwargs = dict(
+            samplerate=self.sample_rate,
+            blocksize=self._block_size,
+            dtype="int16",
+            channels=1,
+            callback=self._callback,
+        )
+        try:
+            stream = sd.RawInputStream(**base_kwargs, device=device)
+            stream.start()
+        except Exception:
             try:
-                self._stream = sd.RawInputStream(
-                    samplerate=self.sample_rate,
-                    blocksize=self._block_size,
-                    dtype="int16",
-                    channels=1,
-                    callback=self._callback,
-                    device=device,
-                )
-                self._stream.start()
-            except Exception:
                 # Fallback to default input device
-                self._stream = sd.RawInputStream(
-                    samplerate=self.sample_rate,
-                    blocksize=self._block_size,
-                    dtype="int16",
-                    channels=1,
-                    callback=self._callback,
-                )
-                self._stream.start()
+                stream = sd.RawInputStream(**base_kwargs)
+                stream.start()
+            except Exception:
+                logger.error("Failed to create audio stream", exc_info=True)
+                with self._lock:
+                    self._starting_since = None
+                return None
 
+        # --- Phase 4: commit (lock held briefly) ------------------------
+        with self._lock:
+            self._stream = stream
             self._recording = True
+            self._starting_since = None
             self._last_device_name = current_name
             logger.info("Recording started (sr=%d)", self.sample_rate)
             return current_name
 
     def stop(self) -> Optional[bytes]:
-        """Stop recording and return WAV data as bytes, or None if nothing recorded."""
+        """Stop recording and return WAV data as bytes, or None if nothing recorded.
+
+        The callback guard (``if not self._recording``) provides a
+        deterministic cutoff — no new frames are enqueued after
+        ``_recording`` is set to ``False``.  Stream close is therefore
+        fire-and-forget; we never need to block the caller waiting for
+        PortAudio to finish.
+        """
         with self._lock:
             if not self._recording:
                 return None
 
             self._recording = False
+            self._current_rms = 0.0
             stream = self._stream
             self._stream = None
 
-        # Stop/close stream outside the lock with a timeout so a hung
-        # PortAudio callback cannot block the caller (e.g. the Quartz
-        # event-tap thread) forever.
+        # Fire-and-forget stream close.  The _close_done event lets a
+        # subsequent start() know whether cleanup has finished.
         if stream is not None:
-            done = threading.Event()
+            self._close_done.clear()
 
             def _close_stream() -> None:
                 try:
@@ -155,15 +200,9 @@ class Recorder:
                 except Exception as e:
                     logger.warning("Error closing audio stream: %s", e)
                 finally:
-                    done.set()
+                    self._close_done.set()
 
             threading.Thread(target=_close_stream, daemon=True).start()
-            if not done.wait(timeout=self._STREAM_CLOSE_TIMEOUT):
-                logger.error(
-                    "Audio stream stop/close timed out after %.1fs, "
-                    "continuing without waiting",
-                    self._STREAM_CLOSE_TIMEOUT,
-                )
 
         # Collect all buffered frames
         frames = []
@@ -180,7 +219,7 @@ class Recorder:
         audio = np.concatenate(frames)
         duration = len(audio) / self.sample_rate
         rms = int(np.sqrt(np.mean(audio.astype(np.float64) ** 2)))
-        logger.warning(
+        logger.info(
             "Recording stopped, captured %d samples (%.1fs), RMS=%d",
             len(audio), duration, rms,
         )
@@ -204,6 +243,12 @@ class Recorder:
         self._on_audio_chunk = None
 
     def _callback(self, in_data, frames, time_info, status):
+        # Guard: once _recording is False the callback becomes a no-op.
+        # This prevents an orphaned (not-yet-closed) stream from
+        # polluting the queue, RMS, or chunk callback.
+        if not self._recording:
+            return
+
         if status:
             logger.warning("Audio stream status: %s", status)
 
@@ -228,6 +273,15 @@ class Recorder:
                 cb(copied)
             except Exception:
                 logger.debug("Audio chunk callback error", exc_info=True)
+
+    @staticmethod
+    def _reinit_portaudio() -> None:
+        """Force-terminate and re-initialize PortAudio."""
+        try:
+            sd._terminate()
+            sd._initialize()
+        except Exception:
+            logger.debug("PortAudio re-init failed, continuing", exc_info=True)
 
     @staticmethod
     def _query_device_name(device: Optional[str]) -> Optional[str]:

--- a/src/wenzi/controllers/recording_controller.py
+++ b/src/wenzi/controllers/recording_controller.py
@@ -190,10 +190,11 @@ class RecordingController:
             finally:
                 app._recording_started.set()
 
-            # If hotkey was released while blocked (e.g. mic permission dialog),
-            # stop the orphaned recording/streaming now.
-            if self._release_done and app._recorder.is_recording:
-                logger.info("Hotkey released during delayed start, stopping orphaned recording")
+            # If hotkey was released or recording was cancelled while
+            # blocked (e.g. mic permission dialog or slow PortAudio
+            # init), stop the orphaned recording/streaming now.
+            if (self._release_done or self._cancel_delayed.is_set()) and app._recorder.is_recording:
+                logger.info("Recording orphaned during delayed start, stopping")
                 self._stop_streaming_if_active("orphan cleanup")
                 app._recorder.stop()
                 from PyObjCTools import AppHelper

--- a/tests/audio/test_recorder.py
+++ b/tests/audio/test_recorder.py
@@ -1,6 +1,7 @@
 """Tests for the recorder module."""
 
 import threading
+import time
 from unittest.mock import patch, MagicMock
 
 import numpy as np
@@ -167,11 +168,9 @@ class TestRecorder:
         r.stop()
 
     @patch("wenzi.audio.recorder.sd.RawInputStream")
-    def test_stop_returns_data_when_stream_close_hangs(self, mock_stream_cls, monkeypatch):
-        """stop() should return audio data even if stream.stop() hangs."""
-        monkeypatch.setattr(Recorder, "_STREAM_CLOSE_TIMEOUT", 0.01)
+    def test_stop_returns_data_when_stream_close_hangs(self, mock_stream_cls):
+        """stop() is non-blocking and returns audio data even if stream close hangs."""
         mock_stream = MagicMock()
-        # Make stream.stop() block forever (simulating a hung PortAudio callback)
         hang_event = threading.Event()
         mock_stream.stop.side_effect = lambda: hang_event.wait()
         mock_stream_cls.return_value = mock_stream
@@ -183,8 +182,142 @@ class TestRecorder:
         r._queue.put(frame)
 
         wav_data = r.stop()
-        # Should succeed despite the hung stream.stop()
+        # stop() returns immediately without waiting for stream close
         assert wav_data is not None
         assert r.is_recording is False
+        assert not r._close_done.is_set()  # close still pending
         # Unblock the background thread to avoid leaking it
         hang_event.set()
+        r._close_done.wait(timeout=1.0)
+        assert r._close_done.is_set()
+
+    def test_callback_guard_blocks_when_not_recording(self):
+        """_callback should be a no-op when _recording is False."""
+        r = Recorder(sample_rate=16000, block_ms=20)
+        # _recording is False by default
+        frame_data = np.full(320, 500, dtype=np.int16).tobytes()
+        r._callback(frame_data, 320, None, None)
+        # Nothing should be queued
+        assert r._queue.empty()
+        assert r._current_rms == 0.0
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_callback_guard_stops_after_stop(self, mock_stream_cls):
+        """After stop(), the callback should no longer enqueue frames."""
+        mock_stream = MagicMock()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r.start()
+
+        frame_data = np.full(320, 500, dtype=np.int16).tobytes()
+        r._callback(frame_data, 320, None, None)
+        assert r._queue.qsize() == 1
+
+        r.stop()
+
+        # Simulate orphaned stream still calling callback
+        r._callback(frame_data, 320, None, None)
+        # Queue was drained by stop(), and guard prevents new frames
+        assert r._queue.empty()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_start_waits_for_pending_close(self, mock_stream_cls, monkeypatch):
+        """start() should wait briefly for a pending close before proceeding."""
+        monkeypatch.setattr(Recorder, "_CLOSE_WAIT_TIMEOUT", 0.05)
+        mock_stream = MagicMock()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r.start()
+        r._queue.put(np.full(320, 500, dtype=np.int16))
+        r.stop()
+        assert r._close_done.wait(timeout=1.0)  # normal close finishes
+
+        # Second start should proceed without reinit
+        r.start()
+        assert r.is_recording is True
+        r.stop()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    @patch("wenzi.audio.recorder.sd._terminate")
+    @patch("wenzi.audio.recorder.sd._initialize")
+    def test_start_reinits_on_close_timeout(
+        self, mock_init, mock_term, mock_stream_cls, monkeypatch
+    ):
+        """start() should force PortAudio re-init when previous close is still pending."""
+        monkeypatch.setattr(Recorder, "_CLOSE_WAIT_TIMEOUT", 0.01)
+        mock_stream = MagicMock()
+        hang_event = threading.Event()
+        mock_stream.stop.side_effect = lambda: hang_event.wait()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._query_device_name_enabled = False
+        r.start()
+        r._queue.put(np.full(320, 500, dtype=np.int16))
+        r.stop()
+        # close is still pending (stream.stop() hangs)
+        assert not r._close_done.is_set()
+
+        # Second start should detect pending close and reinit
+        r.start()
+        assert r.is_recording is True
+        mock_term.assert_called()
+        mock_init.assert_called()
+        assert r._close_done.is_set()
+        # Cleanup
+        hang_event.set()
+        r.stop()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_starting_flag_prevents_concurrent_start(self, mock_stream_cls):
+        """A second start() should return immediately when _starting_since is set."""
+        mock_stream = MagicMock()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._starting_since = time.monotonic()
+        result = r.start()
+        # Should return without creating a stream
+        assert result is r._last_device_name
+        assert not r._recording
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_stale_starting_flag_is_reset(self, mock_stream_cls, monkeypatch):
+        """A stuck _starting_since should be reset after the staleness timeout."""
+        monkeypatch.setattr(Recorder, "_STARTING_STALE_SECS", 0.0)
+        mock_stream = MagicMock()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._query_device_name_enabled = False
+        r._starting_since = time.monotonic() - 1.0  # already stale
+        r.start()
+        # Should have reset _starting_since and proceeded
+        assert r.is_recording is True
+        r.stop()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_stop_is_nonblocking(self, mock_stream_cls):
+        """stop() should return without waiting for stream close."""
+        mock_stream = MagicMock()
+
+        # Make close take 10 seconds (we should NOT wait for it)
+        def slow_close():
+            time.sleep(10)
+        mock_stream.close.side_effect = slow_close
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r.start()
+        r._queue.put(np.full(320, 500, dtype=np.int16))
+
+        t0 = time.monotonic()
+        r.stop()
+        elapsed = time.monotonic() - t0
+        # stop() should return in well under 1 second
+        assert elapsed < 0.5
+        # Cleanup: unblock by setting _close_done (stream.close will
+        # eventually finish or be abandoned as daemon thread)
+        r._close_done.set()

--- a/tests/audio/test_recorder_streaming.py
+++ b/tests/audio/test_recorder_streaming.py
@@ -24,6 +24,7 @@ class TestAudioChunkCallback:
 
     def test_callback_receives_audio_chunks(self):
         r = Recorder(sample_rate=16000, block_ms=20)
+        r._recording = True  # callback guard requires recording state
         chunks = []
         r.set_on_audio_chunk(lambda data: chunks.append(data))
 
@@ -36,6 +37,7 @@ class TestAudioChunkCallback:
 
     def test_callback_not_called_when_unset(self):
         r = Recorder(sample_rate=16000, block_ms=20)
+        r._recording = True
 
         fake_audio = np.array([100, 200], dtype=np.int16)
         # Should not raise when no callback is set
@@ -43,6 +45,7 @@ class TestAudioChunkCallback:
 
     def test_callback_error_does_not_break_recording(self):
         r = Recorder(sample_rate=16000, block_ms=20)
+        r._recording = True
 
         def bad_cb(data):
             raise RuntimeError("callback error")
@@ -60,6 +63,7 @@ class TestAudioChunkCallback:
 
     def test_callback_receives_copy_not_original(self):
         r = Recorder(sample_rate=16000, block_ms=20)
+        r._recording = True
         received = []
         r.set_on_audio_chunk(lambda data: received.append(data))
 
@@ -72,6 +76,7 @@ class TestAudioChunkCallback:
 
     def test_callback_not_invoked_when_max_size_reached(self):
         r = Recorder(sample_rate=16000, block_ms=20, max_session_bytes=4)
+        r._recording = True
         cb = MagicMock()
         r.set_on_audio_chunk(cb)
 


### PR DESCRIPTION
## Summary

- Fix recorder becoming permanently stuck after PortAudio stream close times out — subsequent recordings would hang with a grey indicator that couldn't be interrupted
- Make `stop()` fully non-blocking (fire-and-forget stream close) so it no longer blocks the CGEventTap thread for up to 2s
- Restructure `start()` to create streams outside the lock, preventing deadlocks when PortAudio hangs
- Add callback guard (`if not self._recording: return`) so orphaned streams don't pollute queue/RMS/chunk callbacks
- Force PortAudio re-init on next `start()` when previous close is still pending
- Expand orphan detection in `_delayed_start` to also cover cancel-during-start scenarios

## Root cause

When `stream.stop()/close()` timed out after 2s, the orphaned PortAudio stream kept running — its callback continued filling the queue and updating RMS. On next `start()`, `sd.RawInputStream()` would hang because PortAudio was in a dirty state, and since the lock was held during stream creation, all subsequent `start()`/`stop()`/`is_recording` calls deadlocked.

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3460 passed
- [x] New tests cover: callback guard, non-blocking stop, start after close timeout (reinit path), `_starting_since` concurrency guard, staleness self-heal, stop timing assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)