### PR TITLE
fix(screenshot): remove CSS border that causes offset in exported image

### DIFF
--- a/src/wenzi/screenshot/templates/annotation.css
+++ b/src/wenzi/screenshot/templates/annotation.css
@@ -14,7 +14,6 @@ html, body {
   overflow: hidden;
   background: transparent;
   font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
-  border: 1.5px solid rgba(128, 128, 128, 0.5);
 }
 
 /* ── Canvas ── */


### PR DESCRIPTION
## Summary

- Remove the `border: 1.5px solid` on `body` in annotation.css that caused the canvas content to shift, resulting in window background and padding being included in exported screenshots

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/test_screenshot/` — 23 pass
- [ ] Manual: take screenshot, copy to clipboard, paste — verify no extra border/padding in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)