### PR TITLE
fix: prevent menubar items from disappearing on script reload

### DIFF
--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -728,6 +728,15 @@ class WenZiApp(StatusBarApp):
         else:
             self.title = display_text  # fallback to text-only if SF Symbols unavailable
 
+    def _refresh_status_bar(self) -> None:
+        """Re-apply the current status to the menubar icon.
+
+        Called on the next run-loop iteration after a script reload so
+        that macOS re-renders the status item even if the internal
+        NSStatusBar layout dropped it during the reload cycle.
+        """
+        self._set_status(self._current_status)
+
     def _start_recording_indicator(self) -> None:
         self._recording_controller.start_recording_indicator()
 
@@ -1455,6 +1464,9 @@ class WenZiApp(StatusBarApp):
 
             self._script_engine.set_system_settings_open_callback(
                 self._usage_stats.record_system_settings_open
+            )
+            self._script_engine.set_post_reload_callback(
+                self._refresh_status_bar
             )
 
         # Start clipboard enhance hotkey listener if configured

--- a/src/wenzi/scripting/api/menubar.py
+++ b/src/wenzi/scripting/api/menubar.py
@@ -15,6 +15,7 @@ class MenuBarItem:
         from AppKit import NSStatusBar
 
         self._name = name
+        self._destroyed = False
         self._ns_item = NSStatusBar.systemStatusBar().statusItemWithLength_(-1)
         self._ns_item.setTitle_(title)
         self._menu_item_refs: list = []  # prevent GC of NSMenuItems
@@ -25,9 +26,16 @@ class MenuBarItem:
 
     def set_title(self, title: str) -> None:
         """Update the status-bar title (main-thread safe)."""
+        if self._destroyed:
+            return
         from PyObjCTools import AppHelper
 
-        AppHelper.callAfter(lambda: self._ns_item.setTitle_(title))
+        AppHelper.callAfter(lambda: self._set_title_on_main(title))
+
+    def _set_title_on_main(self, title: str) -> None:
+        if self._destroyed:
+            return
+        self._ns_item.setTitle_(title)
 
     def set_menu(self, items: list[dict]) -> None:
         """Set the dropdown menu.
@@ -35,11 +43,15 @@ class MenuBarItem:
         Each dict: ``{"title": str, "action": callable}``
         or ``{"separator": True}``.
         """
+        if self._destroyed:
+            return
         from PyObjCTools import AppHelper
 
         AppHelper.callAfter(lambda: self._set_menu_on_main(items))
 
     def _set_menu_on_main(self, items: list[dict]) -> None:
+        if self._destroyed:
+            return
         from AppKit import NSMenu, NSMenuItem
         from wenzi.statusbar import _get_callback_handler, _ns_to_callback
 
@@ -73,8 +85,21 @@ class MenuBarItem:
 
         self._ns_item.setMenu_(menu)
 
+    def _reset(self, title: str = "") -> None:
+        """Reclaim a stale item: clear menu, reset title, mark alive."""
+        from wenzi.statusbar import _ns_to_callback
+
+        self._destroyed = False
+        # Clean up old menu callbacks
+        for mi in self._menu_item_refs:
+            _ns_to_callback.pop(id(mi), None)
+        self._menu_item_refs.clear()
+        self._ns_item.setMenu_(None)
+        self._ns_item.setTitle_(title)
+
     def _destroy(self) -> None:
         """Remove this item from the status bar and clean up callbacks."""
+        self._destroyed = True
         from AppKit import NSStatusBar
         from wenzi.statusbar import _ns_to_callback
 
@@ -89,11 +114,18 @@ class MenuBarAPI:
 
     def __init__(self) -> None:
         self._items: dict[str, MenuBarItem] = {}
+        self._stale: dict[str, MenuBarItem] = {}
 
     def create(self, name: str, title: str = "") -> MenuBarItem:
         """Create (or recreate) a named status-bar item."""
         if name in self._items:
             self._items[name]._destroy()
+        # Reuse a stale item from the previous cycle if available
+        stale = self._stale.pop(name, None)
+        if stale is not None:
+            stale._reset(title)
+            self._items[name] = stale
+            return stale
         item = MenuBarItem(name, title)
         self._items[name] = item
         return item
@@ -108,6 +140,21 @@ class MenuBarAPI:
         """Return an existing item by name, or None."""
         return self._items.get(name)
 
+    def prepare_reload(self) -> None:
+        """Move all current items to the stale pool for reuse.
+
+        Called before scripts reload. Items stay visible in the status bar
+        and can be reclaimed by ``create()`` during the reload cycle.
+        """
+        self._stale.update(self._items)
+        self._items.clear()
+
+    def finish_reload(self) -> None:
+        """Destroy stale items that were not reclaimed during reload."""
+        for item in self._stale.values():
+            item._destroy()
+        self._stale.clear()
+
     def cleanup(self) -> None:
         """Remove all script-created status-bar items.
 
@@ -116,3 +163,6 @@ class MenuBarAPI:
         for item in self._items.values():
             item._destroy()
         self._items.clear()
+        for item in self._stale.values():
+            item._destroy()
+        self._stale.clear()

--- a/src/wenzi/scripting/engine.py
+++ b/src/wenzi/scripting/engine.py
@@ -45,6 +45,7 @@ class ScriptEngine:
         self._system_settings_source = None
         self._system_settings_open_cb: Optional[Callable[[], None]] = None
         self._reloading = False
+        self._post_reload_callback: Optional[Callable[[], None]] = None
         self._plugin_metas: Dict[str, PluginMeta] = {}
         self._plugin_load_errors: Dict[str, Dict[str, str]] = {}
 
@@ -134,12 +135,15 @@ class ScriptEngine:
             self._wz._hotkey_api = None
             self._wz._chooser_api = None
             self._wz._ui_api = None
+            # Keep menubar items alive for reuse (avoids NSStatusBar flicker)
             if self._wz._menubar_api is not None:
-                self._wz._menubar_api.cleanup()
-                self._wz._menubar_api = None
+                self._wz._menubar_api.prepare_reload()
             self._register_builtin_sources()
             self._load_plugins()
             self._load_scripts()
+            # Destroy any menubar items that scripts didn't reclaim
+            if self._wz._menubar_api is not None:
+                self._wz._menubar_api.finish_reload()
             self._bind_chooser_hotkey()
             self._bind_source_hotkeys()
             self._bind_new_snippet_hotkey()
@@ -153,6 +157,13 @@ class ScriptEngine:
                 )
             else:
                 self._try_alert("Scripts reloaded", duration=1.5)
+            # Notify the app to refresh its own status-bar item.
+            # Deferred to the next run-loop iteration so that
+            # NSStatusBar has finished laying out script-created items.
+            if self._post_reload_callback is not None:
+                from PyObjCTools import AppHelper
+
+                AppHelper.callAfter(self._post_reload_callback)
         finally:
             self._reloading = False
 
@@ -251,6 +262,14 @@ class ScriptEngine:
         self._wz.pasteboard._set_monitor(None)
         self._wz.chooser.unregister_source("clipboard")
         logger.info("Clipboard monitor disabled at runtime")
+
+    def set_post_reload_callback(self, callback: Callable[[], None]) -> None:
+        """Set a callback invoked after each script reload completes.
+
+        The callback is deferred via ``callAfter`` so it runs on the next
+        run-loop iteration, after NSStatusBar has finished its layout pass.
+        """
+        self._post_reload_callback = callback
 
     def set_system_settings_open_callback(
         self, callback: Callable[[], None]

--- a/tests/scripting/test_api_menubar.py
+++ b/tests/scripting/test_api_menubar.py
@@ -64,6 +64,99 @@ class TestMenuBarAPI:
         assert mock_bar.systemStatusBar.return_value.removeStatusItem_.call_count == 2
 
 
+class TestMenuBarReload:
+    """Tests for the prepare_reload / finish_reload stale-pool mechanism."""
+
+    def test_prepare_reload_moves_items_to_stale(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        item = api.create("prices")
+        api.prepare_reload()
+        # Item is no longer in active set
+        assert api.get("prices") is None
+        # But it's in the stale pool (not destroyed)
+        assert item._destroyed is False
+        assert "prices" in api._stale
+
+    def test_create_reclaims_stale_item(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        original = api.create("prices", title="old")
+        ns_item = original._ns_item
+
+        api.prepare_reload()
+        reclaimed = api.create("prices", title="new")
+
+        # Same underlying object — no removeStatusItem_ called
+        assert reclaimed is original
+        assert reclaimed._ns_item is ns_item
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_not_called()
+        # Title updated via _reset
+        ns_item.setTitle_.assert_called_with("new")
+        # Stale pool is empty
+        assert "prices" not in api._stale
+
+    def test_finish_reload_destroys_unreclaimed(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        item = api.create("old_item")
+
+        api.prepare_reload()
+        # Don't reclaim — simulate script no longer creating this item
+        api.finish_reload()
+
+        assert item._destroyed is True
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()
+        assert len(api._stale) == 0
+
+    def test_finish_reload_keeps_reclaimed(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.create("keep")
+        api.create("drop")
+
+        api.prepare_reload()
+        reclaimed = api.create("keep", title="refreshed")
+        api.finish_reload()
+
+        # "keep" reclaimed, "drop" destroyed
+        assert api.get("keep") is reclaimed
+        assert reclaimed._destroyed is False
+        mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()
+
+    def test_cleanup_also_clears_stale(self, monkeypatch):
+        mock_bar, _ = _patch_appkit(monkeypatch)
+        api = MenuBarAPI()
+        api.create("a")
+        api.prepare_reload()
+        api.create("b")
+        api.cleanup()
+        assert len(api._items) == 0
+        assert len(api._stale) == 0
+        # "a" (stale) + "b" (active) both destroyed
+        assert mock_bar.systemStatusBar.return_value.removeStatusItem_.call_count == 2
+
+    def test_reset_clears_old_callbacks(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        mock_ns_to_callback = {}
+        import wenzi.statusbar as sb
+        monkeypatch.setattr(sb, "_ns_to_callback", mock_ns_to_callback)
+
+        api = MenuBarAPI()
+        item = api.create("test")
+        # Simulate having menu item refs from previous cycle
+        fake_mi = MagicMock()
+        item._menu_item_refs.append(fake_mi)
+        mock_ns_to_callback[id(fake_mi)] = (None, lambda: None)
+
+        api.prepare_reload()
+        api.create("test", title="fresh")
+
+        # Old callbacks should be cleaned up by _reset
+        assert id(fake_mi) not in mock_ns_to_callback
+        assert len(item._menu_item_refs) == 0
+
+
 class TestMenuBarItem:
     def test_set_title(self, monkeypatch):
         _, mock_ns = _patch_appkit(monkeypatch)
@@ -128,6 +221,56 @@ class TestMenuBarItem:
 
         item._destroy()
 
+        assert item._destroyed is True
         assert id(fake_mi) not in mock_ns_to_callback
         assert len(item._menu_item_refs) == 0
         mock_bar.systemStatusBar.return_value.removeStatusItem_.assert_called_once()
+
+    def test_set_title_noop_after_destroy(self, monkeypatch):
+        _, mock_ns = _patch_appkit(monkeypatch)
+        call_after_calls = []
+        monkeypatch.setattr(
+            "PyObjCTools.AppHelper.callAfter",
+            lambda fn, *a: call_after_calls.append(fn),
+        )
+        item = MenuBarItem("test", title="init")
+        item._destroy()
+        mock_ns.setTitle_.reset_mock()
+
+        item.set_title("should not happen")
+        assert call_after_calls == []
+
+    def test_set_title_on_main_noop_after_destroy(self, monkeypatch):
+        _, mock_ns = _patch_appkit(monkeypatch)
+        item = MenuBarItem("test", title="init")
+        item._destroy()
+        mock_ns.setTitle_.reset_mock()
+
+        item._set_title_on_main("should not happen")
+        mock_ns.setTitle_.assert_not_called()
+
+    def test_set_menu_noop_after_destroy(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        call_after_calls = []
+        monkeypatch.setattr(
+            "PyObjCTools.AppHelper.callAfter",
+            lambda fn, *a: call_after_calls.append(fn),
+        )
+        item = MenuBarItem("test")
+        item._destroy()
+
+        item.set_menu([{"title": "X", "action": lambda: None}])
+        assert call_after_calls == []
+
+    def test_set_menu_on_main_noop_after_destroy(self, monkeypatch):
+        _patch_appkit(monkeypatch)
+        mock_ns_to_callback = {}
+        import wenzi.statusbar as sb
+        monkeypatch.setattr(sb, "_ns_to_callback", mock_ns_to_callback)
+
+        item = MenuBarItem("test")
+        item._destroy()
+
+        item._set_menu_on_main([{"title": "X", "action": lambda: None}])
+        # No callbacks should have been registered
+        assert len(mock_ns_to_callback) == 0


### PR DESCRIPTION
## Summary

- **Stale-pool reuse**: Instead of destroying and recreating NSStatusItems during script reload, items are moved to a stale pool (`prepare_reload`) and reclaimed by `create()` via `_reset()`. Only items scripts no longer use are destroyed after reload (`finish_reload`). This avoids the NSStatusBar layout glitch caused by rapid `removeStatusItem_` + `statusItemWithLength_`.
- **Destroyed guard**: `MenuBarItem` now has a `_destroyed` flag that prevents stale `callAfter` operations (from old timer callbacks) from calling `setTitle_`/`setMenu_` on removed items.
- **Post-reload refresh**: The engine now invokes a deferred callback after reload that re-applies the main app's status icon, forcing macOS to re-render it on the next run-loop iteration.

## Test plan

- [ ] Run `uv run pytest tests/scripting/test_api_menubar.py -v` — 19 tests covering stale-pool, destroyed guard, and cleanup
- [ ] Run full suite `uv run pytest tests/ -v` — all 3750 tests pass
- [ ] Manual: open WenZi with a script that creates a menubar item (e.g. crypto ticker), run "reload scripts" multiple times, verify both voice icon and crypto ticker persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)