### PR TITLE
feat(scripting): add window management API

### DIFF
--- a/src/wenzi/scripting/api/__init__.py
+++ b/src/wenzi/scripting/api/__init__.py
@@ -35,10 +35,11 @@ class _WZNamespace:
         self.snippets = SnippetsAPI()
         self.timer = TimerAPI(registry)
         self.store = StoreAPI()
-        # HotkeyAPI, ChooserAPI, and UIAPI are created lazily to avoid circular imports
+        # HotkeyAPI, ChooserAPI, UIAPI, WindowAPI are created lazily
         self._hotkey_api = None
         self._chooser_api = None
         self._ui_api = None
+        self._window_api = None
         self._reload_callback: Optional[Callable] = None
 
     @property
@@ -67,6 +68,15 @@ class _WZNamespace:
 
             self._ui_api = UIAPI()
         return self._ui_api
+
+    @property
+    def window(self):
+        """Access the window management API (lazy init)."""
+        if self._window_api is None:
+            from .window import WindowAPI
+
+            self._window_api = WindowAPI()
+        return self._window_api
 
     def leader(
         self,

--- a/src/wenzi/scripting/api/window.py
+++ b/src/wenzi/scripting/api/window.py
@@ -1,0 +1,269 @@
+"""Window management API — move, resize, and snap the focused window."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_focused_window():
+    """Return the AXUIElement for the focused window, or None."""
+    from ApplicationServices import (
+        AXUIElementCreateSystemWide,
+        AXUIElementCopyAttributeValue,
+        kAXErrorSuccess,
+    )
+
+    system = AXUIElementCreateSystemWide()
+    err, app = AXUIElementCopyAttributeValue(
+        system, "AXFocusedApplication", None
+    )
+    if err != kAXErrorSuccess or app is None:
+        return None
+    err, win = AXUIElementCopyAttributeValue(app, "AXFocusedWindow", None)
+    if err != kAXErrorSuccess or win is None:
+        return None
+    return win
+
+
+def _get_position(win) -> Optional[tuple]:
+    """Return (x, y) of the window in AX (top-left origin) coords."""
+    from ApplicationServices import (
+        AXUIElementCopyAttributeValue,
+        AXValueGetValue,
+        kAXErrorSuccess,
+        kAXValueCGPointType,
+    )
+
+    err, val = AXUIElementCopyAttributeValue(win, "AXPosition", None)
+    if err != kAXErrorSuccess or val is None:
+        return None
+    ok, point = AXValueGetValue(val, kAXValueCGPointType, None)
+    if ok:
+        return (point.x, point.y)
+    return None
+
+
+def _set_position(win, x: float, y: float):
+    """Set the window position in AX coords."""
+    from ApplicationServices import (
+        AXUIElementSetAttributeValue,
+        AXValueCreate,
+        kAXValueCGPointType,
+    )
+    import Quartz
+
+    point = Quartz.CGPoint(x=x, y=y)
+    val = AXValueCreate(kAXValueCGPointType, point)
+    AXUIElementSetAttributeValue(win, "AXPosition", val)
+
+
+def _get_size(win) -> Optional[tuple]:
+    """Return (width, height) of the window."""
+    from ApplicationServices import (
+        AXUIElementCopyAttributeValue,
+        AXValueGetValue,
+        kAXErrorSuccess,
+        kAXValueCGSizeType,
+    )
+
+    err, val = AXUIElementCopyAttributeValue(win, "AXSize", None)
+    if err != kAXErrorSuccess or val is None:
+        return None
+    ok, size = AXValueGetValue(val, kAXValueCGSizeType, None)
+    if ok:
+        return (size.width, size.height)
+    return None
+
+
+def _set_size(win, w: float, h: float):
+    """Set the window size."""
+    from ApplicationServices import (
+        AXUIElementSetAttributeValue,
+        AXValueCreate,
+        kAXValueCGSizeType,
+    )
+    import Quartz
+
+    size = Quartz.CGSize(width=w, height=h)
+    val = AXValueCreate(kAXValueCGSizeType, size)
+    AXUIElementSetAttributeValue(win, "AXSize", val)
+
+
+def _visible_frame_ax(screen) -> tuple:
+    """Return (x, y, w, h) of screen's visible area in AX coords.
+
+    Converts from Cocoa (bottom-left origin) to AX (top-left origin).
+    """
+    from AppKit import NSScreen
+
+    main_h = NSScreen.mainScreen().frame().size.height
+    vf = screen.visibleFrame()
+    ax_x = vf.origin.x
+    ax_y = main_h - vf.origin.y - vf.size.height
+    return (ax_x, ax_y, vf.size.width, vf.size.height)
+
+
+def _screen_for_window(win):
+    """Find the NSScreen whose visible area contains the window center."""
+    from AppKit import NSScreen
+
+    pos = _get_position(win)
+    sz = _get_size(win)
+    if pos is None or sz is None:
+        return NSScreen.mainScreen()
+
+    cx = pos[0] + sz[0] / 2
+    cy = pos[1] + sz[1] / 2
+
+    for s in NSScreen.screens():
+        sx, sy, sw, sh = _visible_frame_ax(s)
+        if sx <= cx <= sx + sw and sy <= cy <= sy + sh:
+            return s
+    return NSScreen.mainScreen()
+
+
+class WindowAPI:
+    """Window management — ``wz.window``."""
+
+    def focused_frame(self) -> Optional[dict]:
+        """Return ``{"x", "y", "w", "h"}`` of the focused window, or None."""
+        win = _get_focused_window()
+        if win is None:
+            return None
+        pos = _get_position(win)
+        sz = _get_size(win)
+        if pos is None or sz is None:
+            return None
+        return {"x": pos[0], "y": pos[1], "w": sz[0], "h": sz[1]}
+
+    def set_frame(self, x: float, y: float, w: float, h: float) -> None:
+        """Move and resize the focused window."""
+        win = _get_focused_window()
+        if win is None:
+            return
+        # Set position, then size, then position again.
+        # Some apps reposition the window on resize, so the second
+        # position call corrects for that.
+        _set_position(win, x, y)
+        _set_size(win, w, h)
+        _set_position(win, x, y)
+
+    def screens(self) -> list[dict]:
+        """Return visible area of each screen in AX coords.
+
+        Each dict has ``x``, ``y``, ``w``, ``h``, and ``name``.
+        """
+        from AppKit import NSScreen
+
+        result = []
+        for s in NSScreen.screens():
+            sx, sy, sw, sh = _visible_frame_ax(s)
+            name = (
+                s.localizedName()
+                if hasattr(s, "localizedName")
+                else str(s)
+            )
+            result.append(
+                {"x": sx, "y": sy, "w": sw, "h": sh, "name": name}
+            )
+        return result
+
+    _SNAP_POSITIONS = {
+        "left": (0, 0, 0.5, 1),
+        "right": (0.5, 0, 0.5, 1),
+        "top": (0, 0, 1, 0.5),
+        "bottom": (0, 0.5, 1, 0.5),
+        "full": (0, 0, 1, 1),
+        "top-left": (0, 0, 0.5, 0.5),
+        "top-right": (0.5, 0, 0.5, 0.5),
+        "bottom-left": (0, 0.5, 0.5, 0.5),
+        "bottom-right": (0.5, 0.5, 0.5, 0.5),
+    }
+
+    def snap(self, position: str) -> None:
+        """Snap the focused window.
+
+        Positions: ``left``, ``right``, ``top``, ``bottom``, ``full``,
+        ``top-left``, ``top-right``, ``bottom-left``, ``bottom-right``.
+        """
+        fracs = self._SNAP_POSITIONS.get(position)
+        if fracs is None:
+            logger.warning("Unknown snap position: %s", position)
+            return
+        win = _get_focused_window()
+        if win is None:
+            return
+
+        sx, sy, sw, sh = _visible_frame_ax(_screen_for_window(win))
+        fx, fy, fw, fh = fracs
+        x = sx + fx * sw
+        y = sy + fy * sh
+        w = fw * sw
+        h = fh * sh
+
+        _set_position(win, x, y)
+        _set_size(win, w, h)
+        _set_position(win, x, y)
+
+    def center(self) -> None:
+        """Center the focused window on its current screen."""
+        win = _get_focused_window()
+        if win is None:
+            return
+        sz = _get_size(win)
+        if sz is None:
+            return
+        sx, sy, sw, sh = _visible_frame_ax(_screen_for_window(win))
+        _set_position(win, sx + (sw - sz[0]) / 2, sy + (sh - sz[1]) / 2)
+
+    def move_to_screen(self, direction: str = "next") -> None:
+        """Move the focused window to the next or previous screen.
+
+        Preserves relative position and size within the visible area.
+        """
+        from AppKit import NSScreen
+
+        win = _get_focused_window()
+        if win is None:
+            return
+        all_screens = NSScreen.screens()
+        if len(all_screens) < 2:
+            return
+
+        current = _screen_for_window(win)
+        idx = 0
+        for i, s in enumerate(all_screens):
+            if s == current:
+                idx = i
+                break
+
+        if direction == "prev":
+            new_idx = (idx - 1) % len(all_screens)
+        else:
+            new_idx = (idx + 1) % len(all_screens)
+
+        pos = _get_position(win)
+        sz = _get_size(win)
+        if pos is None or sz is None:
+            return
+
+        osx, osy, osw, osh = _visible_frame_ax(current)
+        nsx, nsy, nsw, nsh = _visible_frame_ax(all_screens[new_idx])
+
+        # Map relative position from old screen to new screen
+        rel_x = (pos[0] - osx) / osw if osw else 0
+        rel_y = (pos[1] - osy) / osh if osh else 0
+        rel_w = sz[0] / osw if osw else 0.5
+        rel_h = sz[1] / osh if osh else 0.5
+
+        new_x = nsx + rel_x * nsw
+        new_y = nsy + rel_y * nsh
+        new_w = rel_w * nsw
+        new_h = rel_h * nsh
+
+        _set_position(win, new_x, new_y)
+        _set_size(win, new_w, new_h)
+        _set_position(win, new_x, new_y)

--- a/tests/scripting/test_api_window.py
+++ b/tests/scripting/test_api_window.py
@@ -1,0 +1,237 @@
+"""Tests for wz.window API."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wenzi.scripting.api.window import (
+    WindowAPI,
+    _visible_frame_ax,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_ax(monkeypatch, *, pos=(100, 200), size=(800, 600)):
+    """Patch AX helpers to return fixed values without real Accessibility."""
+    win = MagicMock(name="AXWindow")
+    monkeypatch.setattr(
+        "wenzi.scripting.api.window._get_focused_window", lambda: win
+    )
+    monkeypatch.setattr(
+        "wenzi.scripting.api.window._get_position",
+        lambda w: pos if w is win else None,
+    )
+    monkeypatch.setattr(
+        "wenzi.scripting.api.window._get_size",
+        lambda w: size if w is win else None,
+    )
+    set_pos_calls = []
+    set_size_calls = []
+    monkeypatch.setattr(
+        "wenzi.scripting.api.window._set_position",
+        lambda w, x, y: set_pos_calls.append((x, y)),
+    )
+    monkeypatch.setattr(
+        "wenzi.scripting.api.window._set_size",
+        lambda w, x, y: set_size_calls.append((x, y)),
+    )
+    return win, set_pos_calls, set_size_calls
+
+
+def _mock_screen(x=0, y=0, w=1920, h=1080, vis_x=0, vis_y=0, vis_w=1920, vis_h=1055, name="Built-in"):
+    """Create a fake NSScreen-like object."""
+    screen = MagicMock()
+    frame = MagicMock()
+    frame.origin.x = x
+    frame.origin.y = y
+    frame.size.width = w
+    frame.size.height = h
+    screen.frame.return_value = frame
+    vf = MagicMock()
+    vf.origin.x = vis_x
+    vf.origin.y = vis_y
+    vf.size.width = vis_w
+    vf.size.height = vis_h
+    screen.visibleFrame.return_value = vf
+    screen.localizedName.return_value = name
+    return screen
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestFocusedFrame:
+    def test_returns_dict(self, monkeypatch):
+        _mock_ax(monkeypatch, pos=(50, 100), size=(640, 480))
+        api = WindowAPI()
+        frame = api.focused_frame()
+        assert frame == {"x": 50, "y": 100, "w": 640, "h": 480}
+
+    def test_returns_none_when_no_window(self, monkeypatch):
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_focused_window", lambda: None
+        )
+        assert WindowAPI().focused_frame() is None
+
+
+class TestSetFrame:
+    def test_sets_position_and_size(self, monkeypatch):
+        _, pos_calls, size_calls = _mock_ax(monkeypatch)
+        WindowAPI().set_frame(10, 20, 300, 400)
+        # Position set twice (before and after resize)
+        assert pos_calls == [(10, 20), (10, 20)]
+        assert size_calls == [(300, 400)]
+
+    def test_noop_when_no_window(self, monkeypatch):
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_focused_window", lambda: None
+        )
+        WindowAPI().set_frame(0, 0, 100, 100)  # should not raise
+
+
+class TestSnap:
+    @pytest.mark.parametrize(
+        "position, expected_frac",
+        [
+            ("left", (0, 0, 0.5, 1)),
+            ("right", (0.5, 0, 0.5, 1)),
+            ("top", (0, 0, 1, 0.5)),
+            ("bottom", (0, 0.5, 1, 0.5)),
+            ("full", (0, 0, 1, 1)),
+            ("top-left", (0, 0, 0.5, 0.5)),
+            ("bottom-right", (0.5, 0.5, 0.5, 0.5)),
+        ],
+    )
+    def test_snap_positions(self, monkeypatch, position, expected_frac):
+        win, pos_calls, size_calls = _mock_ax(monkeypatch, pos=(100, 50), size=(800, 600))
+        # Mock screen: visible area 1920x1055 starting at (0, 25) in AX coords
+        screen = _mock_screen()
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._screen_for_window", lambda w: screen
+        )
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._visible_frame_ax",
+            lambda s: (0, 25, 1920, 1055),
+        )
+
+        WindowAPI().snap(position)
+
+        fx, fy, fw, fh = expected_frac
+        expected_x = 0 + fx * 1920
+        expected_y = 25 + fy * 1055
+        expected_w = fw * 1920
+        expected_h = fh * 1055
+
+        assert size_calls == [(expected_w, expected_h)]
+        assert pos_calls == [(expected_x, expected_y), (expected_x, expected_y)]
+
+    def test_unknown_position_warns(self, monkeypatch, caplog):
+        _mock_ax(monkeypatch)
+        import logging
+        with caplog.at_level(logging.WARNING):
+            WindowAPI().snap("diagonal")
+        assert "Unknown snap position" in caplog.text
+
+
+class TestCenter:
+    def test_centers_on_screen(self, monkeypatch):
+        win, pos_calls, _ = _mock_ax(monkeypatch, pos=(0, 0), size=(400, 300))
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._screen_for_window", lambda w: MagicMock()
+        )
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._visible_frame_ax",
+            lambda s: (0, 25, 1920, 1055),
+        )
+
+        WindowAPI().center()
+
+        # Centered: x = (1920-400)/2, y = 25 + (1055-300)/2
+        assert pos_calls == [(760.0, 402.5)]
+
+
+def _patch_nsscreen(monkeypatch, screens):
+    """Patch AppKit.NSScreen so lazy imports inside window.py see the mock."""
+    import AppKit as _appkit
+
+    mock_ns = MagicMock()
+    mock_ns.mainScreen.return_value = screens[0]
+    mock_ns.screens.return_value = screens
+    monkeypatch.setattr(_appkit, "NSScreen", mock_ns)
+    return mock_ns
+
+
+class TestScreens:
+    def test_returns_screen_info(self, monkeypatch):
+        screen = _mock_screen(vis_x=0, vis_y=0, vis_w=1920, vis_h=1055)
+        _patch_nsscreen(monkeypatch, [screen])
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._visible_frame_ax",
+            lambda s: (0, 25, 1920, 1055),
+        )
+
+        result = WindowAPI().screens()
+
+        assert len(result) == 1
+        assert result[0]["w"] == 1920
+        assert result[0]["name"] == "Built-in"
+
+
+class TestMoveToScreen:
+    def test_moves_to_next_screen(self, monkeypatch):
+        win, pos_calls, size_calls = _mock_ax(
+            monkeypatch, pos=(100, 125), size=(960, 1055)
+        )
+        s1 = _mock_screen(name="Primary")
+        s2 = _mock_screen(name="Secondary")
+        _patch_nsscreen(monkeypatch, [s1, s2])
+
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._screen_for_window", lambda w: s1
+        )
+
+        def fake_visible(s):
+            if s is s1:
+                return (0, 25, 1920, 1055)
+            return (1920, 25, 1920, 1055)
+
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._visible_frame_ax", fake_visible
+        )
+
+        WindowAPI().move_to_screen("next")
+
+        assert len(pos_calls) == 2
+        assert len(size_calls) == 1
+
+    def test_noop_single_screen(self, monkeypatch):
+        _mock_ax(monkeypatch)
+        s1 = _mock_screen()
+        _patch_nsscreen(monkeypatch, [s1])
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._screen_for_window", lambda w: s1
+        )
+        WindowAPI().move_to_screen("next")  # should not raise
+
+
+class TestVisibleFrameAx:
+    def test_coordinate_conversion(self, monkeypatch):
+        """Cocoa bottom-left origin → AX top-left origin."""
+        screen = _mock_screen(
+            w=1920, h=1080,
+            vis_x=0, vis_y=25, vis_w=1920, vis_h=1055,
+        )
+        main_screen = _mock_screen(w=1920, h=1080)
+        _patch_nsscreen(monkeypatch, [main_screen])
+
+        x, y, w, h = _visible_frame_ax(screen)
+
+        assert x == 0
+        # AX y = main_h - cocoa_y - vis_h = 1080 - 25 - 1055 = 0
+        assert y == 0
+        assert w == 1920
+        assert h == 1055


### PR DESCRIPTION
## Summary
- Add `wz.window` API with `snap()`, `center()`, `set_frame()`, `move_to_screen()`, `focused_frame()`, and `screens()` methods
- Uses macOS Accessibility APIs (AXUIElement) for window positioning and resizing
- Supports 9 snap positions: left, right, top, bottom, full, top-left, top-right, bottom-left, bottom-right

## Test plan
- [x] 17 unit tests covering all API methods, coordinate conversion, and edge cases
- [x] Lint clean (`ruff check`)
- [x] Full test suite passes (3690 tests)
- [ ] Manual test: bind hotkeys in `init.py` and verify snap/center/move work on real windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)