### PR TITLE
feat(scripting): add toggle_leader() for sticky leader-key mode

### DIFF
--- a/src/wenzi/scripting/api/hotkey.py
+++ b/src/wenzi/scripting/api/hotkey.py
@@ -22,6 +22,8 @@ class HotkeyAPI:
         self._listener = None  # _QuartzAllKeysListener
         self._active_leader: Optional[LeaderConfig] = None
         self._leader_triggered: bool = False
+        self._sticky_leader: bool = False
+        self._click_monitor = None
         self._lock = threading.Lock()
         self._started = False
 
@@ -91,6 +93,46 @@ class HotkeyAPI:
         if entry and self._registry.remap_listener:
             self._registry.remap_listener.remove(source_vk)
 
+    def toggle_leader(self, trigger_key: str) -> None:
+        """Toggle leader mode for *trigger_key* (sticky — stays open until dismissed).
+
+        If the same leader is already active in sticky mode, close it.
+        Otherwise, show the leader panel and enter sticky mode where the
+        panel remains visible until a sub-key, Esc, or mouse click dismisses it.
+        """
+        with self._lock:
+            if (
+                self._active_leader is not None
+                and self._sticky_leader
+                and self._active_leader.trigger_key == trigger_key
+            ):
+                self._active_leader = None
+                self._sticky_leader = False
+                self._leader_triggered = False
+                try:
+                    from PyObjCTools import AppHelper
+
+                    AppHelper.callAfter(self._close_leader_ui)
+                except Exception:
+                    pass
+                return
+
+            if trigger_key not in self._registry.leaders:
+                logger.warning("toggle_leader: no leader registered for %s", trigger_key)
+                return
+
+            self._active_leader = self._registry.leaders[trigger_key]
+            self._leader_triggered = False
+            self._sticky_leader = True
+
+        try:
+            from PyObjCTools import AppHelper
+
+            leader = self._active_leader
+            AppHelper.callAfter(self._show_sticky_leader, leader)
+        except Exception:
+            pass
+
     def start(self) -> None:
         """Start all hotkey and leader-key listeners."""
         self._started = True
@@ -115,11 +157,12 @@ class HotkeyAPI:
         with self._lock:
             self._active_leader = None
             self._leader_triggered = False
-        # Close leader alert panel (may be called from background thread)
+            self._sticky_leader = False
+        # Close leader alert panel and stop click monitor
         try:
             from PyObjCTools import AppHelper
 
-            AppHelper.callAfter(self._leader_alert.close)
+            AppHelper.callAfter(self._close_leader_ui)
         except Exception:
             pass
         logger.info("Hotkey API stopped")
@@ -188,15 +231,102 @@ class HotkeyAPI:
         if not listener.is_running():
             listener.start()
 
+    # ------------------------------------------------------------------
+    # Sticky leader helpers (main-thread only)
+    # ------------------------------------------------------------------
+
+    def _show_sticky_leader(self, leader: LeaderConfig) -> None:
+        self._leader_alert.show(leader.trigger_key, leader.mappings, leader.position)
+        self._start_click_monitor()
+
+    def _close_leader_ui(self) -> None:
+        self._leader_alert.close()
+        self._stop_click_monitor()
+
+    def _start_click_monitor(self) -> None:
+        self._stop_click_monitor()
+        from AppKit import NSEvent
+
+        self._click_monitor = NSEvent.addGlobalMonitorForEventsMatchingMask_handler_(
+            (1 << 1) | (1 << 3),  # NSLeftMouseDownMask | NSRightMouseDownMask
+            lambda _event: self._on_global_click(),
+        )
+
+    def _stop_click_monitor(self) -> None:
+        if self._click_monitor is not None:
+            from AppKit import NSEvent
+
+            NSEvent.removeMonitor_(self._click_monitor)
+            self._click_monitor = None
+
+    def _on_global_click(self) -> None:
+        with self._lock:
+            if not self._sticky_leader:
+                return
+            self._active_leader = None
+            self._sticky_leader = False
+            self._leader_triggered = False
+        self._close_leader_ui()  # already on main thread
+
     def _on_press(self, name: str) -> bool:
         """Handle key press. Returns True to swallow the event."""
         with self._lock:
             if self._active_leader is not None:
+                # --- Sticky mode special handling ---
+                if self._sticky_leader:
+                    # Esc or Ctrl+C closes the leader
+                    _dismiss = name.lower() == "esc"
+                    if not _dismiss and name.lower() == "c":
+                        try:
+                            import Quartz
+
+                            flags = Quartz.CGEventSourceFlagsState(
+                                Quartz.kCGEventSourceStateCombinedSessionState
+                            )
+                            _dismiss = bool(flags & (1 << 18))  # Ctrl
+                        except Exception:
+                            pass
+                    if _dismiss:
+                        self._active_leader = None
+                        self._sticky_leader = False
+                        self._leader_triggered = False
+                        try:
+                            from PyObjCTools import AppHelper
+
+                            AppHelper.callAfter(self._close_leader_ui)
+                        except Exception:
+                            pass
+                        return True
+
+                    # Don't match sub-keys when modifier keys are held
+                    # (e.g. user pressing Cmd+D again to toggle-close)
+                    try:
+                        import Quartz
+
+                        flags = Quartz.CGEventSourceFlagsState(
+                            Quartz.kCGEventSourceStateCombinedSessionState
+                        )
+                        _MOD_MASK = (1 << 20) | (1 << 18) | (1 << 19)  # Cmd|Ctrl|Alt
+                        if flags & _MOD_MASK:
+                            return True
+                    except Exception:
+                        pass
+
                 # Leader mode active — check for sub-key match
                 leader = self._active_leader
                 for m in leader.mappings:
                     if m.key.lower() == name.lower():
                         self._leader_triggered = True
+                        # Sticky mode: close panel on sub-key press
+                        if self._sticky_leader:
+                            self._active_leader = None
+                            self._sticky_leader = False
+                            try:
+                                from PyObjCTools import AppHelper
+
+                                AppHelper.callAfter(self._close_leader_ui)
+                            except Exception:
+                                pass
                         threading.Thread(
                             target=self._execute_mapping, args=(m,), daemon=True
                         ).start()
@@ -233,6 +363,9 @@ class HotkeyAPI:
         """Handle key release."""
         with self._lock:
             if self._active_leader and name == self._active_leader.trigger_key:
+                # Sticky mode: don't close on trigger key release
+                if self._sticky_leader:
+                    return
                 self._active_leader = None
                 self._leader_triggered = False
                 # Always close alert when trigger key is released

--- a/tests/scripting/test_api_hotkey.py
+++ b/tests/scripting/test_api_hotkey.py
@@ -107,7 +107,110 @@ class TestHotkeyAPI:
         _, api = self._make_api()
         api._leader_alert = MagicMock()
         api.stop()
-        mock_call_after.assert_called_with(api._leader_alert.close)
+        mock_call_after.assert_called_with(api._close_leader_ui)
+
+
+class TestToggleLeader:
+    """Tests for sticky (toggle) leader mode."""
+
+    def _make_api(self):
+        reg = ScriptingRegistry()
+        reg.register_leader("cmd_d", [
+            LeaderMapping(key="w", app="WeChat"),
+            LeaderMapping(key="t", desc="term", func=lambda: None),
+        ])
+        api = HotkeyAPI(reg)
+        return reg, api
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_toggle_leader_activates_sticky(self, mock_helper):
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        assert api._active_leader is not None
+        assert api._active_leader.trigger_key == "cmd_d"
+        assert api._sticky_leader is True
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_toggle_leader_again_deactivates(self, mock_helper):
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        api.toggle_leader("cmd_d")
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_toggle_leader_unknown_key_noop(self, mock_helper):
+        _, api = self._make_api()
+        api.toggle_leader("nonexistent")
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_sticky_release_does_not_close(self, mock_helper):
+        """Releasing the trigger key should NOT close the panel in sticky mode."""
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        api._on_release("cmd_d")
+        assert api._active_leader is not None
+        assert api._sticky_leader is True
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_sticky_esc_dismisses(self, mock_helper):
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        result = api._on_press("esc")
+        assert result is True
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+
+    @patch.object(HotkeyAPI, "_execute_mapping")
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_sticky_subkey_executes_and_closes(self, mock_helper, mock_exec):
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        result = api._on_press("w")
+        assert result is True
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_sticky_unmatched_key_swallowed(self, mock_helper):
+        _, api = self._make_api()
+        api.toggle_leader("cmd_d")
+        result = api._on_press("z")
+        assert result is True
+        # Panel stays open
+        assert api._active_leader is not None
+        assert api._sticky_leader is True
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_global_click_dismisses_sticky(self, mock_helper):
+        _, api = self._make_api()
+        api._leader_alert = MagicMock()
+        api.toggle_leader("cmd_d")
+        api._on_global_click()
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+
+    @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
+    def test_global_click_noop_when_not_sticky(self, mock_helper):
+        """_on_global_click should be a no-op when not in sticky mode."""
+        _, api = self._make_api()
+        api._leader_alert = MagicMock()
+        api._on_global_click()
+        api._leader_alert.close.assert_not_called()
+
+    @patch("PyObjCTools.AppHelper.callAfter")
+    def test_stop_clears_sticky_state(self, mock_call_after):
+        _, api = self._make_api()
+        api._leader_alert = MagicMock()
+        # Manually set sticky state
+        api._active_leader = api._registry.leaders["cmd_d"]
+        api._sticky_leader = True
+        api.stop()
+        assert api._active_leader is None
+        assert api._sticky_leader is False
+        mock_call_after.assert_called_with(api._close_leader_ui)
 
 
 class TestDefineKeys:


### PR DESCRIPTION
## Summary
- Add `wz.hotkey.toggle_leader(trigger_key)` API for sticky leader-key mode — the panel stays open until explicitly dismissed (sub-key, Esc, Ctrl+C, or mouse click), unlike the hold-to-show behavior
- Toggle the same key again to close the panel
- Modifier keys held during sticky mode are ignored to prevent accidental sub-key matches (e.g. pressing Cmd+D to toggle-close)
- `stop()` properly clears sticky state and removes the global click monitor

## Test plan
- [x] `toggle_leader()` activates sticky mode
- [x] Calling `toggle_leader()` again on the same key deactivates
- [x] Unknown trigger key is a no-op
- [x] Trigger key release does NOT close in sticky mode
- [x] Esc dismisses the sticky panel
- [x] Sub-key press executes mapping and closes panel
- [x] Unmatched keys are swallowed (panel stays open)
- [x] Global mouse click dismisses sticky panel
- [x] `stop()` clears sticky state

🤖 Generated with [Claude Code](https://claude.com/claude-code)