### PR TITLE
feat: add window-manager plugin

### DIFF
--- a/plugins/registry.toml
+++ b/plugins/registry.toml
@@ -17,3 +17,12 @@ version = "0.1.3"
 author = "WenZi"
 min_wenzi_version = "0.1.12"
 source = "https://raw.githubusercontent.com/Airead/WenZi/refs/heads/main/plugins/cc_sessions/plugin.toml"
+
+[[plugins]]
+id = "io.github.airead.wenzi.window-manager"
+name = "Window Manager"
+description = "Vim-style window snapping, centering, and multi-monitor movement"
+version = "0.1.0"
+author = "WenZi"
+min_wenzi_version = "0.1.12"
+source = "https://raw.githubusercontent.com/Airead/WenZi/refs/heads/main/plugins/window_manager/plugin.toml"

--- a/plugins/window_manager/__init__.py
+++ b/plugins/window_manager/__init__.py
@@ -1,0 +1,29 @@
+"""Window Manager — vim-style window snapping and movement.
+
+Binds Ctrl+Cmd + h/j/k/l/r/w/e to snap, center, and move
+the focused window across screens.
+"""
+
+# Default key bindings: (hotkey, action)
+_BINDINGS = [
+    ("ctrl+cmd+h", ("snap", "left")),
+    ("ctrl+cmd+l", ("snap", "right")),
+    ("ctrl+cmd+k", ("snap", "top")),
+    ("ctrl+cmd+j", ("snap", "bottom")),
+    ("ctrl+cmd+r", ("snap", "full")),
+    ("ctrl+cmd+w", ("center",)),
+    ("ctrl+cmd+e", ("move_to_screen", "next")),
+]
+
+
+def setup(wz):
+    """Entry point called by the ScriptEngine plugin loader."""
+    for hotkey, action in _BINDINGS:
+        if action[0] == "snap":
+            position = action[1]
+            wz.hotkey.bind(hotkey, lambda p=position: wz.window.snap(p))
+        elif action[0] == "center":
+            wz.hotkey.bind(hotkey, lambda: wz.window.center())
+        elif action[0] == "move_to_screen":
+            direction = action[1]
+            wz.hotkey.bind(hotkey, lambda d=direction: wz.window.move_to_screen(d))

--- a/plugins/window_manager/plugin.toml
+++ b/plugins/window_manager/plugin.toml
@@ -1,0 +1,11 @@
+[plugin]
+id = "io.github.airead.wenzi.window-manager"
+name = "Window Manager"
+description = "Vim-style window snapping, centering, and multi-monitor movement"
+version = "0.1.0"
+author = "WenZi"
+url = "https://github.com/Airead/WenZi"
+min_wenzi_version = "0.1.12"
+files = [
+    "__init__.py",
+]


### PR DESCRIPTION
## Summary
- Add `window_manager` plugin with vim-style window snapping hotkeys (ctrl+cmd + hjklrwe)
- Migrates window management bindings from user `init.py` script to an official, installable plugin
- Register plugin in `registry.toml`

## Test plan
- [ ] Install plugin and verify all 7 hotkeys work: snap left/right/top/bottom/full, center, move to next screen
- [ ] Confirm no conflicts when window management lines are removed from `~/.config/WenZi/scripts/init.py`
- [ ] Verify plugin loads cleanly after `wz.reload()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)