### PR TITLE
feat(window): add list, focus, and close APIs

### DIFF
--- a/src/wenzi/scripting/api/window.py
+++ b/src/wenzi/scripting/api/window.py
@@ -1,8 +1,9 @@
-"""Window management API — move, resize, and snap the focused window."""
+"""Window management API — move, resize, snap, list, focus, and close windows."""
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -60,6 +61,34 @@ def _get_focused_window():
         front_app.localizedName(), pid, win,
     )
     return win
+
+
+def _get_windows_for_pid(pid: int):
+    """Return the AXWindows array for a given PID, or None."""
+    from ApplicationServices import (
+        AXUIElementCreateApplication,
+        AXUIElementCopyAttributeValue,
+        kAXErrorSuccess,
+    )
+
+    ax_app = AXUIElementCreateApplication(pid)
+    err, windows = AXUIElementCopyAttributeValue(ax_app, "AXWindows", None)
+    if err != kAXErrorSuccess or not windows:
+        return None
+    return windows
+
+
+def _get_window_title(win) -> str:
+    """Return the AXTitle of a window, or empty string."""
+    from ApplicationServices import (
+        AXUIElementCopyAttributeValue,
+        kAXErrorSuccess,
+    )
+
+    err, title = AXUIElementCopyAttributeValue(win, "AXTitle", None)
+    if err != kAXErrorSuccess or title is None:
+        return ""
+    return str(title)
 
 
 def _get_position(win) -> Optional[tuple]:
@@ -306,3 +335,106 @@ class WindowAPI:
         new_h = rel_h * nsh
 
         _apply_frame(win, new_x, new_y, new_w, new_h)
+
+    def list(self) -> list[dict]:
+        """Return info about all open windows across all applications.
+
+        Each dict has ``app_name``, ``title``, ``pid``, ``window_index``,
+        and ``app_path``.  Windows without a title are skipped (utility
+        windows, hidden panels, etc.).
+        """
+        from AppKit import (
+            NSApplicationActivationPolicyRegular,
+            NSWorkspace,
+        )
+
+        result = []
+        own_pid = os.getpid()
+        workspace = NSWorkspace.sharedWorkspace()
+
+        for app in workspace.runningApplications():
+            if app.activationPolicy() != NSApplicationActivationPolicyRegular:
+                continue
+            pid = app.processIdentifier()
+            if pid == own_pid:
+                continue
+            app_name = app.localizedName() or ""
+            bundle_url = app.bundleURL()
+            app_path = str(bundle_url.path()) if bundle_url else ""
+
+            windows = _get_windows_for_pid(pid)
+            if not windows:
+                continue
+
+            for idx, win in enumerate(windows):
+                title = _get_window_title(win)
+                if not title:
+                    continue
+                result.append({
+                    "app_name": app_name,
+                    "title": title,
+                    "pid": pid,
+                    "window_index": idx,
+                    "app_path": app_path,
+                })
+        return result
+
+    def focus(self, pid: int, window_index: int = 0) -> bool:
+        """Bring the specified window to the front.
+
+        Args:
+            pid: Process ID of the application.
+            window_index: Index in the app's ``AXWindows`` array.
+
+        Returns:
+            True if the window was raised successfully.
+        """
+        from AppKit import NSWorkspace
+        from ApplicationServices import AXUIElementPerformAction
+
+        windows = _get_windows_for_pid(pid)
+        if not windows or window_index >= len(windows):
+            logger.debug("focus: no window for pid=%s idx=%s", pid, window_index)
+            return False
+
+        AXUIElementPerformAction(windows[window_index], "AXRaise")
+
+        # Activate the owning application
+        for app in NSWorkspace.sharedWorkspace().runningApplications():
+            if app.processIdentifier() == pid:
+                # NSApplicationActivateIgnoringOtherApps = 1 << 1 = 2
+                app.activateWithOptions_(2)
+                break
+        return True
+
+    def close(self, pid: int, window_index: int = 0) -> bool:
+        """Close the specified window via its AXCloseButton.
+
+        Args:
+            pid: Process ID of the application.
+            window_index: Index in the app's ``AXWindows`` array.
+
+        Returns:
+            True if the close button was pressed successfully.
+        """
+        from ApplicationServices import (
+            AXUIElementCopyAttributeValue,
+            AXUIElementPerformAction,
+            kAXErrorSuccess,
+        )
+
+        windows = _get_windows_for_pid(pid)
+        if not windows or window_index >= len(windows):
+            logger.debug("close: no window for pid=%s idx=%s", pid, window_index)
+            return False
+
+        win = windows[window_index]
+        err, close_btn = AXUIElementCopyAttributeValue(
+            win, "AXCloseButton", None,
+        )
+        if err != kAXErrorSuccess or close_btn is None:
+            logger.debug("close: no AXCloseButton for pid=%s idx=%s", pid, window_index)
+            return False
+
+        AXUIElementPerformAction(close_btn, "AXPress")
+        return True

--- a/tests/scripting/test_api_window.py
+++ b/tests/scripting/test_api_window.py
@@ -6,6 +6,8 @@ import pytest
 
 from wenzi.scripting.api.window import (
     WindowAPI,
+    _get_window_title,
+    _get_windows_for_pid,
     _unzoom_if_needed,
     _visible_frame_ax,
 )
@@ -345,3 +347,256 @@ class TestVisibleFrameAx:
         assert y == 0
         assert w == 1920
         assert h == 1055
+
+
+# ---------------------------------------------------------------------------
+# Helpers for list / focus / close
+# ---------------------------------------------------------------------------
+
+def _make_running_app(pid, name="TestApp", policy=0, bundle_path="/Applications/Test.app"):
+    """Create a fake NSRunningApplication."""
+    app = MagicMock()
+    app.processIdentifier.return_value = pid
+    app.localizedName.return_value = name
+    app.activationPolicy.return_value = policy
+    bundle_url = MagicMock()
+    bundle_url.path.return_value = bundle_path
+    app.bundleURL.return_value = bundle_url
+    return app
+
+
+def _patch_workspace_apps(monkeypatch, apps):
+    """Patch NSWorkspace.sharedWorkspace().runningApplications()."""
+    import AppKit as _appkit
+
+    workspace = MagicMock()
+    workspace.runningApplications.return_value = apps
+    ns_workspace = MagicMock()
+    ns_workspace.sharedWorkspace.return_value = workspace
+    monkeypatch.setattr(_appkit, "NSWorkspace", ns_workspace)
+    return workspace
+
+
+# ---------------------------------------------------------------------------
+# Tests: list / focus / close
+# ---------------------------------------------------------------------------
+
+class TestList:
+    def test_returns_windows(self, monkeypatch):
+        win1 = MagicMock(name="win1")
+        win2 = MagicMock(name="win2")
+        app = _make_running_app(100, "Safari", bundle_path="/Applications/Safari.app")
+        _patch_workspace_apps(monkeypatch, [app])
+
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [win1, win2] if pid == 100 else None,
+        )
+        titles = {"win1": "Google", "win2": "GitHub"}
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_window_title",
+            lambda w: titles.get(w._mock_name, ""),
+        )
+        monkeypatch.setattr("wenzi.scripting.api.window.os.getpid", lambda: 999)
+
+        result = WindowAPI().list()
+
+        assert len(result) == 2
+        assert result[0] == {
+            "app_name": "Safari",
+            "title": "Google",
+            "pid": 100,
+            "window_index": 0,
+            "app_path": "/Applications/Safari.app",
+        }
+        assert result[1]["title"] == "GitHub"
+        assert result[1]["window_index"] == 1
+
+    def test_skips_own_process(self, monkeypatch):
+        app = _make_running_app(42, "WenZi")
+        _patch_workspace_apps(monkeypatch, [app])
+        monkeypatch.setattr("wenzi.scripting.api.window.os.getpid", lambda: 42)
+
+        result = WindowAPI().list()
+        assert result == []
+
+    def test_skips_non_regular_apps(self, monkeypatch):
+        # policy=1 → NSApplicationActivationPolicyAccessory
+        app = _make_running_app(100, "Daemon", policy=1)
+        _patch_workspace_apps(monkeypatch, [app])
+        monkeypatch.setattr("wenzi.scripting.api.window.os.getpid", lambda: 999)
+
+        result = WindowAPI().list()
+        assert result == []
+
+    def test_skips_windows_without_title(self, monkeypatch):
+        win = MagicMock(name="untitled")
+        app = _make_running_app(100, "Foo")
+        _patch_workspace_apps(monkeypatch, [app])
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [win],
+        )
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_window_title",
+            lambda w: "",
+        )
+        monkeypatch.setattr("wenzi.scripting.api.window.os.getpid", lambda: 999)
+
+        result = WindowAPI().list()
+        assert result == []
+
+    def test_skips_apps_with_no_windows(self, monkeypatch):
+        app = _make_running_app(100, "Empty")
+        _patch_workspace_apps(monkeypatch, [app])
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: None,
+        )
+        monkeypatch.setattr("wenzi.scripting.api.window.os.getpid", lambda: 999)
+
+        result = WindowAPI().list()
+        assert result == []
+
+
+class TestFocus:
+    def test_raises_and_activates(self, monkeypatch):
+        import ApplicationServices as _as
+
+        win = MagicMock(name="target")
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [win] if pid == 100 else None,
+        )
+        perform_calls = []
+        monkeypatch.setattr(
+            _as, "AXUIElementPerformAction",
+            lambda w, action: perform_calls.append((w, action)),
+        )
+        app = _make_running_app(100, "Safari")
+        _patch_workspace_apps(monkeypatch, [app])
+
+        result = WindowAPI().focus(100, 0)
+
+        assert result is True
+        assert perform_calls == [(win, "AXRaise")]
+        app.activateWithOptions_.assert_called_once_with(2)
+
+    def test_returns_false_no_windows(self, monkeypatch):
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: None,
+        )
+        assert WindowAPI().focus(100) is False
+
+    def test_returns_false_bad_index(self, monkeypatch):
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [MagicMock()],
+        )
+        assert WindowAPI().focus(100, window_index=5) is False
+
+
+class TestClose:
+    def test_presses_close_button(self, monkeypatch):
+        import ApplicationServices as _as
+
+        win = MagicMock(name="win")
+        close_btn = MagicMock(name="close_btn")
+
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [win] if pid == 100 else None,
+        )
+
+        def fake_copy(element, attr, _):
+            if element is win and attr == "AXCloseButton":
+                return (_as.kAXErrorSuccess, close_btn)
+            return (-1, None)
+
+        monkeypatch.setattr(_as, "AXUIElementCopyAttributeValue", fake_copy)
+
+        perform_calls = []
+        monkeypatch.setattr(
+            _as, "AXUIElementPerformAction",
+            lambda w, action: perform_calls.append((w, action)),
+        )
+
+        result = WindowAPI().close(100, 0)
+
+        assert result is True
+        assert perform_calls == [(close_btn, "AXPress")]
+
+    def test_returns_false_no_close_button(self, monkeypatch):
+        import ApplicationServices as _as
+
+        win = MagicMock()
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: [win],
+        )
+        monkeypatch.setattr(
+            _as, "AXUIElementCopyAttributeValue",
+            lambda w, attr, _: (-1, None),
+        )
+
+        assert WindowAPI().close(100, 0) is False
+
+    def test_returns_false_no_windows(self, monkeypatch):
+        monkeypatch.setattr(
+            "wenzi.scripting.api.window._get_windows_for_pid",
+            lambda pid: None,
+        )
+        assert WindowAPI().close(100) is False
+
+
+class TestGetWindowsForPid:
+    def test_returns_windows(self, monkeypatch):
+        import ApplicationServices as _as
+
+        win_list = [MagicMock(), MagicMock()]
+        monkeypatch.setattr(
+            _as, "AXUIElementCreateApplication",
+            lambda pid: MagicMock(),
+        )
+        monkeypatch.setattr(
+            _as, "AXUIElementCopyAttributeValue",
+            lambda app, attr, _: (_as.kAXErrorSuccess, win_list),
+        )
+
+        result = _get_windows_for_pid(42)
+        assert result is win_list
+
+    def test_returns_none_on_error(self, monkeypatch):
+        import ApplicationServices as _as
+
+        monkeypatch.setattr(
+            _as, "AXUIElementCreateApplication",
+            lambda pid: MagicMock(),
+        )
+        monkeypatch.setattr(
+            _as, "AXUIElementCopyAttributeValue",
+            lambda app, attr, _: (-1, None),
+        )
+
+        assert _get_windows_for_pid(42) is None
+
+
+class TestGetWindowTitle:
+    def test_returns_title(self, monkeypatch):
+        import ApplicationServices as _as
+
+        monkeypatch.setattr(
+            _as, "AXUIElementCopyAttributeValue",
+            lambda w, attr, _: (_as.kAXErrorSuccess, "My Window"),
+        )
+        assert _get_window_title(MagicMock()) == "My Window"
+
+    def test_returns_empty_on_error(self, monkeypatch):
+        import ApplicationServices as _as
+
+        monkeypatch.setattr(
+            _as, "AXUIElementCopyAttributeValue",
+            lambda w, attr, _: (-1, None),
+        )
+        assert _get_window_title(MagicMock()) == ""


### PR DESCRIPTION
## Summary
- Add `list()`, `focus(pid, window_index)`, and `close(pid, window_index)` to `WindowAPI` (`wz.window`)
- `list()` enumerates all open windows across running applications via the Accessibility API
- `focus()` raises a specific window and activates its owning app
- `close()` presses the window's AXCloseButton
- 15 new tests covering all methods and edge cases (39 total in test file)

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/scripting/test_api_window.py -v` — 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)