### PR TITLE
fix: resolve memory leaks across multiple modules

### DIFF
--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -1123,6 +1123,9 @@ class WenZiApp(StatusBarApp):
             except Exception:
                 logger.debug("Enhancer close timed out or failed", exc_info=True)
         async_loop.shutdown_sync(timeout=5)
+        from wenzi.statusbar import cleanup_callbacks
+
+        cleanup_callbacks()
         quit_application()
 
     @staticmethod

--- a/src/wenzi/audio/recorder.py
+++ b/src/wenzi/audio/recorder.py
@@ -188,6 +188,10 @@ class Recorder:
             stream = self._stream
             self._stream = None
 
+        # Break circular references: the callback typically captures the
+        # caller's self, preventing GC until the next start().
+        self.clear_on_audio_chunk()
+
         # Fire-and-forget stream close.  The _close_done event lets a
         # subsequent start() know whether cleanup has finished.
         if stream is not None:
@@ -214,6 +218,7 @@ class Recorder:
 
         if not frames:
             logger.warning("No audio frames captured")
+            self._flush()  # ensure queue is fully drained
             return None
 
         audio = np.concatenate(frames)
@@ -227,6 +232,7 @@ class Recorder:
         if rms < self.silence_rms:
             logger.warning("Audio below silence threshold (RMS=%d < %d), discarding",
                            rms, self.silence_rms)
+            self._flush()  # release any frames that arrived during drain
             return None
 
         # Encode as WAV in memory

--- a/src/wenzi/enhance/auto_vocab_builder.py
+++ b/src/wenzi/enhance/auto_vocab_builder.py
@@ -95,7 +95,12 @@ class AutoVocabBuilder:
 
     def _run_silent_build(self) -> None:
         """Submit vocabulary build to the shared asyncio loop."""
-        async_loop.submit(self._build_async())
+        try:
+            async_loop.submit(self._build_async())
+        except Exception:
+            logger.error("Failed to submit vocab build", exc_info=True)
+            with self._lock:
+                self._building = False
 
     async def _build_async(self) -> None:
         """Execute incremental vocabulary build, reload index, and notify."""

--- a/src/wenzi/enhance/pool_monitor.py
+++ b/src/wenzi/enhance/pool_monitor.py
@@ -188,12 +188,16 @@ class PoolMonitor:
             return  # already running
 
         async def _loop() -> None:
-            while True:
-                await asyncio.sleep(interval)
-                try:
-                    self.log_stats("periodic")
-                except Exception:
-                    logger.debug("Periodic pool stats failed", exc_info=True)
+            try:
+                while True:
+                    await asyncio.sleep(interval)
+                    try:
+                        self.log_stats("periodic")
+                    except Exception:
+                        logger.debug("Periodic pool stats failed", exc_info=True)
+            except asyncio.CancelledError:
+                logger.debug("Periodic pool monitor cancelled")
+                return
 
         try:
             from wenzi import async_loop

--- a/src/wenzi/scripting/clipboard_monitor.py
+++ b/src/wenzi/scripting/clipboard_monitor.py
@@ -561,6 +561,9 @@ class ClipboardMonitor:
         if self._ocr_executor is not None:
             self._ocr_executor.shutdown(wait=False)
             self._ocr_executor = None
+        if self._db is not None:
+            self._db.close()
+            self._db = None
         logger.info("Clipboard monitor stopped")
 
     def clear(self) -> None:

--- a/src/wenzi/statusbar.py
+++ b/src/wenzi/statusbar.py
@@ -59,6 +59,15 @@ def _get_callback_handler() -> _MenuCallbackTarget:
     return _callback_handler
 
 
+def cleanup_callbacks() -> None:
+    """Clear the global callback mapping.
+
+    Should be called on application quit to release references to
+    ``StatusMenuItem`` / callable pairs held for menu item routing.
+    """
+    _ns_to_callback.clear()
+
+
 # ---------------------------------------------------------------------------
 # SeparatorMenuItem
 # ---------------------------------------------------------------------------

--- a/src/wenzi/transcription/apple.py
+++ b/src/wenzi/transcription/apple.py
@@ -541,6 +541,12 @@ class AppleSpeechTranscriber(BaseTranscriber):
         t = self._stream_runloop_thread
         if t is not None and t.is_alive():
             t.join(timeout=2.0)
+            if t.is_alive():
+                logger.warning(
+                    "RunLoop thread did not exit within timeout, cleaning up references"
+                )
+                self._stream_runloop_thread = None
+                self._stream_on_partial = None
 
     def _reset_streaming_state(self) -> None:
         """Clear all streaming state."""

--- a/src/wenzi/transcription/funasr.py
+++ b/src/wenzi/transcription/funasr.py
@@ -29,6 +29,7 @@ class FunASRTranscriber(BaseTranscriber):
         self._vad_model = None
         self._punc_restorer = None
         self._initialized = False
+        self._initializing_lock = threading.Lock()
         self._transcription_count = 0
 
     @property
@@ -44,6 +45,19 @@ class FunASRTranscriber(BaseTranscriber):
         if self._initialized:
             return
 
+        if not self._initializing_lock.acquire(blocking=False):
+            logger.info("FunASR initialization already in progress, skipping")
+            return
+
+        try:
+            if self._initialized:
+                return
+            self._initialize_models()
+        finally:
+            self._initializing_lock.release()
+
+    def _initialize_models(self) -> None:
+        """Internal: load models while holding the init lock."""
         logger.info("Initializing FunASR models...")
         start = time.time()
 

--- a/src/wenzi/transcription/sherpa.py
+++ b/src/wenzi/transcription/sherpa.py
@@ -254,6 +254,12 @@ class SherpaOnnxTranscriber(BaseTranscriber):
         self._stream_stop.set()
         if self._decode_thread is not None:
             self._decode_thread.join(timeout=5.0)
+            if self._decode_thread.is_alive():
+                logger.warning(
+                    "Decode thread did not exit within timeout, cleaning up references"
+                )
+                self._decode_thread = None
+                self._on_partial = None
 
         # Final decode pass
         while self._recognizer.is_ready(self._stream):
@@ -276,6 +282,10 @@ class SherpaOnnxTranscriber(BaseTranscriber):
         self._stream_stop.set()
         if self._decode_thread is not None:
             self._decode_thread.join(timeout=2.0)
+            if self._decode_thread.is_alive():
+                logger.warning(
+                    "Decode thread did not exit within timeout, cleaning up references"
+                )
         self._cleanup_stream()
         logger.info("Sherpa streaming cancelled")
 
@@ -300,6 +310,7 @@ class SherpaOnnxTranscriber(BaseTranscriber):
         self._decode_thread = None
         self._on_partial = None
         self._last_text = ""
+        self._stream_stop.set()  # ensure thread sees stop signal
 
     def cleanup(self) -> None:
         if self._stream is not None:

--- a/src/wenzi/ui/history_browser_window_web.py
+++ b/src/wenzi/ui/history_browser_window_web.py
@@ -182,11 +182,17 @@ class HistoryBrowserPanel:
             self._panel = None
         if self._webview is not None:
             self._webview.setNavigationDelegate_(None)
+            try:
+                self._webview.configuration().userContentController().removeScriptMessageHandlerForName_("action")
+            except Exception:
+                pass
         self._webview = None
         self._message_handler = None
         self._navigation_delegate = None
         self._page_loaded = False
         self._pending_js = []
+        self._all_records = []
+        self._filtered_records = []
 
         if self._conversation_history is not None:
             self._conversation_history.release_full_cache()

--- a/src/wenzi/ui/result_window_web.py
+++ b/src/wenzi/ui/result_window_web.py
@@ -906,6 +906,10 @@ class ResultPreviewPanel:
             self._panel = None
         if self._webview is not None:
             self._webview.setNavigationDelegate_(None)
+            try:
+                self._webview.configuration().userContentController().removeScriptMessageHandlerForName_("action")
+            except Exception:
+                pass
         self._webview = None
         self._message_handler = None
         self._navigation_delegate = None


### PR DESCRIPTION
## Summary

- **WKWebView handler 泄漏**: `result_window_web` 和 `history_browser_window_web` 的 `close()` 中添加 `removeScriptMessageHandlerForName_` 打破 retain cycle，每次开关面板不再泄漏 30-60 MB
- **历史浏览器数据未释放**: 关闭面板时清空 `_all_records` / `_filtered_records`（最多 20-40 MB）
- **ClipboardMonitor SQLite 连接泄漏**: `stop()` 中关闭数据库并置 None
- **Recorder 循环引用**: `stop()` 时清除回调、异常路径 flush queue
- **线程超时残留**: apple.py / sherpa.py 线程 join 超时后清理引用，防止 GC 阻塞
- **FunASR 重复加载**: 添加 `threading.Lock` 防止并发初始化导致模型内存翻倍
- **PoolMonitor 无限循环**: 添加 `CancelledError` 处理，任务取消时干净退出
- **AutoVocabBuilder 死锁**: `submit()` 失败时重置 `_building` 标志
- **Statusbar 回调字典**: 添加 `cleanup_callbacks()` 并在退出时调用

Closes #97
Closes #98

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run python -m pytest tests/ -v` — 3673 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)