### PR TITLE
fix: defer script reload to prevent crash from chooser

### DIFF
--- a/src/wenzi/scripting/api/__init__.py
+++ b/src/wenzi/scripting/api/__init__.py
@@ -226,11 +226,22 @@ class _WZNamespace:
         _submit_and_log(coro)
 
     def reload(self) -> None:
-        """Reload all scripts."""
-        if self._reload_callback:
-            self._reload_callback()
-        else:
+        """Reload all scripts.
+
+        The actual reload is deferred to the next main-loop iteration via
+        ``AppHelper.callAfter`` so that the caller (e.g. a chooser command
+        action) can finish before the chooser API is torn down and rebuilt.
+        """
+        if not self._reload_callback:
             logger.warning("Reload not available (engine not set)")
+            return
+        try:
+            from PyObjCTools import AppHelper
+
+            AppHelper.callAfter(self._reload_callback)
+        except Exception:
+            # Fallback: call directly (shouldn't happen in a running app)
+            self._reload_callback()
 
 
 # Module-level singleton — created and set by ScriptEngine

--- a/tests/scripting/test_wz_namespace.py
+++ b/tests/scripting/test_wz_namespace.py
@@ -72,13 +72,14 @@ class TestWZNamespace:
         assert len(result) == 10
         assert result[4] == "-"
 
-    def test_reload_callback(self):
+    @patch("PyObjCTools.AppHelper")
+    def test_reload_callback(self, mock_apphelper):
+        """reload() defers the callback via AppHelper.callAfter."""
         reg = ScriptingRegistry()
         wz = _WZNamespace(reg)
-        called = []
-        wz._reload_callback = lambda: called.append(1)
+        wz._reload_callback = lambda: None
         wz.reload()
-        assert called == [1]
+        mock_apphelper.callAfter.assert_called_once_with(wz._reload_callback)
 
     @patch("wenzi.statusbar.send_notification")
     def test_notify(self, mock_send):


### PR DESCRIPTION
## Summary
- When "Reload Scripts" was invoked from the chooser command palette, `reload()` ran synchronously inside the command action handler, destroying the chooser API while it was still processing — causing a native crash with no Python traceback
- Defer the reload callback via `AppHelper.callAfter()` so the chooser action fully unwinds before the engine tears down and rebuilds

## Test plan
- [x] Existing test updated to verify `callAfter` is used
- [x] Full test suite passes (3713 passed)
- [x] Lint clean
- [ ] Manual: invoke `>Reload Scripts` from chooser — app should not exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)