### PR TITLE
feat(chooser): add debounce support for async sources

### DIFF
--- a/src/wenzi/scripting/api/chooser.py
+++ b/src/wenzi/scripting/api/chooser.py
@@ -119,12 +119,14 @@ class ChooserAPI:
                     m2, _ = fuzzy_match(args.strip(), src.prefix)
                     if not m1 and not m2:
                         continue
-                items.append({
-                    "title": desc,
-                    "subtitle": f"{src.prefix} <query>",
-                    "item_id": f"help:{src.name}",
-                    "action": lambda p=src.prefix: self.show_source(p),
-                })
+                items.append(
+                    {
+                        "title": desc,
+                        "subtitle": f"{src.prefix} <query>",
+                        "item_id": f"help:{src.name}",
+                        "action": lambda p=src.prefix: self.show_source(p),
+                    }
+                )
             if items:
                 self.pick(
                     items,
@@ -132,13 +134,15 @@ class ChooserAPI:
                     placeholder="Available prefixes...",
                 )
 
-        self._command_source.register(CommandEntry(
-            name="help",
-            title="Help",
-            subtitle="Show available prefixes",
-            action=_help_action,
-            promoted=True,
-        ))
+        self._command_source.register(
+            CommandEntry(
+                name="help",
+                title="Help",
+                subtitle="Show available prefixes",
+                action=_help_action,
+                promoted=True,
+            )
+        )
 
     def _register_quit_all_command(self) -> None:
         """Register the built-in quit-all command."""
@@ -158,13 +162,15 @@ class ChooserAPI:
                     continue
                 app.terminate()
 
-        self._command_source.register(CommandEntry(
-            name="quit-all",
-            title="Quit All Applications",
-            subtitle="Quit all running applications",
-            action=_quit_all_action,
-            promoted=True,
-        ))
+        self._command_source.register(
+            CommandEntry(
+                name="quit-all",
+                title="Quit All Applications",
+                subtitle="Quit all running applications",
+                action=_quit_all_action,
+                promoted=True,
+            )
+        )
 
     def _register_reload_command(self) -> None:
         """Register the built-in reload command."""
@@ -176,13 +182,15 @@ class ChooserAPI:
             if _wz is not None:
                 _wz.reload()
 
-        self._command_source.register(CommandEntry(
-            name="reload",
-            title="Reload Scripts",
-            subtitle="Reload all scripts and plugins",
-            action=_reload_action,
-            promoted=True,
-        ))
+        self._command_source.register(
+            CommandEntry(
+                name="reload",
+                title="Reload Scripts",
+                subtitle="Reload all scripts and plugins",
+                action=_reload_action,
+                promoted=True,
+            )
+        )
 
     def register_source(self, source: ChooserSource) -> None:
         """Register a data source."""
@@ -202,7 +210,8 @@ class ChooserAPI:
             from PyObjCTools import AppHelper
 
             AppHelper.callAfter(
-                self._panel.show, initial_query=initial_query,
+                self._panel.show,
+                initial_query=initial_query,
             )
         except Exception:
             logger.exception("Failed to show chooser")
@@ -457,7 +466,8 @@ class ChooserAPI:
         action_hints: Optional[dict] = None,
         description: str = "",
         show_preview: bool = False,
-        search_timeout: float = 5.0,
+        search_timeout: Optional[float] = None,
+        debounce_delay: Optional[float] = None,
     ) -> Callable:
         """Decorator to register a search function as a chooser source.
 
@@ -482,20 +492,33 @@ class ChooserAPI:
                     data = await resp.json()
                 return [{"title": r["name"]} for r in data]
 
+        Debounced async sources (wait for user to stop typing)::
+
+            @wz.chooser.source("api", prefix="api", debounce_delay=0.3)
+            async def search_api(query):
+                ...
+
         Args:
             search_timeout: Per-source timeout in seconds for async sources.
+                None uses the global default (5.0s).
+            debounce_delay: Debounce delay in seconds for async sources.
+                None uses the global default (0.15s), 0 disables debouncing.
         """
 
         def decorator(func: Callable[[str], List[dict]]) -> Callable:
             _is_async = asyncio.iscoroutinefunction(func)
 
             if _is_async:
+
                 async def _async_search(query: str) -> List[ChooserItem]:
                     return _convert_items(await func(query))
+
                 search_fn = _async_search
             else:
+
                 def _search(query: str) -> List[ChooserItem]:
                     return _convert_items(func(query))
+
                 search_fn = _search
 
             src = ChooserSource(
@@ -508,11 +531,13 @@ class ChooserAPI:
                 show_preview=show_preview,
                 is_async=_is_async,
                 search_timeout=search_timeout,
+                debounce_delay=debounce_delay,
             )
             self._panel.register_source(src)
             logger.info(
                 "User script registered chooser source: %s (async=%s)",
-                name, _is_async,
+                name,
+                _is_async,
             )
             return func
 

--- a/src/wenzi/scripting/sources/__init__.py
+++ b/src/wenzi/scripting/sources/__init__.py
@@ -26,10 +26,12 @@ def paste_text(text: str) -> None:
         time.sleep(0.05)
         subprocess.run(
             [
-                "osascript", "-e",
+                "osascript",
+                "-e",
                 'tell application "System Events" to keystroke "v" using command down',
             ],
-            capture_output=True, timeout=5,
+            capture_output=True,
+            timeout=5,
         )
     except Exception:
         _logger.exception("Failed to paste text")
@@ -67,7 +69,8 @@ class ChooserItem:
     secondary_action: Optional[Callable] = field(default=None, repr=False)  # Cmd+Enter
     reveal_path: Optional[str] = None  # For Cmd+Enter (reveal in Finder)
     modifiers: Optional[Dict[str, ModifierAction]] = field(
-        default=None, repr=False,
+        default=None,
+        repr=False,
     )  # key: "cmd", "alt", "ctrl", "shift"
     delete_action: Optional[Callable] = field(default=None, repr=False)
     confirm_delete: bool = False  # Two-step delete confirmation
@@ -95,13 +98,16 @@ class ChooserSource:
     description: str = ""  # Human-readable description shown in help
     show_preview: bool = False  # Show the preview panel when this source is active
     complete: Optional[Callable[[str, "ChooserItem"], Optional[str]]] = field(
-        default=None, repr=False,
+        default=None,
+        repr=False,
     )  # Tab completion: (query, selected_item) -> completed query (without prefix) or None
     create_action: Optional[Callable[[str], None]] = field(
-        default=None, repr=False,
+        default=None,
+        repr=False,
     )  # Optional "create new" action; receives stripped query
     is_async: bool = False
-    search_timeout: float = 5.0  # Async sources only; sync sources ignore this
+    search_timeout: Optional[float] = None  # Async sources only; None = use global default
+    debounce_delay: Optional[float] = None  # Async sources only; None = use global default, 0 = no debounce
 
 
 # ---------------------------------------------------------------------------

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 import os
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, NamedTuple, Optional
 
 from wenzi.i18n import t
 from wenzi.scripting.sources import ChooserItem, ChooserSource
@@ -142,6 +142,40 @@ def _get_panel_delegate_class():
 
 
 # ---------------------------------------------------------------------------
+# Debounce timer helper (lazy-created)
+# ---------------------------------------------------------------------------
+_DebounceTimerHelper = None
+
+
+def _get_debounce_timer_helper_class():
+    """Return an NSObject subclass for NSTimer callbacks."""
+    global _DebounceTimerHelper
+    if _DebounceTimerHelper is not None:
+        return _DebounceTimerHelper
+
+    from Foundation import NSObject
+
+    class ChooserDebounceTimerHelper(NSObject):
+        _callback = None
+
+        def fire_(self, _timer):
+            if self._callback is not None:
+                self._callback()
+
+    _DebounceTimerHelper = ChooserDebounceTimerHelper
+    return _DebounceTimerHelper
+
+
+class _DebounceEntry(NamedTuple):
+    """Per-source debounce state: timer, helper ref, and search args."""
+    timer: object  # NSTimer
+    helper: object  # NSObject helper (prevents GC)
+    source: ChooserSource
+    query: str
+    generation: int
+
+
+# ---------------------------------------------------------------------------
 # Panel
 # ---------------------------------------------------------------------------
 
@@ -157,6 +191,8 @@ class ChooserPanel:
     _INITIAL_HEIGHT = 80  # bootstrap; JS updates after page load
     _MAX_TOTAL_RESULTS = 50
     _DEFERRED_ACTION_DELAY = 0.15  # seconds to let previous app regain focus
+    _DEFAULT_ASYNC_DEBOUNCE = 0.15  # seconds
+    _DEFAULT_ASYNC_TIMEOUT = 5.0  # seconds
 
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
@@ -195,6 +231,7 @@ class ChooserPanel:
         self._search_generation: int = 0
         self._pending_async_count: int = 0
         self._loading_visible: bool = False
+        self._debounce_state: Dict[str, _DebounceEntry] = {}  # source_name -> pending debounce
 
     # ------------------------------------------------------------------
     # Panel resize (driven by JS)
@@ -470,6 +507,9 @@ class ChooserPanel:
             return
         self._closing = True
 
+        # Cancel all pending debounce timers
+        self._cancel_all_debounce_timers()
+
         if self._snippet_expander is not None:
             self._snippet_expander.resume()
         self._calc_sticky = False
@@ -643,12 +683,31 @@ class ChooserPanel:
         # Push sync results immediately
         self._push_items_to_js(source=source)
 
-        # Phase 2: Launch async sources
-        self._pending_async_count = len(async_sources)
+        # Phase 2: Launch async sources (with debounce support)
+        self._cancel_all_debounce_timers()
         if async_sources:
-            self._set_loading(True)
+            immediate = []
+            debounced = []
             for asrc in async_sources:
-                self._launch_async_search(asrc, query, generation)
+                delay = self._get_debounce_delay(asrc)
+                if delay > 0:
+                    debounced.append((asrc, delay))
+                else:
+                    immediate.append(asrc)
+
+            # Launch immediate sources right away
+            self._pending_async_count = len(immediate)
+            if immediate:
+                self._set_loading(True)
+                for asrc in immediate:
+                    self._launch_async_search(asrc, query, generation)
+
+            # Schedule debounced sources (each with its own timer)
+            if debounced:
+                self._pending_async_count += len(debounced)
+                self._set_loading(True)
+                for asrc, delay in debounced:
+                    self._schedule_debounced_search(asrc, query, generation, delay)
         else:
             self._set_loading(False)
 
@@ -752,6 +811,18 @@ class ChooserPanel:
         self._loading_visible = visible
         self._eval_js(f"setLoading({'true' if visible else 'false'})")
 
+    def _get_timeout(self, source: ChooserSource) -> float:
+        """Get the actual timeout for an async source."""
+        if source.search_timeout is not None:
+            return source.search_timeout
+        return self._DEFAULT_ASYNC_TIMEOUT
+
+    def _get_debounce_delay(self, source: ChooserSource) -> float:
+        """Get the actual debounce delay for an async source."""
+        if source.debounce_delay is not None:
+            return source.debounce_delay
+        return self._DEFAULT_ASYNC_DEBOUNCE
+
     def _launch_async_search(
         self,
         source: ChooserSource,
@@ -761,17 +832,19 @@ class ChooserPanel:
         """Submit an async source search to the shared event loop."""
         import wenzi.async_loop as _aloop
 
+        timeout = self._get_timeout(source)
+
         async def _run():
             try:
                 return await asyncio.wait_for(
                     source.search(query),
-                    timeout=source.search_timeout,
+                    timeout=timeout,
                 )
             except asyncio.TimeoutError:
                 logger.warning(
                     "Async source %s timed out after %.1fs",
                     source.name,
-                    source.search_timeout,
+                    timeout,
                 )
                 return []
             except asyncio.CancelledError:
@@ -836,6 +909,67 @@ class ChooserPanel:
                     source=self._active_source,
                     preserve_selection=True,
                 )
+
+    # ------------------------------------------------------------------
+    # Debounced async search
+    # ------------------------------------------------------------------
+
+    def _cancel_all_debounce_timers(self) -> None:
+        """Invalidate and remove all pending debounce timers."""
+        for entry in self._debounce_state.values():
+            entry.timer.invalidate()
+        self._debounce_state.clear()
+
+    def _schedule_debounced_search(
+        self,
+        source: ChooserSource,
+        query: str,
+        generation: int,
+        delay: float,
+    ) -> None:
+        """Schedule a debounced async search for a single source using NSTimer."""
+        name = source.name
+
+        # Cancel previous timer for this source
+        old = self._debounce_state.pop(name, None)
+        if old is not None:
+            old.timer.invalidate()
+
+        # Create helper (NSObject target for NSTimer)
+        HelperClass = _get_debounce_timer_helper_class()
+        helper = HelperClass.alloc().init()
+        helper._callback = lambda n=name: self._execute_debounced_search(n)
+
+        from Foundation import NSTimer
+
+        timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+            delay,
+            helper,
+            b"fire:",
+            None,
+            False,
+        )
+
+        self._debounce_state[name] = _DebounceEntry(
+            timer=timer,
+            helper=helper,
+            source=source,
+            query=query,
+            generation=generation,
+        )
+
+    def _execute_debounced_search(self, source_name: str) -> None:
+        """Execute debounced search for a single source (called by NSTimer)."""
+        entry = self._debounce_state.pop(source_name, None)
+        if entry is None:
+            return
+
+        # Discard if stale. The count was already reset by the new _do_search
+        # call that incremented the generation.
+        if entry.generation != self._search_generation:
+            return
+
+        self._launch_async_search(entry.source, entry.query, entry.generation)
 
     # ------------------------------------------------------------------
     # JS message handler

--- a/tests/scripting/conftest.py
+++ b/tests/scripting/conftest.py
@@ -1,0 +1,18 @@
+"""Shared fixtures for scripting tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wenzi.scripting.api.chooser import ChooserAPI
+
+
+@pytest.fixture
+def chooser_panel():
+    """Return a ChooserPanel with mocked JS evaluation."""
+    api = ChooserAPI()
+    panel = api.panel
+    panel._eval_js = MagicMock()
+    return panel

--- a/tests/scripting/test_async_debounce.py
+++ b/tests/scripting/test_async_debounce.py
@@ -1,0 +1,336 @@
+"""Tests for async source debounce functionality."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from wenzi.scripting.sources import ChooserItem, ChooserSource
+from wenzi.scripting.api.chooser import ChooserAPI
+
+
+# ---------------------------------------------------------------------------
+# ChooserSource debounce field
+# ---------------------------------------------------------------------------
+
+
+class TestChooserSourceDebounceField:
+    def test_defaults(self):
+        src = ChooserSource(name="test")
+        assert src.debounce_delay is None
+
+    def test_custom_debounce_delay(self):
+        src = ChooserSource(name="test", debounce_delay=0.3)
+        assert src.debounce_delay == 0.3
+
+    def test_zero_debounce_delay(self):
+        src = ChooserSource(name="test", debounce_delay=0)
+        assert src.debounce_delay == 0
+
+
+# ---------------------------------------------------------------------------
+# ChooserPanel._get_debounce_delay
+# ---------------------------------------------------------------------------
+
+
+class TestGetDebounceDelay:
+    def test_none_uses_global_default(self, chooser_panel):
+        src = ChooserSource(name="test", is_async=True, debounce_delay=None)
+        assert chooser_panel._get_debounce_delay(src) == chooser_panel._DEFAULT_ASYNC_DEBOUNCE
+
+    def test_custom_value(self, chooser_panel):
+        src = ChooserSource(name="test", is_async=True, debounce_delay=0.5)
+        assert chooser_panel._get_debounce_delay(src) == 0.5
+
+    def test_zero_value(self, chooser_panel):
+        src = ChooserSource(name="test", is_async=True, debounce_delay=0)
+        assert chooser_panel._get_debounce_delay(src) == 0
+
+
+# ---------------------------------------------------------------------------
+# ChooserPanel._get_timeout
+# ---------------------------------------------------------------------------
+
+
+class TestGetTimeout:
+    def test_none_uses_global_default(self, chooser_panel):
+        src = ChooserSource(name="test", is_async=True, search_timeout=None)
+        assert chooser_panel._get_timeout(src) == chooser_panel._DEFAULT_ASYNC_TIMEOUT
+
+    def test_custom_value(self, chooser_panel):
+        src = ChooserSource(name="test", is_async=True, search_timeout=3.0)
+        assert chooser_panel._get_timeout(src) == 3.0
+
+
+# ---------------------------------------------------------------------------
+# @source decorator debounce parameter
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDecoratorDebounce:
+    def test_debounce_delay_passed_to_source(self):
+        api = ChooserAPI()
+
+        @api.source("debounced", debounce_delay=0.25)
+        async def search(query):
+            return []
+
+        src = api.panel._sources["debounced"]
+        assert src.debounce_delay == 0.25
+
+    def test_debounce_delay_default_is_none(self):
+        api = ChooserAPI()
+
+        @api.source("no-debounce")
+        async def search(query):
+            return []
+
+        src = api.panel._sources["no-debounce"]
+        assert src.debounce_delay is None
+
+    def test_search_timeout_default_is_none(self):
+        api = ChooserAPI()
+
+        @api.source("no-timeout")
+        async def search(query):
+            return []
+
+        src = api.panel._sources["no-timeout"]
+        assert src.search_timeout is None
+
+
+# ---------------------------------------------------------------------------
+# Debounce scheduling
+# ---------------------------------------------------------------------------
+
+
+class TestDebounceScheduling:
+    def test_schedule_sets_timer(self, chooser_panel):
+        chooser_panel._search_generation = 1
+
+        src = ChooserSource(name="test", is_async=True)
+        chooser_panel._schedule_debounced_search(src, "hello", 1, 0.1)
+
+        entry = chooser_panel._debounce_state.get("test")
+        assert entry is not None
+        assert entry.source is src
+        assert entry.query == "hello"
+        assert entry.generation == 1
+
+        # Cleanup
+        chooser_panel._cancel_all_debounce_timers()
+
+    def test_schedule_cancels_previous_timer_for_same_source(self, chooser_panel):
+        chooser_panel._search_generation = 1
+
+        src = ChooserSource(name="test", is_async=True)
+
+        # Schedule first
+        chooser_panel._schedule_debounced_search(src, "hello", 1, 0.5)
+        old_timer = chooser_panel._debounce_state["test"].timer
+
+        # Schedule second for same source (should cancel first)
+        chooser_panel._schedule_debounced_search(src, "world", 2, 0.5)
+
+        assert chooser_panel._debounce_state["test"].timer is not old_timer
+        assert chooser_panel._debounce_state["test"].query == "world"
+        assert chooser_panel._debounce_state["test"].generation == 2
+
+        # Cleanup
+        chooser_panel._cancel_all_debounce_timers()
+
+    def test_independent_timers_per_source(self, chooser_panel):
+        chooser_panel._search_generation = 1
+
+        src1 = ChooserSource(name="src1", is_async=True)
+        src2 = ChooserSource(name="src2", is_async=True)
+
+        chooser_panel._schedule_debounced_search(src1, "hello", 1, 0.1)
+        chooser_panel._schedule_debounced_search(src2, "hello", 1, 0.5)
+
+        assert "src1" in chooser_panel._debounce_state
+        assert "src2" in chooser_panel._debounce_state
+        assert chooser_panel._debounce_state["src1"].timer is not chooser_panel._debounce_state["src2"].timer
+
+        # Cleanup
+        chooser_panel._cancel_all_debounce_timers()
+
+    def test_close_cancels_all_timers(self, chooser_panel):
+        chooser_panel._search_generation = 1
+
+        src1 = ChooserSource(name="src1", is_async=True)
+        src2 = ChooserSource(name="src2", is_async=True)
+        chooser_panel._schedule_debounced_search(src1, "hello", 1, 1.0)
+        chooser_panel._schedule_debounced_search(src2, "hello", 1, 1.0)
+
+        assert len(chooser_panel._debounce_state) == 2
+
+        # Mock necessary cleanup
+        chooser_panel._webview = None
+        chooser_panel._panel = None
+
+        chooser_panel.close()
+
+        assert len(chooser_panel._debounce_state) == 0
+
+
+# ---------------------------------------------------------------------------
+# _do_search debounce behavior
+# ---------------------------------------------------------------------------
+
+
+class TestDoSearchDebounce:
+    def test_zero_debounce_launches_immediately(self, chooser_panel):
+        async def async_search(query):
+            return [ChooserItem(title=f"async-{query}")]
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="immediate",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0,
+            )
+        )
+
+        with patch.object(chooser_panel, "_launch_async_search") as mock_launch:
+            chooser_panel._do_search("test")
+            mock_launch.assert_called_once()
+
+    def test_positive_debounce_schedules(self, chooser_panel):
+        async def async_search(query):
+            return [ChooserItem(title=f"async-{query}")]
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="debounced",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0.3,
+            )
+        )
+
+        with patch.object(chooser_panel, "_schedule_debounced_search") as mock_schedule:
+            chooser_panel._do_search("test")
+            mock_schedule.assert_called_once()
+            args = mock_schedule.call_args[0]
+            assert args[0].name == "debounced"  # source
+            assert args[1] == "test"  # query
+            assert args[3] == 0.3  # delay
+
+    def test_mixed_immediate_and_debounced(self, chooser_panel):
+        async def async_search(query):
+            return [ChooserItem(title=f"async-{query}")]
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="immediate",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0,
+            )
+        )
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="debounced",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0.2,
+            )
+        )
+
+        with patch.object(chooser_panel, "_launch_async_search") as mock_launch, \
+                patch.object(chooser_panel, "_schedule_debounced_search") as mock_schedule:
+            chooser_panel._do_search("test")
+            # Immediate source should launch
+            mock_launch.assert_called_once()
+            # Debounced source should be scheduled
+            mock_schedule.assert_called_once()
+
+    def test_each_debounced_source_gets_own_delay(self, chooser_panel):
+        async def async_search(query):
+            return [ChooserItem(title=f"async-{query}")]
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="slow",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0.5,
+            )
+        )
+
+        chooser_panel.register_source(
+            ChooserSource(
+                name="fast",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0.1,
+            )
+        )
+
+        with patch.object(chooser_panel, "_schedule_debounced_search") as mock_schedule:
+            chooser_panel._do_search("test")
+            assert mock_schedule.call_count == 2
+            calls = mock_schedule.call_args_list
+            delays = {c[0][0].name: c[0][3] for c in calls}
+            assert delays["slow"] == 0.5
+            assert delays["fast"] == 0.1
+
+
+# ---------------------------------------------------------------------------
+# Integration: debounce timer fires
+# ---------------------------------------------------------------------------
+
+
+class TestDebounceTimerFires:
+    def test_timer_fires_and_launches_search(self, chooser_panel):
+        """Debounce timer fires after delay and launches async search."""
+        chooser_panel._search_generation = 1
+
+        launch_calls = []
+
+        def capture_launch(src, query, gen):
+            launch_calls.append((src.name, query, gen))
+            chooser_panel._pending_async_count = max(0, chooser_panel._pending_async_count - 1)
+
+        chooser_panel._launch_async_search = capture_launch
+
+        src = ChooserSource(name="test", is_async=True)
+        chooser_panel._schedule_debounced_search(src, "hello", 1, 0.1)
+
+        entry = chooser_panel._debounce_state["test"]
+        assert entry is not None
+
+        # Manually fire the timer callback (simulates RunLoop firing timer)
+        entry.helper.fire_(entry.timer)
+
+        assert len(launch_calls) == 1
+        assert launch_calls[0] == ("test", "hello", 1)
+        assert "test" not in chooser_panel._debounce_state
+
+    def test_stale_generation_discarded(self, chooser_panel):
+        """Timer fires but search is discarded if generation changed."""
+        chooser_panel._search_generation = 1
+
+        launch_calls = []
+
+        def capture_launch(src, query, gen):
+            launch_calls.append((src.name, query, gen))
+
+        chooser_panel._launch_async_search = capture_launch
+
+        src = ChooserSource(name="test", is_async=True)
+        chooser_panel._schedule_debounced_search(src, "hello", 1, 0.1)
+
+        entry = chooser_panel._debounce_state["test"]
+
+        # Simulate new search before timer fires (which resets generation)
+        chooser_panel._search_generation = 2
+
+        # Manually fire the timer callback
+        entry.helper.fire_(entry.timer)
+
+        # Should not have launched because generation is stale
+        assert len(launch_calls) == 0
+        assert "test" not in chooser_panel._debounce_state

--- a/tests/scripting/test_async_source.py
+++ b/tests/scripting/test_async_source.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from wenzi.scripting.sources import ChooserItem, ChooserSource
 from wenzi.scripting.api.chooser import ChooserAPI
@@ -24,21 +24,25 @@ def _wait_for(predicate, timeout=5.0, interval=0.05):
 # ChooserSource dataclass — new fields
 # ---------------------------------------------------------------------------
 
+
 class TestChooserSourceAsyncFields:
     def test_defaults(self):
         src = ChooserSource(name="test")
         assert src.is_async is False
-        assert src.search_timeout == 5.0
+        assert src.search_timeout is None
+        assert src.debounce_delay is None
 
     def test_custom_values(self):
-        src = ChooserSource(name="test", is_async=True, search_timeout=3.0)
+        src = ChooserSource(name="test", is_async=True, search_timeout=3.0, debounce_delay=0.2)
         assert src.is_async is True
         assert src.search_timeout == 3.0
+        assert src.debounce_delay == 0.2
 
 
 # ---------------------------------------------------------------------------
 # Source decorator — async detection
 # ---------------------------------------------------------------------------
+
 
 class TestSourceDecoratorAsyncDetection:
     def test_sync_source_not_async(self):
@@ -71,265 +75,255 @@ class TestSourceDecoratorAsyncDetection:
             return []
 
         src = api.panel._sources["async-default"]
-        assert src.search_timeout == 5.0
+        assert src.search_timeout is None
+        assert src.debounce_delay is None
 
 
 # ---------------------------------------------------------------------------
 # ChooserPanel — _do_search sync/async split
 # ---------------------------------------------------------------------------
 
+
 class TestDoSearchSyncAsyncSplit:
     """Test that _do_search partitions sources correctly."""
 
-    def _make_panel(self):
-        api = ChooserAPI()
-        panel = api.panel
-        panel._eval_js = MagicMock()
-        return panel
+    def test_sync_source_works_unchanged(self, chooser_panel):
+        chooser_panel.register_source(
+            ChooserSource(
+                name="apps",
+                search=lambda q: [ChooserItem(title=f"App-{q}")],
+            )
+        )
+        chooser_panel._do_search("hello")
+        assert len(chooser_panel._current_items) == 1
+        assert chooser_panel._current_items[0].title == "App-hello"
 
-    def test_sync_source_works_unchanged(self):
-        panel = self._make_panel()
-        panel.register_source(ChooserSource(
-            name="apps",
-            search=lambda q: [ChooserItem(title=f"App-{q}")],
-        ))
-        panel._do_search("hello")
-        assert len(panel._current_items) == 1
-        assert panel._current_items[0].title == "App-hello"
-
-    def test_generation_counter_increments(self):
-        panel = self._make_panel()
-        panel.register_source(ChooserSource(
-            name="apps",
-            search=lambda q: [ChooserItem(title="a")],
-        ))
-        panel._do_search("a")
-        gen1 = panel._search_generation
-        panel._do_search("b")
-        gen2 = panel._search_generation
+    def test_generation_counter_increments(self, chooser_panel):
+        chooser_panel.register_source(
+            ChooserSource(
+                name="apps",
+                search=lambda q: [ChooserItem(title="a")],
+            )
+        )
+        chooser_panel._do_search("a")
+        gen1 = chooser_panel._search_generation
+        chooser_panel._do_search("b")
+        gen2 = chooser_panel._search_generation
         assert gen2 == gen1 + 1
 
-    def test_async_source_triggers_launch(self):
-        panel = self._make_panel()
-
+    def test_async_source_triggers_launch(self, chooser_panel):
         async def async_search(query):
             return [ChooserItem(title=f"async-{query}")]
 
-        panel.register_source(ChooserSource(
-            name="async-src",
-            search=async_search,
-            is_async=True,
-        ))
+        chooser_panel.register_source(
+            ChooserSource(
+                name="async-src",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0,  # Disable debounce for this test
+            )
+        )
 
-        with patch.object(panel, "_launch_async_search") as mock_launch:
-            panel._do_search("test")
+        with patch.object(chooser_panel, "_launch_async_search") as mock_launch:
+            chooser_panel._do_search("test")
             mock_launch.assert_called_once()
             args = mock_launch.call_args
             assert args[0][0].name == "async-src"
             assert args[0][1] == "test"
 
-    def test_sync_results_immediate_async_deferred(self):
+    def test_sync_results_immediate_async_deferred(self, chooser_panel):
         """Sync sources produce immediate items; async sources are deferred."""
-        panel = self._make_panel()
-        panel.register_source(ChooserSource(
-            name="sync-src",
-            search=lambda q: [ChooserItem(title="sync")],
-        ))
+        chooser_panel.register_source(
+            ChooserSource(
+                name="sync-src",
+                search=lambda q: [ChooserItem(title="sync")],
+            )
+        )
 
         async def async_search(query):
             return [ChooserItem(title="async")]
 
-        panel.register_source(ChooserSource(
-            name="async-src",
-            search=async_search,
-            is_async=True,
-        ))
+        chooser_panel.register_source(
+            ChooserSource(
+                name="async-src",
+                search=async_search,
+                is_async=True,
+            )
+        )
 
-        with patch.object(panel, "_launch_async_search"):
-            panel._do_search("test")
+        with patch.object(chooser_panel, "_launch_async_search"):
+            chooser_panel._do_search("test")
 
         # Sync items are immediately available
-        assert len(panel._current_items) == 1
-        assert panel._current_items[0].title == "sync"
+        assert len(chooser_panel._current_items) == 1
+        assert chooser_panel._current_items[0].title == "sync"
 
-    def test_loading_indicator_set_for_async(self):
-        panel = self._make_panel()
-
+    def test_loading_indicator_set_for_async(self, chooser_panel):
         async def async_search(query):
             return []
 
-        panel.register_source(ChooserSource(
-            name="async-src",
-            search=async_search,
-            is_async=True,
-        ))
+        chooser_panel.register_source(
+            ChooserSource(
+                name="async-src",
+                search=async_search,
+                is_async=True,
+            )
+        )
 
-        with patch.object(panel, "_launch_async_search"):
-            panel._do_search("test")
+        with patch.object(chooser_panel, "_launch_async_search"):
+            chooser_panel._do_search("test")
 
-        js_calls = [str(c) for c in panel._eval_js.call_args_list]
+        js_calls = [str(c) for c in chooser_panel._eval_js.call_args_list]
         assert any("setLoading(true)" in c for c in js_calls)
 
-    def test_no_loading_for_sync_only(self):
-        panel = self._make_panel()
-        panel.register_source(ChooserSource(
-            name="sync-src",
-            search=lambda q: [ChooserItem(title="sync")],
-        ))
-        panel._do_search("test")
+    def test_no_loading_for_sync_only(self, chooser_panel):
+        chooser_panel.register_source(
+            ChooserSource(
+                name="sync-src",
+                search=lambda q: [ChooserItem(title="sync")],
+            )
+        )
+        chooser_panel._do_search("test")
 
         # Loading was never shown — _set_loading(False) is a no-op
-        assert panel._loading_visible is False
-        js_calls = [str(c) for c in panel._eval_js.call_args_list]
+        assert chooser_panel._loading_visible is False
+        js_calls = [str(c) for c in chooser_panel._eval_js.call_args_list]
         assert not any("setLoading(true)" in c for c in js_calls)
 
-    def test_empty_query_clears_loading(self):
-        panel = self._make_panel()
-        panel._pending_async_count = 2  # simulate in-flight
-        panel._loading_visible = True  # simulate loading was shown
-        panel._do_search("")
+    def test_empty_query_clears_loading(self, chooser_panel):
+        chooser_panel._pending_async_count = 2  # simulate in-flight
+        chooser_panel._loading_visible = True  # simulate loading was shown
+        chooser_panel._do_search("")
 
-        assert panel._pending_async_count == 0
-        assert panel._loading_visible is False
-        js_calls = [str(c) for c in panel._eval_js.call_args_list]
+        assert chooser_panel._pending_async_count == 0
+        assert chooser_panel._loading_visible is False
+        js_calls = [str(c) for c in chooser_panel._eval_js.call_args_list]
         assert any("setLoading(false)" in c for c in js_calls)
 
-    def test_prefix_async_source(self):
+    def test_prefix_async_source(self, chooser_panel):
         """Prefix-activated async source should launch async search."""
-        panel = self._make_panel()
-
         async def async_search(query):
             return [ChooserItem(title=f"prefix-{query}")]
 
-        panel.register_source(ChooserSource(
-            name="api-src",
-            prefix="api",
-            search=async_search,
-            is_async=True,
-        ))
+        chooser_panel.register_source(
+            ChooserSource(
+                name="api-src",
+                prefix="api",
+                search=async_search,
+                is_async=True,
+                debounce_delay=0,  # Disable debounce for this test
+            )
+        )
 
-        with patch.object(panel, "_launch_async_search") as mock_launch:
-            panel._do_search("api hello")
+        with patch.object(chooser_panel, "_launch_async_search") as mock_launch:
+            chooser_panel._do_search("api hello")
             mock_launch.assert_called_once()
             # Verify prefix was stripped
             assert mock_launch.call_args[0][1] == "hello"
 
         # No sync items
-        assert len(panel._current_items) == 0
+        assert len(chooser_panel._current_items) == 0
 
-    def test_prefix_sync_source_unchanged(self):
-        panel = self._make_panel()
-        panel.register_source(ChooserSource(
-            name="cb",
-            prefix="cb",
-            search=lambda q: [ChooserItem(title=f"clip-{q}")],
-        ))
-        panel._do_search("cb test")
-        assert len(panel._current_items) == 1
-        assert panel._current_items[0].title == "clip-test"
+    def test_prefix_sync_source_unchanged(self, chooser_panel):
+        chooser_panel.register_source(
+            ChooserSource(
+                name="cb",
+                prefix="cb",
+                search=lambda q: [ChooserItem(title=f"clip-{q}")],
+            )
+        )
+        chooser_panel._do_search("cb test")
+        assert len(chooser_panel._current_items) == 1
+        assert chooser_panel._current_items[0].title == "clip-test"
 
 
 # ---------------------------------------------------------------------------
 # _merge_async_results
 # ---------------------------------------------------------------------------
 
-class TestMergeAsyncResults:
-    def _make_panel(self):
-        api = ChooserAPI()
-        panel = api.panel
-        panel._eval_js = MagicMock()
-        return panel
 
-    def test_merge_appends_items(self):
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
-        panel._current_items = [ChooserItem(title="sync")]
+class TestMergeAsyncResults:
+    def test_merge_appends_items(self, chooser_panel):
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
+        chooser_panel._current_items = [ChooserItem(title="sync")]
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(
+        chooser_panel._merge_async_results(
             src,
             [ChooserItem(title="async")],
             generation=1,
         )
-        assert len(panel._current_items) == 2
-        assert panel._current_items[1].title == "async"
+        assert len(chooser_panel._current_items) == 2
+        assert chooser_panel._current_items[1].title == "async"
 
-    def test_stale_generation_discarded(self):
-        panel = self._make_panel()
-        panel._search_generation = 5
-        panel._pending_async_count = 1
-        panel._current_items = [ChooserItem(title="sync")]
+    def test_stale_generation_discarded(self, chooser_panel):
+        chooser_panel._search_generation = 5
+        chooser_panel._pending_async_count = 1
+        chooser_panel._current_items = [ChooserItem(title="sync")]
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(
+        chooser_panel._merge_async_results(
             src,
             [ChooserItem(title="stale")],
             generation=3,  # old generation
         )
         # Items NOT merged
-        assert len(panel._current_items) == 1
-        assert panel._current_items[0].title == "sync"
+        assert len(chooser_panel._current_items) == 1
+        assert chooser_panel._current_items[0].title == "sync"
 
-    def test_loading_cleared_when_last_async_completes(self):
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
-        panel._loading_visible = True  # loading was turned on
+    def test_loading_cleared_when_last_async_completes(self, chooser_panel):
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
+        chooser_panel._loading_visible = True  # loading was turned on
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(src, [], generation=1)
+        chooser_panel._merge_async_results(src, [], generation=1)
 
-        assert panel._pending_async_count == 0
-        assert panel._loading_visible is False
-        js_calls = [str(c) for c in panel._eval_js.call_args_list]
+        assert chooser_panel._pending_async_count == 0
+        assert chooser_panel._loading_visible is False
+        js_calls = [str(c) for c in chooser_panel._eval_js.call_args_list]
         assert any("setLoading(false)" in c for c in js_calls)
 
-    def test_loading_not_cleared_while_others_pending(self):
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 2
+    def test_loading_not_cleared_while_others_pending(self, chooser_panel):
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 2
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(
+        chooser_panel._merge_async_results(
             src,
             [ChooserItem(title="first")],
             generation=1,
         )
 
-        assert panel._pending_async_count == 1
-        js_calls = [str(c) for c in panel._eval_js.call_args_list]
+        assert chooser_panel._pending_async_count == 1
+        js_calls = [str(c) for c in chooser_panel._eval_js.call_args_list]
         assert not any("setLoading(false)" in c for c in js_calls)
 
-    def test_respects_max_total_results(self):
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
+    def test_respects_max_total_results(self, chooser_panel):
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
         # Fill up to near the limit
-        panel._current_items = [
-            ChooserItem(title=f"item-{i}")
-            for i in range(panel._MAX_TOTAL_RESULTS - 1)
-        ]
+        chooser_panel._current_items = [ChooserItem(title=f"item-{i}") for i in range(chooser_panel._MAX_TOTAL_RESULTS - 1)]
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(
+        chooser_panel._merge_async_results(
             src,
             [ChooserItem(title="a1"), ChooserItem(title="a2")],
             generation=1,
         )
         # Only 1 slot remaining, so only 1 async item added
-        assert len(panel._current_items) == panel._MAX_TOTAL_RESULTS
-        assert panel._current_items[-1].title == "a1"
+        assert len(chooser_panel._current_items) == chooser_panel._MAX_TOTAL_RESULTS
+        assert chooser_panel._current_items[-1].title == "a1"
 
-    def test_preserve_selection_on_merge(self):
+    def test_preserve_selection_on_merge(self, chooser_panel):
         """Merged results should use preserve_selection=True."""
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
-        panel._current_items = [ChooserItem(title="sync")]
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
+        chooser_panel._current_items = [ChooserItem(title="sync")]
 
         src = ChooserSource(name="async-src", is_async=True)
-        panel._merge_async_results(
+        chooser_panel._merge_async_results(
             src,
             [ChooserItem(title="async")],
             generation=1,
@@ -337,7 +331,7 @@ class TestMergeAsyncResults:
 
         # Check that _push_items_to_js was called with preserve_selection
         # by inspecting the JS output for the -2 sentinel
-        js_calls = " ".join(str(c) for c in panel._eval_js.call_args_list)
+        js_calls = " ".join(str(c) for c in chooser_panel._eval_js.call_args_list)
         assert ",-2" in js_calls
 
 
@@ -345,30 +339,24 @@ class TestMergeAsyncResults:
 # Integration: _launch_async_search with real event loop
 # ---------------------------------------------------------------------------
 
+
 class TestLaunchAsyncSearchIntegration:
     """Integration tests using the real asyncio event loop."""
 
-    def _make_panel(self):
-        api = ChooserAPI()
-        panel = api.panel
-        panel._eval_js = MagicMock()
-        return panel
-
     @patch("wenzi.scripting.ui.chooser_panel.AppHelper", create=True)
-    def test_async_source_results_merged(self, _mock_apphelper):
+    def test_async_source_results_merged(self, _mock_apphelper, chooser_panel):
         """Async source results are delivered via _merge_async_results."""
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
 
         merge_calls = []
-        original_merge = panel._merge_async_results
+        original_merge = chooser_panel._merge_async_results
 
         def capture_merge(*args, **kwargs):
             merge_calls.append(args)
             original_merge(*args, **kwargs)
 
-        panel._merge_async_results = capture_merge
+        chooser_panel._merge_async_results = capture_merge
 
         async def fast_search(query):
             await asyncio.sleep(0.05)
@@ -389,27 +377,26 @@ class TestLaunchAsyncSearchIntegration:
             "PyObjCTools.AppHelper.callAfter",
             side_effect=call_directly,
         ):
-            panel._launch_async_search(src, "hello", generation=1)
+            chooser_panel._launch_async_search(src, "hello", generation=1)
             assert _wait_for(lambda: len(merge_calls) > 0, timeout=5.0)
 
-        assert len(panel._current_items) == 1
-        assert panel._current_items[0].title == "fast-hello"
+        assert len(chooser_panel._current_items) == 1
+        assert chooser_panel._current_items[0].title == "fast-hello"
 
     @patch("wenzi.scripting.ui.chooser_panel.AppHelper", create=True)
-    def test_async_source_timeout(self, _mock_apphelper):
+    def test_async_source_timeout(self, _mock_apphelper, chooser_panel):
         """Async source that exceeds timeout returns empty results."""
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
 
         merge_calls = []
-        original_merge = panel._merge_async_results
+        original_merge = chooser_panel._merge_async_results
 
         def capture_merge(*args, **kwargs):
             merge_calls.append(args)
             original_merge(*args, **kwargs)
 
-        panel._merge_async_results = capture_merge
+        chooser_panel._merge_async_results = capture_merge
 
         async def slow_search(query):
             await asyncio.sleep(10.0)  # Much longer than timeout
@@ -426,27 +413,26 @@ class TestLaunchAsyncSearchIntegration:
             "PyObjCTools.AppHelper.callAfter",
             side_effect=lambda fn, *a, **kw: fn(*a, **kw),
         ):
-            panel._launch_async_search(src, "hello", generation=1)
+            chooser_panel._launch_async_search(src, "hello", generation=1)
             assert _wait_for(lambda: len(merge_calls) > 0, timeout=5.0)
 
         # Timed out — no items merged
-        assert len(panel._current_items) == 0
+        assert len(chooser_panel._current_items) == 0
 
     @patch("wenzi.scripting.ui.chooser_panel.AppHelper", create=True)
-    def test_stale_generation_ignored(self, _mock_apphelper):
+    def test_stale_generation_ignored(self, _mock_apphelper, chooser_panel):
         """Async results for an old generation are silently discarded."""
-        panel = self._make_panel()
-        panel._search_generation = 1
-        panel._pending_async_count = 1
+        chooser_panel._search_generation = 1
+        chooser_panel._pending_async_count = 1
 
         merge_calls = []
-        original_merge = panel._merge_async_results
+        original_merge = chooser_panel._merge_async_results
 
         def capture_merge(*args, **kwargs):
             merge_calls.append(args)
             original_merge(*args, **kwargs)
 
-        panel._merge_async_results = capture_merge
+        chooser_panel._merge_async_results = capture_merge
 
         async def search(query):
             await asyncio.sleep(0.05)
@@ -462,18 +448,19 @@ class TestLaunchAsyncSearchIntegration:
             "PyObjCTools.AppHelper.callAfter",
             side_effect=lambda fn, *a, **kw: fn(*a, **kw),
         ):
-            panel._launch_async_search(src, "hello", generation=1)
+            chooser_panel._launch_async_search(src, "hello", generation=1)
             # Simulate user typing again before result arrives
-            panel._search_generation = 2
+            chooser_panel._search_generation = 2
             assert _wait_for(lambda: len(merge_calls) > 0, timeout=5.0)
 
         # Results discarded because generation changed
-        assert len(panel._current_items) == 0
+        assert len(chooser_panel._current_items) == 0
 
 
 # ---------------------------------------------------------------------------
 # Async demo plugin — source registration
 # ---------------------------------------------------------------------------
+
 
 class TestAsyncDemoSourceRegistration:
     def test_async_source_registered(self):
@@ -486,6 +473,7 @@ class TestAsyncDemoSourceRegistration:
         wz.chooser._ensure_command_source()
 
         from async_demo import setup
+
         setup(wz)
 
         assert "async-search" in wz.chooser.panel._sources


### PR DESCRIPTION
## Summary

- Add per-source debounce support for async chooser sources, preventing excessive API calls while the user is still typing
- Each debounced source gets its own independent timer with configurable delay (`debounce_delay` field on `ChooserSource`, `debounce_delay` param on `@source` decorator)
- Global defaults: `_DEFAULT_ASYNC_DEBOUNCE=0.15s`, `_DEFAULT_ASYNC_TIMEOUT=5.0s` (both overridable per-source, `None` = use default, `0` = no debounce)
- Debounce state consolidated into a single `_DebounceEntry` NamedTuple dict for atomic management
- Add shared `chooser_panel` pytest fixture in `tests/scripting/conftest.py`

## Test plan

- [x] `TestChooserSourceDebounceField` — dataclass field defaults and custom values
- [x] `TestGetDebounceDelay` / `TestGetTimeout` — global default fallback logic
- [x] `TestSourceDecoratorDebounce` — `@source` decorator passes debounce params
- [x] `TestDebounceScheduling` — timer creation, same-source cancellation, independent per-source timers, close cleanup
- [x] `TestDoSearchDebounce` — immediate vs debounced partitioning, per-source delay, mixed sources
- [x] `TestDebounceTimerFires` — timer callback execution and stale generation discard
- [x] All 3676 existing tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)