### PR TITLE
feat(scripting): add menubar API and coin price ticker

### DIFF
--- a/src/wenzi/scripting/api/__init__.py
+++ b/src/wenzi/scripting/api/__init__.py
@@ -40,6 +40,7 @@ class _WZNamespace:
         self._chooser_api = None
         self._ui_api = None
         self._window_api = None
+        self._menubar_api = None
         self._reload_callback: Optional[Callable] = None
 
     @property
@@ -77,6 +78,15 @@ class _WZNamespace:
 
             self._window_api = WindowAPI()
         return self._window_api
+
+    @property
+    def menubar(self):
+        """Access the menubar API (lazy init)."""
+        if self._menubar_api is None:
+            from .menubar import MenuBarAPI
+
+            self._menubar_api = MenuBarAPI()
+        return self._menubar_api
 
     def leader(
         self,

--- a/src/wenzi/scripting/api/menubar.py
+++ b/src/wenzi/scripting/api/menubar.py
@@ -1,0 +1,118 @@
+"""Menubar API — create and manage extra status-bar items from scripts."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class MenuBarItem:
+    """A single status-bar item created by a script."""
+
+    def __init__(self, name: str, title: str = ""):
+        from AppKit import NSStatusBar
+
+        self._name = name
+        self._ns_item = NSStatusBar.systemStatusBar().statusItemWithLength_(-1)
+        self._ns_item.setTitle_(title)
+        self._menu_item_refs: list = []  # prevent GC of NSMenuItems
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def set_title(self, title: str) -> None:
+        """Update the status-bar title (main-thread safe)."""
+        from PyObjCTools import AppHelper
+
+        AppHelper.callAfter(lambda: self._ns_item.setTitle_(title))
+
+    def set_menu(self, items: list[dict]) -> None:
+        """Set the dropdown menu.
+
+        Each dict: ``{"title": str, "action": callable}``
+        or ``{"separator": True}``.
+        """
+        from PyObjCTools import AppHelper
+
+        AppHelper.callAfter(lambda: self._set_menu_on_main(items))
+
+    def _set_menu_on_main(self, items: list[dict]) -> None:
+        from AppKit import NSMenu, NSMenuItem
+        from wenzi.statusbar import _get_callback_handler, _ns_to_callback
+
+        # Clean up old callbacks
+        for mi in self._menu_item_refs:
+            _ns_to_callback.pop(id(mi), None)
+        self._menu_item_refs.clear()
+
+        menu = NSMenu.alloc().init()
+        handler = _get_callback_handler()
+
+        for entry in items:
+            if entry.get("separator"):
+                menu.addItem_(NSMenuItem.separatorItem())
+                continue
+
+            title = entry.get("title", "")
+            action = entry.get("action")
+
+            mi = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
+                title, "menuItemClicked:" if action else None, ""
+            )
+            if action:
+                mi.setTarget_(handler)
+                _ns_to_callback[id(mi)] = (
+                    None,
+                    lambda _, cb=action: cb(),
+                )
+            self._menu_item_refs.append(mi)
+            menu.addItem_(mi)
+
+        self._ns_item.setMenu_(menu)
+
+    def _destroy(self) -> None:
+        """Remove this item from the status bar and clean up callbacks."""
+        from AppKit import NSStatusBar
+        from wenzi.statusbar import _ns_to_callback
+
+        for mi in self._menu_item_refs:
+            _ns_to_callback.pop(id(mi), None)
+        self._menu_item_refs.clear()
+        NSStatusBar.systemStatusBar().removeStatusItem_(self._ns_item)
+
+
+class MenuBarAPI:
+    """Manage extra status-bar items — ``wz.menubar``."""
+
+    def __init__(self) -> None:
+        self._items: dict[str, MenuBarItem] = {}
+
+    def create(self, name: str, title: str = "") -> MenuBarItem:
+        """Create (or recreate) a named status-bar item."""
+        if name in self._items:
+            self._items[name]._destroy()
+        item = MenuBarItem(name, title)
+        self._items[name] = item
+        return item
+
+    def remove(self, name: str) -> None:
+        """Remove a named status-bar item."""
+        item = self._items.pop(name, None)
+        if item is not None:
+            item._destroy()
+
+    def get(self, name: str) -> Optional[MenuBarItem]:
+        """Return an existing item by name, or None."""
+        return self._items.get(name)
+
+    def cleanup(self) -> None:
+        """Remove all script-created status-bar items.
+
+        Called automatically on script reload.
+        """
+        for item in self._items.values():
+            item._destroy()
+        self._items.clear()

--- a/src/wenzi/scripting/engine.py
+++ b/src/wenzi/scripting/engine.py
@@ -132,6 +132,9 @@ class ScriptEngine:
             self._wz._hotkey_api = None
             self._wz._chooser_api = None
             self._wz._ui_api = None
+            if self._wz._menubar_api is not None:
+                self._wz._menubar_api.cleanup()
+                self._wz._menubar_api = None
             self._register_builtin_sources()
             self._load_plugins()
             self._load_scripts()

--- a/tests/scripting/test_api_menubar.py
+++ b/tests/scripting/test_api_menubar.py
@@ -1,0 +1,133 @@
+"""Tests for wz.menubar API."""
+
+from unittest.mock import MagicMock
+
+from wenzi.scripting.api.menubar import MenuBarAPI, MenuBarItem
+
+
+def _patch_appkit(monkeypatch):
+    """Patch AppKit imports used by MenuBarItem."""
+    mock_bar = MagicMock()
+    mock_item = MagicMock()
+    mock_bar.systemStatusBar.return_value.statusItemWithLength_.return_value = (
+        mock_item
+    )
+    import AppKit as _appkit
+
+    monkeypatch.setattr(_appkit, "NSStatusBar", mock_bar)
+    return mock_bar, mock_item
+
+
+class TestMenuBarAPI:
+    def test_create_returns_item(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        item = api.create("test", title="Hello")
+        assert isinstance(item, MenuBarItem)
+        assert item.name == "test"
+
+    def test_create_same_name_destroys_old(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.create("test")
+        item2 = api.create("test")
+        # Old item should have been removed from status bar
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()
+        assert api.get("test") is item2
+
+    def test_remove(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.create("test")
+        api.remove("test")
+        assert api.get("test") is None
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()
+
+    def test_remove_nonexistent_is_noop(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.remove("nope")  # should not raise
+
+    def test_get_returns_none_for_missing(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        assert api.get("nope") is None
+
+    def test_cleanup_removes_all(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.create("a")
+        api.create("b")
+        api.cleanup()
+        assert api.get("a") is None
+        assert api.get("b") is None
+        assert mock_bar.systemStatusBar.return_value.removeStatusItem_.call_count == 2
+
+
+class TestMenuBarItem:
+    def test_set_title(self, monkeypatch):
+        _, mock_ns = _patch_appkit(monkeypatch)
+        # Bypass callAfter — call directly
+        monkeypatch.setattr(
+            "wenzi.scripting.api.menubar.MenuBarItem.set_title",
+            lambda self, t: self._ns_item.setTitle_(t),
+        )
+        item = MenuBarItem("test", title="init")
+        item.set_title("updated")
+        mock_ns.setTitle_.assert_called_with("updated")
+
+    def test_set_menu_with_actions(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+
+        # Mock the statusbar callback routing
+        mock_handler = MagicMock()
+        mock_ns_to_callback = {}
+        monkeypatch.setattr(
+            "wenzi.statusbar._get_callback_handler", lambda: mock_handler
+        )
+        import wenzi.statusbar as sb
+        monkeypatch.setattr(sb, "_ns_to_callback", mock_ns_to_callback)
+
+        mock_menu = MagicMock()
+        mock_mi = MagicMock()
+        import AppKit as _appkit
+        monkeypatch.setattr(_appkit, "NSMenu", MagicMock(
+            alloc=MagicMock(return_value=MagicMock(init=MagicMock(return_value=mock_menu)))
+        ))
+        monkeypatch.setattr(_appkit, "NSMenuItem", MagicMock(
+            alloc=MagicMock(return_value=MagicMock(
+                initWithTitle_action_keyEquivalent_=MagicMock(return_value=mock_mi)
+            )),
+            separatorItem=MagicMock(return_value=MagicMock()),
+        ))
+
+        item = MenuBarItem("test")
+        clicked = []
+        item._set_menu_on_main([
+            {"title": "BTC  95000", "action": lambda: clicked.append("btc")},
+            {"separator": True},
+            {"title": "No action"},
+        ])
+
+        # Menu should have 3 items added
+        assert mock_menu.addItem_.call_count == 3
+        # Callback should be registered for the action item
+        assert len(mock_ns_to_callback) == 1
+
+    def test_destroy_cleans_up(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        mock_ns_to_callback = {}
+        import wenzi.statusbar as sb
+        monkeypatch.setattr(sb, "_ns_to_callback", mock_ns_to_callback)
+
+        item = MenuBarItem("test")
+        # Simulate having menu item refs
+        fake_mi = MagicMock()
+        item._menu_item_refs.append(fake_mi)
+        mock_ns_to_callback[id(fake_mi)] = (None, lambda: None)
+
+        item._destroy()
+
+        assert id(fake_mi) not in mock_ns_to_callback
+        assert len(item._menu_item_refs) == 0
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()


### PR DESCRIPTION
## Summary
- Add `wz.menubar` API for creating extra status-bar items from scripts
- Supports `set_title()`, `set_menu()` with click callbacks, and automatic cleanup on reload
- Add coin price ticker to `init.py` using the new API — polls Binance every 5s, shows BTC price in menubar with dropdown for ETH/BNB/SOL/LINK

## Test plan
- [x] 9 unit tests for MenuBarAPI and MenuBarItem
- [x] Lint clean (`ruff check`)
- [x] Full test suite passes (3699 tests)
- [ ] Manual test: verify BTC price appears in menubar and dropdown opens Binance

🤖 Generated with [Claude Code](https://claude.com/claude-code)