### PR TITLE
refactor(snippets): move last_category storage from config to XDG data

### DIFF
--- a/src/wenzi/config.py
+++ b/src/wenzi/config.py
@@ -64,6 +64,7 @@ DEFAULT_CLIPBOARD_IMAGES_DIR = os.path.join(DEFAULT_DATA_DIR, "clipboard_images"
 DEFAULT_CHOOSER_USAGE_PATH = os.path.join(DEFAULT_DATA_DIR, "chooser_usage.json")
 DEFAULT_CHOOSER_HISTORY_PATH = os.path.join(DEFAULT_DATA_DIR, "chooser_history.json")
 DEFAULT_SCRIPT_DATA_PATH = os.path.join(DEFAULT_DATA_DIR, "script_data.json")
+DEFAULT_SNIPPET_LAST_CATEGORY_PATH = os.path.join(DEFAULT_DATA_DIR, "snippet_last_category")
 
 # Cache files (can be safely deleted and regenerated)
 DEFAULT_ICON_CACHE_DIR = os.path.join(DEFAULT_CACHE_DIR, "icon_cache")

--- a/src/wenzi/scripting/sources/snippet_source.py
+++ b/src/wenzi/scripting/sources/snippet_source.py
@@ -51,6 +51,7 @@ import re
 from typing import Dict, List, Optional, Tuple
 
 from wenzi.config import DEFAULT_SNIPPETS_DIR as _CFG_SNIPPETS_DIR
+from wenzi.config import DEFAULT_SNIPPET_LAST_CATEGORY_PATH as _CFG_LAST_CAT
 from wenzi.scripting.sources import (
     ChooserItem, ChooserSource, ModifierAction,
     copy_to_clipboard, fuzzy_match_fields, paste_text,
@@ -59,6 +60,7 @@ from wenzi.scripting.sources import (
 logger = logging.getLogger(__name__)
 
 _DEFAULT_SNIPPETS_DIR = os.path.expanduser(_CFG_SNIPPETS_DIR)
+_DEFAULT_LAST_CAT_PATH = os.path.expanduser(_CFG_LAST_CAT)
 
 _SUPPORTED_EXTENSIONS = (".md", ".txt")
 
@@ -277,8 +279,13 @@ class SnippetStore:
     categories.  Optional YAML frontmatter holds the keyword.
     """
 
-    def __init__(self, path: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        last_category_path: Optional[str] = None,
+    ) -> None:
         self._dir = path or _DEFAULT_SNIPPETS_DIR
+        self._last_cat_path = last_category_path or _DEFAULT_LAST_CAT_PATH
         self._snippets: List[Dict[str, str]] = []
         self._migrated = False
         self._cached_mtime: float = 0.0  # max mtime across directory tree
@@ -646,9 +653,8 @@ class SnippetStore:
     @property
     def last_category(self) -> str:
         """Read the last used category from disk."""
-        path = os.path.join(self._dir, ".last_category")
         try:
-            with open(path, "r", encoding="utf-8") as f:
+            with open(self._last_cat_path, "r", encoding="utf-8") as f:
                 return f.read().strip()
         except (OSError, ValueError):
             return ""
@@ -656,10 +662,9 @@ class SnippetStore:
     @last_category.setter
     def last_category(self, value: str) -> None:
         """Persist the last used category to disk."""
-        os.makedirs(self._dir, exist_ok=True)
-        path = os.path.join(self._dir, ".last_category")
+        os.makedirs(os.path.dirname(self._last_cat_path), exist_ok=True)
         try:
-            with open(path, "w", encoding="utf-8") as f:
+            with open(self._last_cat_path, "w", encoding="utf-8") as f:
                 f.write(value)
         except OSError:
             logger.exception("Failed to save last category")

--- a/tests/scripting/test_snippet_expander.py
+++ b/tests/scripting/test_snippet_expander.py
@@ -31,7 +31,8 @@ def _make_store(setup_fn=None):
     if setup_fn is not None:
         os.makedirs(snippets_dir, exist_ok=True)
         setup_fn(snippets_dir)
-    return SnippetStore(path=snippets_dir)
+    last_cat = os.path.join(tmpdir, "last_cat")
+    return SnippetStore(path=snippets_dir, last_category_path=last_cat)
 
 
 class TestBufferAndMatching:

--- a/tests/scripting/test_snippet_source.py
+++ b/tests/scripting/test_snippet_source.py
@@ -178,7 +178,8 @@ class TestSnippetStore:
         if setup_fn is not None:
             os.makedirs(snippets_dir, exist_ok=True)
             setup_fn(snippets_dir)
-        return SnippetStore(path=snippets_dir), snippets_dir, tmpdir
+        last_cat = os.path.join(tmpdir, "last_cat")
+        return SnippetStore(path=snippets_dir, last_category_path=last_cat), snippets_dir, tmpdir
 
     def test_empty_directory(self):
         store, _, _ = self._make_store()
@@ -1061,6 +1062,42 @@ class TestSplitRandomSections:
 
 
 # ---------------------------------------------------------------------------
+# Last category persistence
+# ---------------------------------------------------------------------------
+
+
+class TestSnippetStoreLastCategory:
+    def test_default_empty(self, tmp_path):
+        store = SnippetStore(
+            path=str(tmp_path / "snippets"),
+            last_category_path=str(tmp_path / "last_cat"),
+        )
+        assert store.last_category == ""
+
+    def test_roundtrip(self, tmp_path):
+        store = SnippetStore(
+            path=str(tmp_path / "snippets"),
+            last_category_path=str(tmp_path / "last_cat"),
+        )
+        store.last_category = "greetings"
+        assert store.last_category == "greetings"
+
+    def test_persists_across_instances(self, tmp_path):
+        cat_path = str(tmp_path / "last_cat")
+        store1 = SnippetStore(path=str(tmp_path / "snippets"), last_category_path=cat_path)
+        store1.last_category = "work"
+
+        store2 = SnippetStore(path=str(tmp_path / "snippets"), last_category_path=cat_path)
+        assert store2.last_category == "work"
+
+    def test_creates_parent_dirs(self, tmp_path):
+        cat_path = str(tmp_path / "nested" / "dir" / "last_cat")
+        store = SnippetStore(path=str(tmp_path / "snippets"), last_category_path=cat_path)
+        store.last_category = "test"
+        assert store.last_category == "test"
+
+
+# ---------------------------------------------------------------------------
 # Random snippet store tests
 # ---------------------------------------------------------------------------
 
@@ -1072,7 +1109,8 @@ class TestSnippetStoreRandom:
         if setup_fn is not None:
             os.makedirs(snippets_dir, exist_ok=True)
             setup_fn(snippets_dir)
-        return SnippetStore(path=snippets_dir), snippets_dir, tmpdir
+        last_cat = os.path.join(tmpdir, "last_cat")
+        return SnippetStore(path=snippets_dir, last_category_path=last_cat), snippets_dir, tmpdir
 
     def test_load_random_snippet(self):
         def setup(d):


### PR DESCRIPTION
Store snippet_last_category in ~/.local/share/WenZi/ instead of ~/.config/WenZi/snippets/.last_category, consistent with other UI state files (chooser_usage, chooser_history). Also fix test helpers to pass last_category_path with tmp_path to avoid touching real user data.