### PR TITLE
fix: re-register openSettings handler after script reload

### DIFF
--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -1367,9 +1367,9 @@ class WenZiApp(StatusBarApp):
             )
             self._script_engine._ua_controller = self._ua_controller
             self._script_engine.start()
-            self._script_engine.wz.chooser._event_handlers.setdefault(
-                "openSettings", []
-            ).append(lambda: self._on_open_settings(None))
+            self._script_engine.set_open_settings_callback(
+                lambda: self._on_open_settings(None)
+            )
 
             self._script_engine.set_system_settings_open_callback(
                 self._usage_stats.record_system_settings_open

--- a/src/wenzi/scripting/engine.py
+++ b/src/wenzi/scripting/engine.py
@@ -44,6 +44,7 @@ class ScriptEngine:
         self._snippet_expander = None
         self._system_settings_source = None
         self._system_settings_open_cb: Optional[Callable[[], None]] = None
+        self._open_settings_cb: Optional[Callable[[], None]] = None
         self._ua_controller = None
         self._reloading = False
         self._post_reload_callback: Optional[Callable[[], None]] = None
@@ -275,6 +276,17 @@ class ScriptEngine:
         """
         self._post_reload_callback = callback
 
+    def set_open_settings_callback(self, callback: Callable[[], None]) -> None:
+        """Set the callback for the built-in 'WenZi Settings' command.
+
+        The callback is stored and re-applied after reload() when the
+        ChooserAPI is recreated.
+        """
+        self._open_settings_cb = callback
+        self._wz.chooser._event_handlers.setdefault(
+            "openSettings", []
+        ).append(callback)
+
     def set_system_settings_open_callback(
         self, callback: Callable[[], None]
     ) -> None:
@@ -480,6 +492,14 @@ class ScriptEngine:
 
         # Command source (always registered when chooser is enabled)
         self._wz.chooser._ensure_command_source()
+
+        # Re-apply openSettings handler on the (possibly new) ChooserAPI
+        if self._open_settings_cb is not None:
+            handlers = self._wz.chooser._event_handlers.setdefault(
+                "openSettings", []
+            )
+            if self._open_settings_cb not in handlers:
+                handlers.append(self._open_settings_cb)
 
         # Switch-to-English setting
         panel = self._wz.chooser._get_panel()


### PR DESCRIPTION
## Summary
- The "WenZi Settings" chooser command stopped working after any script reload because the `openSettings` event handler was only registered once at startup, but the `ChooserAPI` instance is destroyed and recreated during reload
- Added `set_open_settings_callback()` to `ScriptEngine` that stores the callback and re-applies it in `_register_builtin_sources()` after reload, following the same pattern as `set_system_settings_open_callback()`

## Test plan
- [ ] Open chooser → select "WenZi Settings" → settings panel should open
- [ ] Reload scripts (via `> reload` command) → select "WenZi Settings" again → settings panel should still open
- [ ] Press Cmd+, in chooser → settings panel should open (both before and after reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)