### PR TITLE
fix(recorder): prevent PortAudio use-after-free causing recording hang

### DIFF
--- a/src/wenzi/audio/recorder.py
+++ b/src/wenzi/audio/recorder.py
@@ -63,6 +63,9 @@ class Recorder:
         # on init when there is no pending close).
         self._close_done = threading.Event()
         self._close_done.set()
+        # Tracks PortAudio re-init cycles; see _close_stream().
+        self._pa_generation: int = 0
+        self._tainted: bool = False
 
     @property
     def is_recording(self) -> bool:
@@ -99,9 +102,13 @@ class Recorder:
             self._close_done.set()
 
         # --- Phase 1: claim the "starting" slot (lock held briefly) -----
+        needs_tainted_reinit = False
         with self._lock:
             if self._recording:
                 return self._last_device_name
+            if self._tainted:
+                self._tainted = False
+                needs_tainted_reinit = True
             if self._starting_since is not None:
                 elapsed = time.monotonic() - self._starting_since
                 if elapsed > self._STARTING_STALE_SECS:
@@ -117,6 +124,13 @@ class Recorder:
             self._total_bytes = 0
             device = self.device
             last_name = self._last_device_name
+
+        if needs_tainted_reinit:
+            logger.info(
+                "Recorder tainted from previous timeout, "
+                "forcing PortAudio re-init"
+            )
+            self._reinit_portaudio()
 
         # --- Phase 2: device query & PortAudio re-init (lock free) ------
         current_name: Optional[str] = None
@@ -196,11 +210,18 @@ class Recorder:
         # subsequent start() know whether cleanup has finished.
         if stream is not None:
             self._close_done.clear()
+            gen = self._pa_generation
 
             def _close_stream() -> None:
                 try:
                     stream.abort()
-                    stream.close()
+                    if self._pa_generation != gen:
+                        logger.debug(
+                            "Skipping stream.close() – PortAudio was "
+                            "re-initialized during abort"
+                        )
+                    else:
+                        stream.close()
                 except Exception as e:
                     logger.warning("Error closing audio stream: %s", e)
                 finally:
@@ -280,12 +301,23 @@ class Recorder:
             except Exception:
                 logger.debug("Audio chunk callback error", exc_info=True)
 
-    @staticmethod
-    def _reinit_portaudio() -> None:
+    def mark_tainted(self) -> None:
+        """Mark the recorder as needing a PortAudio re-init on next start().
+
+        Called by RecordingFlow when start() times out.  Clears
+        ``_starting_since`` so the next start() is not blocked by the
+        stale flag from the timed-out call.
+        """
+        with self._lock:
+            self._tainted = True
+            self._starting_since = None
+
+    def _reinit_portaudio(self) -> None:
         """Force-terminate and re-initialize PortAudio."""
         try:
             sd._terminate()
             sd._initialize()
+            self._pa_generation += 1
         except Exception:
             logger.debug("PortAudio re-init failed, continuing", exc_info=True)
 

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -75,6 +75,7 @@ class RecordingFlow:
     """Coroutine-based controller for the hotkey → record → output flow."""
 
     _DELAYED_START_SECS = 0.35
+    _START_TIMEOUT = 5.0  # seconds to wait for Recorder.start()
 
     def __init__(self, app: WenZiApp) -> None:
         self._app = app
@@ -252,9 +253,31 @@ class RecordingFlow:
                     raise _RestartSession(key_name)
 
             # ③ Start recording (blocking I/O → executor)
-            dev_name = await self._loop.run_in_executor(
-                None, app._recorder.start
-            )
+            if app._recorder.is_recording:
+                logger.warning(
+                    "Recorder unexpectedly active, "
+                    "stopping orphaned session"
+                )
+                await self._loop.run_in_executor(
+                    None, app._recorder.stop
+                )
+
+            try:
+                dev_name = await asyncio.wait_for(
+                    self._loop.run_in_executor(
+                        None, app._recorder.start
+                    ),
+                    timeout=self._START_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Recorder.start() timed out after %.0fs, "
+                    "aborting session",
+                    self._START_TIMEOUT,
+                )
+                app._recorder.mark_tainted()
+                AppHelper.callAfter(self._reset_to_idle)
+                return
             if dev_name and app._recording_indicator.show_device_name:
                 AppHelper.callAfter(
                     app._recording_indicator.update_device_name, dev_name

--- a/tests/audio/test_recorder.py
+++ b/tests/audio/test_recorder.py
@@ -271,6 +271,79 @@ class TestRecorder:
         r.stop()
 
     @patch("wenzi.audio.recorder.sd.RawInputStream")
+    @patch("wenzi.audio.recorder.sd._terminate")
+    @patch("wenzi.audio.recorder.sd._initialize")
+    def test_close_skips_stream_close_after_reinit(
+        self, mock_init, mock_term, mock_stream_cls, monkeypatch
+    ):
+        """_close_stream should skip stream.close() when PortAudio was re-initialized."""
+        monkeypatch.setattr(Recorder, "_CLOSE_WAIT_TIMEOUT", 0.01)
+
+        abort_entered = threading.Event()
+        abort_proceed = threading.Event()
+
+        mock_stream = MagicMock()
+
+        def hanging_abort():
+            abort_entered.set()
+            abort_proceed.wait()
+
+        mock_stream.abort.side_effect = hanging_abort
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._query_device_name_enabled = False
+        r.start()
+        r._queue.put(np.full(320, 500, dtype=np.int16))
+
+        initial_gen = r._pa_generation
+        r.stop()
+
+        # Wait for background thread to enter abort
+        assert abort_entered.wait(timeout=2.0)
+
+        # Simulate PortAudio re-init (as Phase 0 of a new start() would)
+        r._reinit_portaudio()
+        assert r._pa_generation == initial_gen + 1
+
+        # Unblock abort — thread should skip close()
+        abort_proceed.set()
+        assert r._close_done.wait(timeout=2.0)
+
+        # stream.close() should NOT have been called
+        mock_stream.close.assert_not_called()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    def test_mark_tainted_clears_starting_since(self, mock_stream_cls):
+        """mark_tainted() should set tainted and clear _starting_since."""
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._starting_since = time.monotonic()
+        r.mark_tainted()
+        assert r._tainted is True
+        assert r._starting_since is None
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
+    @patch("wenzi.audio.recorder.sd._terminate")
+    @patch("wenzi.audio.recorder.sd._initialize")
+    def test_tainted_recorder_reinits_on_next_start(
+        self, mock_init, mock_term, mock_stream_cls
+    ):
+        """A tainted recorder should force PortAudio re-init on next start()."""
+        mock_stream = MagicMock()
+        mock_stream_cls.return_value = mock_stream
+
+        r = Recorder(sample_rate=16000, block_ms=20)
+        r._query_device_name_enabled = False
+        r.mark_tainted()
+
+        r.start()
+        assert r.is_recording is True
+        assert r._tainted is False
+        mock_term.assert_called()
+        mock_init.assert_called()
+        r.stop()
+
+    @patch("wenzi.audio.recorder.sd.RawInputStream")
     def test_starting_flag_prevents_concurrent_start(self, mock_stream_cls):
         """A second start() should return immediately when _starting_since is set."""
         mock_stream = MagicMock()

--- a/tests/controllers/test_recording_flow.py
+++ b/tests/controllers/test_recording_flow.py
@@ -278,7 +278,8 @@ class TestCancel:
         """Cancel during recording should stop and not transcribe."""
         mock_ah.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
         mock_app._sound_manager.enabled = False
-        mock_app._recorder.is_recording = True
+        # is_recording starts False (no orphan), becomes True after start()
+        mock_app._recorder.is_recording = False
 
         async def _test():
             await flow._handle_press("fn")
@@ -469,6 +470,65 @@ class TestStreaming:
 
         # Should fall back to batch transcription
         mock_app._transcriber.transcribe.assert_called_once()
+
+
+class TestStartTimeout:
+    @patch("wenzi.controllers.recording_flow.capture_input_context", return_value=None)
+    @patch("PyObjCTools.AppHelper")
+    def test_start_timeout_resets_to_idle(
+        self, mock_ah, _mock_ic, flow, mock_app, monkeypatch
+    ):
+        """When recorder.start() times out, session should reset to idle."""
+        mock_ah.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+        mock_app._sound_manager.enabled = False
+        monkeypatch.setattr(RecordingFlow, "_START_TIMEOUT", 0.1)
+
+        def hanging_start():
+            # Block until cancelled — simulates a hung PortAudio call
+            import time
+            time.sleep(5)
+
+        mock_app._recorder.start.side_effect = hanging_start
+
+        async def _test():
+            await flow._handle_press("fn")
+            # Wait for session to finish (via timeout)
+            for _ in range(100):
+                if not flow.is_busy:
+                    break
+                await asyncio.sleep(0.05)
+
+        run(_test())
+
+        mock_app._recorder.mark_tainted.assert_called_once()
+        mock_app._recording_indicator.hide.assert_called()
+        assert not flow.is_busy
+
+    @patch("wenzi.controllers.recording_flow.capture_input_context", return_value=None)
+    @patch("PyObjCTools.AppHelper")
+    def test_orphaned_recording_cleaned_up(
+        self, mock_ah, _mock_ic, flow, mock_app
+    ):
+        """An orphaned active recording should be stopped before starting."""
+        mock_ah.callAfter = lambda fn, *a, **kw: fn(*a, **kw)
+        mock_app._sound_manager.enabled = False
+        mock_app._recorder.is_recording = True
+        mock_app._recorder.start.return_value = "TestMic"
+        mock_app._transcriber.transcribe.return_value = (
+            f"[mock from {_FILE}::test_orphaned_recording_cleaned_up]"
+        )
+
+        async def _test():
+            await flow._handle_press("fn")
+            await asyncio.sleep(0.05)
+            flow._actions.put_nowait(Action.RELEASE)
+            await flow._current_task
+
+        run(_test())
+
+        # stop() should be called twice: once for orphan cleanup,
+        # once for the normal release
+        assert mock_app._recorder.stop.call_count == 2
 
 
 class TestConfigDegraded:


### PR DESCRIPTION
## Summary

- Fix use-after-free race condition in `_close_stream` background thread: when `stream.abort()` hangs and PortAudio is force-reinitialized, the thread would call `stream.close()` on an invalidated handle, corrupting PortAudio state and causing subsequent `Recorder.start()` to hang indefinitely
- Add `_pa_generation` counter to track PortAudio re-init cycles; `_close_stream` skips `stream.close()` if generation changed during `abort()`
- Add 5s timeout on `Recorder.start()` in `RecordingFlow`; on timeout, mark recorder as tainted and reset UI to idle so the next hotkey press can recover
- Detect and clean up orphaned recordings from previously timed-out `start()` calls that eventually completed in background

## Test plan

- [x] `test_close_skips_stream_close_after_reinit` — verifies `stream.close()` is skipped when PortAudio was re-initialized during `abort()`
- [x] `test_mark_tainted_clears_starting_since` — verifies `mark_tainted()` sets flag and clears stale `_starting_since`
- [x] `test_tainted_recorder_reinits_on_next_start` — verifies tainted recorder forces PortAudio re-init on next `start()`
- [x] `test_start_timeout_resets_to_idle` — verifies recording flow resets to idle when `start()` times out
- [x] `test_orphaned_recording_cleaned_up` — verifies orphaned active recording is stopped before starting a new one
- [x] Full test suite: 3719 passed, ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)