### PR TITLE
feat(dictionary): open definition in standalone window on Enter

### DIFF
--- a/plugins/dictionary/__init__.py
+++ b/plugins/dictionary/__init__.py
@@ -16,24 +16,66 @@ def _detect_direction(query: str) -> str:
     return "en2zh-CHS"
 
 
+def _wrap_html(content: str) -> str:
+    """Wrap dictionary HTML with CSS variables for standalone window."""
+    return (
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><style>"
+        ":root{--bg:#f5f5f7;--text:#1d1d1f;--secondary:#86868b;--border:#d2d2d7}"
+        "@media(prefers-color-scheme:dark)"
+        "{:root{--bg:#2c2c2e;--text:#e5e5e7;--secondary:#98989d;--border:#48484a}}"
+        "body{font-family:-apple-system,sans-serif;background:var(--bg);"
+        "color:var(--text);padding:16px;}"
+        "</style></head><body>" + content + "</body></html>"
+    )
+
+
 def setup(wz) -> None:
     """Register the dictionary chooser source."""
     from .render import render_definition
     from .youdao import lookup, suggest
 
-    def _make_preview(word: str, direction: str):
-        """Return a lazy callable for the preview panel."""
-        def _load():
-            data = lookup(word, direction)
-            if not data:
-                return {
-                    "type": "html",
-                    "content": f'<div style="color:var(--secondary);'
-                    f'text-align:center;padding:40px">'
-                    f"Failed to load definition for <b>{_esc(word)}</b></div>",
-                }
-            return {"type": "html", "content": render_definition(data, word)}
-        return _load
+    _panel_ref = [None]
+
+    def _make_preview_and_action(word: str, direction: str):
+        """Return (preview_callable, action_callable) sharing a lookup cache."""
+        _cache = {}
+
+        def _load_html():
+            if "html" not in _cache:
+                data = lookup(word, direction)
+                if data:
+                    _cache["html"] = render_definition(data, word)
+                else:
+                    _cache["html"] = (
+                        f'<div style="color:var(--secondary);'
+                        f'text-align:center;padding:40px">'
+                        f"Failed to load definition for <b>{_esc(word)}</b></div>"
+                    )
+            return _cache["html"]
+
+        def _preview():
+            return {"type": "html", "content": _load_html()}
+
+        def _action():
+            html = _load_html()
+            if not html:
+                return
+            if _panel_ref[0] is not None:
+                try:
+                    _panel_ref[0].close()
+                except Exception:
+                    pass
+            panel = wz.ui.webview_panel(
+                title=word,
+                html=_wrap_html(html),
+                width=500,
+                height=600,
+                floating=True,
+            )
+            panel.show()
+            _panel_ref[0] = panel
+
+        return _preview, _action
 
     @wz.chooser.source(
         "dictionary",
@@ -41,7 +83,7 @@ def setup(wz) -> None:
         priority=5,
         description="Youdao Dictionary (EN↔ZH)",
         show_preview=True,
-        action_hints={"enter": "Dismiss"},
+        action_hints={"enter": "Open"},
         search_timeout=5.0,
         debounce_delay=0.2,
     )
@@ -57,7 +99,9 @@ def setup(wz) -> None:
             {
                 "title": entry["word"],
                 "subtitle": entry.get("explain", ""),
-                "preview": _make_preview(entry["word"], direction),
+                "preview": preview,
+                "action": action,
             }
             for entry in results
+            for preview, action in [_make_preview_and_action(entry["word"], direction)]
         ]


### PR DESCRIPTION
## Summary
- Pressing Enter on a dictionary candidate now opens the preview in a standalone floating window via `wz.ui.webview_panel()`, instead of just dismissing the chooser
- Preview and action share a lookup cache (`_cache` dict) to avoid redundant Youdao API calls
- Standalone window wraps HTML with light/dark mode CSS variables matching the chooser theme
- Single-panel management: opening a new definition closes the previous window

## Test plan
- [ ] Open chooser, type `d hello`, browse candidates — preview still works in the chooser panel
- [ ] Press Enter on a candidate — a floating 500x600 window appears with the full definition
- [ ] Press Enter on another word — the previous window closes, new one opens
- [ ] Verify dark mode rendering in the standalone window
- [ ] Verify audio pronunciation buttons work in the standalone window

🤖 Generated with [Claude Code](https://claude.com/claude-code)