### PR TITLE
fix: address code review issues from 2026-03-27 audit

### DIFF
--- a/WenZi-Lite.spec
+++ b/WenZi-Lite.spec
@@ -70,6 +70,7 @@ a = Analysis(
         'wenzi.enhance.preview_history',
         'wenzi.enhance.mode_loader',
         'wenzi.enhance.text_diff',
+        'wenzi.enhance.manual_vocabulary',
         'wenzi.enhance.pool_monitor',
         # wenzi.ui
         'wenzi.ui',
@@ -97,6 +98,7 @@ a = Analysis(
         'wenzi.controllers.update_controller',
         'wenzi.controllers.menu_builder',
         'wenzi.controllers.recording_flow',
+        'wenzi.controllers.universal_action_controller',
         'wenzi.updater',
         # wenzi.scripting
         'wenzi.scripting',
@@ -123,6 +125,7 @@ a = Analysis(
         'wenzi.scripting.api.store',
         'wenzi.scripting.api.timer',
         'wenzi.scripting.api.ui',
+        'wenzi.scripting.api.keychain',
         # wenzi.scripting.sources
         'wenzi.scripting.sources',
         'wenzi.scripting.sources._mdquery',

--- a/WenZi.spec
+++ b/WenZi.spec
@@ -80,6 +80,7 @@ a = Analysis(
         'wenzi.enhance.preview_history',
         'wenzi.enhance.mode_loader',
         'wenzi.enhance.text_diff',
+        'wenzi.enhance.manual_vocabulary',
         'wenzi.enhance.pool_monitor',
         # wenzi.ui
         'wenzi.ui',
@@ -107,6 +108,7 @@ a = Analysis(
         'wenzi.controllers.update_controller',
         'wenzi.controllers.menu_builder',
         'wenzi.controllers.recording_flow',
+        'wenzi.controllers.universal_action_controller',
         'wenzi.updater',
         # wenzi.scripting
         'wenzi.scripting',
@@ -133,6 +135,7 @@ a = Analysis(
         'wenzi.scripting.api.store',
         'wenzi.scripting.api.timer',
         'wenzi.scripting.api.ui',
+        'wenzi.scripting.api.keychain',
         # wenzi.scripting.sources
         'wenzi.scripting.sources',
         'wenzi.scripting.sources._mdquery',

--- a/plugins/dictionary/render.py
+++ b/plugins/dictionary/render.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+import re
 from html import escape
 from urllib.parse import quote as _urlquote
+
+_SAFE_TAGS_RE = re.compile(r"<(?!/?(?:b|i|em|strong)\b)[^>]+>", re.IGNORECASE)
+
+
+def _sanitize_html(html: str) -> str:
+    """Allow only <b>, <i>, <em>, <strong> tags, strip all others."""
+    return _SAFE_TAGS_RE.sub("", html)
 
 _STYLE = """\
 <style>
@@ -175,7 +183,7 @@ def render_definition(data: dict, word: str) -> str:
                     f'<div class="collins-entry">'
                     f'<span class="collins-pos">{escape(pos)}</span> '
                     f'<span class="tag">{escape(pos_tips)}</span><br>'
-                    f"{tran}</div>"  # tran contains <b> tags, keep HTML
+                    f"{_sanitize_html(tran)}</div>"
                 )
                 # Collins example sentences
                 exam_sents = te.get("exam_sents", {}).get("sent", [])

--- a/plugins/dictionary/youdao.py
+++ b/plugins/dictionary/youdao.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import urllib.request
+from urllib.parse import quote as _urlquote
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,7 @@ def suggest(query: str) -> list[dict]:
     Returns list of ``{"word": str, "explain": str}``.
     Returns empty list on any error.
     """
-    url = _SUGGEST_URL.format(query=urllib.request.quote(query))
+    url = _SUGGEST_URL.format(query=_urlquote(query, safe=""))
     try:
         with urllib.request.urlopen(url, timeout=_SUGGEST_TIMEOUT) as resp:
             data = json.loads(resp.read())
@@ -69,8 +70,8 @@ def lookup(word: str, direction: str) -> dict:
     le = "zh" if direction == "zh2en" else "en"
     url = _LOOKUP_URL.format(
         le=le,
-        direction=urllib.request.quote(direction),
-        query=urllib.request.quote(word),
+        direction=_urlquote(direction, safe=""),
+        query=_urlquote(word, safe=""),
         dicts=_DICTS_FILTER,
     )
     try:

--- a/src/wenzi/controllers/universal_action_controller.py
+++ b/src/wenzi/controllers/universal_action_controller.py
@@ -34,20 +34,21 @@ class UniversalActionController:
             logger.debug("Universal Action ignored: app is busy")
             return
 
-        self._selected_text = get_selected_text() or ""
+        text = get_selected_text() or ""
 
         from PyObjCTools import AppHelper
 
-        AppHelper.callAfter(self._show_ua_panel)
+        AppHelper.callAfter(self._show_ua_panel, text)
 
-    def _show_ua_panel(self) -> None:
+    def _show_ua_panel(self, text: str) -> None:
         """Register temp source and show the chooser in UA mode.  Main thread."""
+        self._selected_text = text
         try:
-            self._show_ua_panel_inner()
+            self._show_ua_panel_inner(text)
         except Exception:
             logger.exception("Universal Action: _show_ua_panel failed")
 
-    def _show_ua_panel_inner(self) -> None:
+    def _show_ua_panel_inner(self, text: str) -> None:
         """Inner implementation — separated so exceptions are always logged."""
         items = self._build_action_items()
         if not items:
@@ -81,7 +82,7 @@ class UniversalActionController:
             chooser._panel.unregister_source(_UA_SOURCE_NAME)
 
         chooser.show_universal_action(
-            context_text=self._selected_text,
+            context_text=text,
             exclusive_source=_UA_SOURCE_NAME,
             on_close=_on_close,
             initial_query="",
@@ -173,9 +174,14 @@ class UniversalActionController:
         if not text:
             return
 
-        app._enhance_mode = mode_id
-        if app._enhancer:
-            app._enhancer.mode = mode_id
+        from PyObjCTools import AppHelper
+
+        def _set_mode():
+            app._enhance_mode = mode_id
+            if app._enhancer:
+                app._enhancer.mode = mode_id
+
+        AppHelper.callAfter(_set_mode)
 
         preview_ctrl = getattr(app, "_preview_controller", None)
         if preview_ctrl is not None:

--- a/src/wenzi/enhance/enhancer.py
+++ b/src/wenzi/enhance/enhancer.py
@@ -1016,12 +1016,12 @@ class TextEnhancer:
 
         if not self._providers or self._active_provider not in self._providers:
             logger.warning("AI enhancer not available, returning original text")
-            yield text, None
+            yield text, None, False
             return
 
         mode_def = self._modes.get(self._mode)
         if not mode_def:
-            yield text, None
+            yield text, None, False
             return
 
         from openai import RateLimitError

--- a/src/wenzi/scripting/api/hotkey.py
+++ b/src/wenzi/scripting/api/hotkey.py
@@ -266,7 +266,9 @@ class HotkeyAPI:
             self._active_leader = None
             self._sticky_leader = False
             self._leader_triggered = False
-        self._close_leader_ui()  # already on main thread
+        from PyObjCTools import AppHelper
+
+        AppHelper.callAfter(self._close_leader_ui)
 
     def _on_press(self, name: str) -> bool:
         """Handle key press. Returns True to swallow the event."""

--- a/src/wenzi/ui/result_window_web.py
+++ b/src/wenzi/ui/result_window_web.py
@@ -371,6 +371,7 @@ class ResultPreviewPanel:
         self._on_remove_manual_vocab: Optional[Callable] = None
         self._on_diff_panel_toggle: Optional[Callable[[bool], None]] = None
         self._diff_panel_open: bool = False
+        self._diff_panel_original_x: Optional[float] = None
         self._enhanced_text_cache: str = ""
 
     # ------------------------------------------------------------------
@@ -1123,6 +1124,7 @@ class ResultPreviewPanel:
         x = frame.origin.x
         # Shift left if expanding would overflow the screen right edge
         if is_open:
+            self._diff_panel_original_x = x
             screen = self._screen_for_mouse()
             if screen:
                 vis = screen.visibleFrame()
@@ -1130,6 +1132,10 @@ class ResultPreviewPanel:
                 overflow = (x + width) - max_right
                 if overflow > 0:
                     x = max(vis.origin.x, x - overflow)
+        else:
+            if self._diff_panel_original_x is not None:
+                x = self._diff_panel_original_x
+                self._diff_panel_original_x = None
         from Foundation import NSMakeRect
         self._panel.setFrame_display_(
             NSMakeRect(x, frame.origin.y, width, frame.size.height),

--- a/src/wenzi/vault.py
+++ b/src/wenzi/vault.py
@@ -275,15 +275,23 @@ class Vault:
             self._dirty = False
             snapshot = json.dumps(self._data, ensure_ascii=False)
 
+        tmp_path = self._path + ".tmp"
         try:
             dirpath = os.path.dirname(self._path)
             os.makedirs(dirpath, exist_ok=True)
-            tmp_path = self._path + ".tmp"
-            with open(tmp_path, "w", encoding="utf-8") as f:
+            fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with open(fd, "w", encoding="utf-8") as f:
                 f.write(snapshot)
             os.replace(tmp_path, self._path)
+            os.chmod(self._path, 0o600)
         except Exception:
             logger.warning("Failed to save vault", exc_info=True)
+            with self._lock:
+                self._dirty = True
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/controllers/test_universal_action_controller.py
+++ b/tests/controllers/test_universal_action_controller.py
@@ -87,7 +87,12 @@ class TestTrigger:
         app._script_engine._wz.chooser._panel._sources = {}
         app._recording_controller._is_busy = False
         ctrl = UniversalActionController(app)
-        ctrl.trigger()
+
+        # Patch callAfter to execute the callback immediately so we can
+        # verify that _show_ua_panel stores the captured text.
+        with patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+            ctrl.trigger()
+
         mock_get.assert_called_once()
         assert ctrl._selected_text == "hello"
 

--- a/tests/enhance/test_enhancer.py
+++ b/tests/enhance/test_enhancer.py
@@ -1746,6 +1746,49 @@ class TestTextEnhancerEnhanceStream:
         assert "all 1 attempts failed" in results[0][0]
 
 
+class TestEnhanceStreamYields3Tuples:
+    """Regression: enhance_stream must always yield 3-tuples (chunk, usage, is_thinking)."""
+
+    def test_no_providers_yields_3_tuple(self):
+        """When no providers are configured, enhance_stream must still yield a 3-tuple."""
+        with patch("wenzi.enhance.enhancer.TextEnhancer._init_providers"):
+            enhancer = TextEnhancer(_make_config(enabled=True, mode="proofread"))
+            # Simulate no providers initialized
+            enhancer._providers = {}
+            enhancer._active_provider = "ollama"
+
+        results = []
+        async def collect():
+            async for item in enhancer.enhance_stream("hello world"):
+                results.append(item)
+
+        asyncio.run(collect())
+        assert len(results) == 1
+        assert len(results[0]) == 3, f"Expected 3-tuple, got {len(results[0])}-tuple"
+        assert results[0] == ("hello world", None, False)
+
+    def test_missing_mode_yields_3_tuple(self):
+        """When mode definition is not found, enhance_stream must still yield a 3-tuple."""
+        with patch("wenzi.enhance.enhancer.TextEnhancer._init_providers"):
+            enhancer = TextEnhancer(_make_config(enabled=True, mode="proofread"))
+            enhancer._providers = {
+                "ollama": (MagicMock(), ["qwen2.5:7b"], {}),
+            }
+            enhancer._active_provider = "ollama"
+            # Set mode to something not in _modes so mode_def lookup fails
+            enhancer._mode = "nonexistent_mode_xyz"
+
+        results = []
+        async def collect():
+            async for item in enhancer.enhance_stream("hello world"):
+                results.append(item)
+
+        asyncio.run(collect())
+        assert len(results) == 1
+        assert len(results[0]) == 3, f"Expected 3-tuple, got {len(results[0])}-tuple"
+        assert results[0] == ("hello world", None, False)
+
+
 class TestConnectionTimeoutRetry:
     """Tests for connection timeout retry logic in enhance_stream."""
 

--- a/tests/plugins/test_dictionary_render.py
+++ b/tests/plugins/test_dictionary_render.py
@@ -195,3 +195,89 @@ class TestRenderDefinition:
         html = render_definition(SAMPLE_DATA, "hello")
         assert "<style>" in html
         assert "var(--text)" in html
+
+    def test_collins_tran_strips_script_tags(self):
+        from dictionary.render import render_definition
+
+        data = {
+            "collins": {
+                "collins_entries": [
+                    {
+                        "entries": {
+                            "entry": [
+                                {
+                                    "tran_entry": [
+                                        {
+                                            "pos_entry": {"pos": "N", "pos_tips": ""},
+                                            "tran": 'Hello <script>alert("xss")</script>world',
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        html = render_definition(data, "test")
+        assert "<script>" not in html
+        assert "</script>" not in html
+        # The text content between tags is kept, only the tags are stripped
+        assert "Hello" in html
+        assert "world" in html
+
+    def test_collins_tran_preserves_b_tags(self):
+        from dictionary.render import render_definition
+
+        data = {
+            "collins": {
+                "collins_entries": [
+                    {
+                        "entries": {
+                            "entry": [
+                                {
+                                    "tran_entry": [
+                                        {
+                                            "pos_entry": {"pos": "V", "pos_tips": ""},
+                                            "tran": "You say <b>hello</b> to greet.",
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        html = render_definition(data, "test")
+        assert "<b>hello</b>" in html
+
+    def test_collins_tran_strips_event_handler_attributes(self):
+        from dictionary.render import render_definition
+
+        data = {
+            "collins": {
+                "collins_entries": [
+                    {
+                        "entries": {
+                            "entry": [
+                                {
+                                    "tran_entry": [
+                                        {
+                                            "pos_entry": {"pos": "N", "pos_tips": ""},
+                                            "tran": 'Hello <span onclick="alert(1)">click</span> world',
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        }
+        html = render_definition(data, "test")
+        assert "onclick" not in html
+        # The <span onclick=...> tag is stripped but text content remains
+        assert "click" in html
+        assert "Hello" in html
+        assert "world" in html

--- a/tests/plugins/test_dictionary_youdao.py
+++ b/tests/plugins/test_dictionary_youdao.py
@@ -158,3 +158,21 @@ class TestLookup:
             result = lookup("hello", "en2zh-CHS")
 
         assert result == {}
+
+    def test_special_characters_encoded_in_url(self):
+        """Slash, hash, ampersand in queries must be percent-encoded."""
+        body = json.dumps({"ec": {}}).encode()
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = body
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("urllib.request.urlopen", return_value=mock_resp) as mock_open:
+            from dictionary.youdao import lookup
+
+            lookup("a/b#c&d", "en2zh-CHS")
+
+        call_url = mock_open.call_args[0][0]
+        # '/' '#' '&' must NOT appear literally in the query part
+        # They should be encoded as %2F %23 %26
+        assert "a%2Fb%23c%26d" in call_url

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from unittest.mock import patch
 
 MOCK_MASTER_KEY_B64 = "QUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUE="  # 32 bytes
@@ -135,6 +136,43 @@ class TestVaultFlush:
 
         v2 = Vault(vault_path=vault_path)
         assert v2.get("token") == "persisted"
+
+    @patch("wenzi.vault._keychain_set", return_value=True)
+    @patch("wenzi.vault._keychain_get", return_value=MOCK_MASTER_KEY_B64)
+    def test_flush_sets_file_permissions_0600(self, mock_get, mock_set, tmp_path):
+        from wenzi.vault import Vault
+
+        vault_path = str(tmp_path / "vault.json")
+        v = Vault(vault_path=vault_path)
+        v.set("token", "secret")
+        v.flush_sync()
+        mode = stat.S_IMODE(os.stat(vault_path).st_mode)
+        assert mode == 0o600
+
+    @patch("wenzi.vault._keychain_set", return_value=True)
+    @patch("wenzi.vault._keychain_get", return_value=MOCK_MASTER_KEY_B64)
+    def test_dirty_re_set_on_replace_failure(self, mock_get, mock_set, tmp_path):
+        from wenzi.vault import Vault
+
+        vault_path = str(tmp_path / "vault.json")
+        v = Vault(vault_path=vault_path)
+        v.set("token", "secret")
+        with patch("os.replace", side_effect=OSError("disk full")):
+            v.flush_sync()
+        assert v._dirty is True
+
+    @patch("wenzi.vault._keychain_set", return_value=True)
+    @patch("wenzi.vault._keychain_get", return_value=MOCK_MASTER_KEY_B64)
+    def test_tmp_file_cleaned_on_replace_failure(self, mock_get, mock_set, tmp_path):
+        from wenzi.vault import Vault
+
+        vault_path = str(tmp_path / "vault.json")
+        v = Vault(vault_path=vault_path)
+        v.set("token", "secret")
+        with patch("os.replace", side_effect=OSError("disk full")):
+            v.flush_sync()
+        tmp_path_file = vault_path + ".tmp"
+        assert not os.path.exists(tmp_path_file)
 
 
 class TestVaultMigration:


### PR DESCRIPTION
## Summary

Comprehensive code review of all commits since 2026-03-27 identified 11 issues across security, correctness, robustness, and packaging. This PR fixes all of them with corresponding test coverage.

### Security (3 fixes)
- **Dictionary XSS**: Collins `tran` field from Youdao API was inserted as raw HTML into WKWebView. Now sanitized with a whitelist allowing only `<b>`, `<i>`, `<em>`, `<strong>` tags
- **Vault file permissions**: Encrypted vault file was created with default umask (typically 0644). Now written with `0o600` (owner-only)
- **URL encoding**: `urllib.parse.quote()` default `safe='/'` could alter URL path structure. Changed to `safe=''`

### Correctness (4 fixes)
- **Enhancer 2-tuple bug**: `enhance_stream` error paths yielded `(text, None)` but consumer destructures as 3-tuple — would crash with `ValueError` if triggered
- **UA thread safety**: `_on_enhance_mode_selected` mutated `app._enhance_mode` from background thread; now dispatched to main thread via `callAfter`
- **UA shared state**: `_selected_text` was written on event tap thread and read on main thread; now passed as parameter through dispatch chain
- **Leader key race**: `_on_global_click` and `toggle_leader` could both call `_close_leader_ui` concurrently; now serialized via `callAfter`

### Robustness (3 fixes)
- **Vault dirty flag**: `_dirty` was cleared before disk write — if write failed, data was never retried. Now re-set on failure
- **Vault tmp cleanup**: Failed `os.replace` left `.tmp` file with encrypted data on disk. Now cleaned up in except block
- **Diff panel x drift**: Opening diff panel near screen edge shifted window left, but closing didn't restore position. Now saves/restores original x

### Packaging (1 fix)
- Added missing `hiddenimports` to both spec files: `wenzi.enhance.manual_vocabulary`, `wenzi.controllers.universal_action_controller`, `wenzi.scripting.api.keychain`

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3605 passed (5 pre-existing failures in updater/funasr unrelated to this PR)
- [x] New tests added for: vault flush permissions/retry/cleanup, enhancer stream 3-tuple, dictionary XSS sanitization, Youdao URL encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)