### PR TITLE
feat(chooser): add built-in WenZi Settings command

### DIFF
--- a/src/wenzi/scripting/api/chooser.py
+++ b/src/wenzi/scripting/api/chooser.py
@@ -99,6 +99,8 @@ class ChooserAPI:
             self._register_quit_all_command()
         if "reload" not in self._command_source._commands:
             self._register_reload_command()
+        if "settings" not in self._command_source._commands:
+            self._register_settings_command()
 
     def _register_help_command(self) -> None:
         """Register the built-in help command."""
@@ -188,6 +190,25 @@ class ChooserAPI:
                 title="Reload Scripts",
                 subtitle="Reload all scripts and plugins",
                 action=_reload_action,
+                promoted=True,
+            )
+        )
+
+    def _register_settings_command(self) -> None:
+        """Register the built-in WenZi Settings command."""
+
+        def _settings_action(args: str) -> None:
+            from PyObjCTools import AppHelper
+
+            AppHelper.callAfter(self._fire_event, "openSettings")
+
+        self._command_source.register(
+            CommandEntry(
+                name="settings",
+                title="WenZi Settings",
+                subtitle="Open WenZi preferences",
+                icon="⚙️",
+                action=_settings_action,
                 promoted=True,
             )
         )


### PR DESCRIPTION
## Summary
- Add a promoted "WenZi Settings" command to the chooser command palette
- Selecting it opens the WenZi preferences panel (same as Cmd+,)
- Appears in both prefixed (`> settings`) and unprefixed search

## Test plan
- [x] Existing chooser API and command source tests pass (89/89)
- [ ] Open chooser, type "settings", verify "WenZi Settings" item appears
- [ ] Select and press Enter, verify settings panel opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)