### PR TITLE
refactor(settings): move registry cache to default cache directory

### DIFF
--- a/src/wenzi/controllers/settings_controller.py
+++ b/src/wenzi/controllers/settings_controller.py
@@ -52,7 +52,7 @@ class SettingsController:
         plugins_dir = os.path.join(app._config_dir, "plugins")
         self._plugin_registry = PluginRegistry(plugins_dir=plugins_dir)
         self._plugin_installer = PluginInstaller(plugins_dir=plugins_dir)
-        self._registry_cache_dir = os.path.join(app._config_dir, "registry_cache")
+        self._registry_cache_dir = os.path.join(app._cache_dir, "registry_cache")
         self._needs_reload = False
         self._last_plugin_infos: list[PluginInfo] = []
         self._verify_in_progress = False


### PR DESCRIPTION
## Summary
- Move plugin registry cache from `~/.config/WenZi/registry_cache` to `~/.cache/WenZi/registry_cache` to follow XDG convention — cache data belongs in the cache directory, not the config directory.

## Test plan
- [x] All 3723 tests pass
- [x] Lint clean