### PR TITLE
perf(launcher): reuse panel across open/close cycles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,16 @@ All `chat.completions.create` calls **must** include `max_tokens` to prevent run
 
 When adding a new LLM call, always set `max_tokens` to a reasonable upper bound for the expected output.
 
+## Launcher (Chooser) Panel Lifecycle
+
+The chooser panel (`ChooserPanel`) uses a **hide/reuse** strategy for performance. WKWebView creation + HTML loading is expensive (~200-500ms), so the panel is kept alive across open/close cycles:
+
+- **`close()`** — hides the panel (`orderOut_`) and breaks `_panel_ref` back-references to prevent retain cycles. The NSPanel, WKWebView, and delegates remain alive for reuse.
+- **`destroy()`** — fully tears down the panel and webview. Only called during `engine.reload()` when HTML/i18n may have changed.
+- **`show()`** — if a hidden panel exists (`self._panel is not None and self._page_loaded`), it reconnects refs and resets UI via JS instead of rebuilding from scratch.
+
+When modifying `close()`, do NOT set `self._panel = None` or `self._webview = None` — this would break the reuse path and force a cold start on every open. To prevent retain cycles while hidden, nil out `_panel_ref` on the message handler, navigation delegate, and panel delegate instead.
+
 ## Screenshot & Picture Editor
 
 ### Architecture

--- a/src/wenzi/scripting/engine.py
+++ b/src/wenzi/scripting/engine.py
@@ -135,13 +135,14 @@ class ScriptEngine:
 
             unregister_custom_keys()
             # Reset APIs so they create fresh instances.
-            # Close the chooser panel first to break WKWebView retain cycles.
+            # Destroy the chooser panel so the WKWebView is fully released
+            # and will be recreated with fresh HTML/i18n on next show().
             self._wz._hotkey_api = None
             try:
                 if self._wz._chooser_api is not None:
-                    self._wz._chooser_api.panel.close()
+                    self._wz._chooser_api.panel.destroy()
             except Exception:
-                logger.debug("Error closing chooser panel during reload", exc_info=True)
+                logger.debug("Error destroying chooser panel during reload", exc_info=True)
             self._wz._chooser_api = None
             self._wz._ui_api = None
             # Keep menubar items alive for reuse (avoids NSStatusBar flicker)

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -256,6 +256,57 @@ class ChooserPanel:
         self._panel.setFrame_display_(new_frame, True)
 
     # ------------------------------------------------------------------
+    # Panel reuse helpers
+    # ------------------------------------------------------------------
+
+    def _reconnect_panel_refs(self) -> None:
+        """Restore ``_panel_ref`` back-references broken by :meth:`close`."""
+        if self._message_handler is not None:
+            self._message_handler._panel_ref = self
+        if self._navigation_delegate is not None:
+            self._navigation_delegate._panel_ref = self
+        if self._panel_delegate is not None:
+            self._panel_delegate._panel_ref = self
+
+    def _reset_panel_ui(
+        self,
+        initial_query: Optional[str] = None,
+        placeholder: Optional[str] = None,
+    ) -> None:
+        """Reset the webview UI state for a reused panel.
+
+        Clears the previous search input, results, context block, and
+        preview/compact modes so the panel appears fresh.
+        """
+        parts = [
+            "setResults([])",
+            "setPreviewVisible(false)",
+            "setCompact(false)",
+            "setModifierHints({},null)",
+            "setCreateButton(false)",
+        ]
+        # Clear or set input value
+        if initial_query:
+            parts.append(f"setInputValue({json.dumps(initial_query)})")
+            # pending_initial_query is consumed by _on_page_loaded only on
+            # first load; for reuse we apply it directly here.
+            self._pending_initial_query = None
+        else:
+            parts.append("setInputValue('')")
+        # Handle context block (Universal Action)
+        if self._context_text is not None:
+            escaped = json.dumps(self._context_text)
+            label = json.dumps(t("chooser.ua.context_label"))
+            parts.append(f"setContextText({escaped}, {label})")
+        else:
+            parts.append("clearContext()")
+        # Apply placeholder
+        if placeholder:
+            parts.append(f"setPlaceholder({json.dumps(placeholder)})")
+            self._pending_placeholder = None
+        self._eval_js(";".join(parts))
+
+    # ------------------------------------------------------------------
     # Source management
     # ------------------------------------------------------------------
 
@@ -477,7 +528,14 @@ class ChooserPanel:
 
         self._previous_app = get_frontmost_app()
 
-        self._build_panel()
+        if self._panel is not None and self._page_loaded:
+            # Reuse hidden panel — reconnect refs and reset UI
+            self._reconnect_panel_refs()
+            self._reset_panel_ui(initial_query, placeholder)
+        else:
+            # First show — build from scratch
+            self._build_panel()
+
         self._panel.makeKeyAndOrderFront_(None)
 
         from AppKit import NSApp
@@ -527,7 +585,15 @@ class ChooserPanel:
         self.show(on_close=on_close, initial_query=initial_query, placeholder=placeholder)
 
     def close(self) -> None:
-        """Close the chooser panel."""
+        """Hide the chooser panel, preserving WKWebView for fast re-show.
+
+        Breaks ``_panel_ref`` back-references to prevent retain cycles
+        while the panel is hidden.  The panel and webview remain alive
+        so that the next :meth:`show` can skip the expensive
+        WKWebView + HTML-load cold start.
+
+        Use :meth:`destroy` for full teardown (e.g. during reload).
+        """
         if self._closing:
             return
         self._closing = True
@@ -546,29 +612,19 @@ class ChooserPanel:
             self._ql_panel.close()
             self._ql_panel = None
 
-        if self._webview is not None:
-            self._webview.setNavigationDelegate_(None)
-            # Remove the script message handler to break the reference cycle
-            try:
-                config = self._webview.configuration()
-                if config:
-                    config.userContentController().removeScriptMessageHandlerForName_("chooser")
-            except Exception:
-                pass
+        # Break back-references to prevent retain cycles while hidden.
+        # The objects themselves are kept alive for reuse.
         if self._message_handler is not None:
             self._message_handler._panel_ref = None
         if self._navigation_delegate is not None:
             self._navigation_delegate._panel_ref = None
+        if self._panel_delegate is not None:
+            self._panel_delegate._panel_ref = None
+
+        # Hide the panel (keep it alive)
         if self._panel is not None:
-            self._panel.setDelegate_(None)
-            self._panel_delegate = None
             self._panel.orderOut_(None)
-            self._panel = None
-        self._webview = None
-        self._message_handler = None
-        self._navigation_delegate = None
-        self._page_loaded = False
-        self._pending_js = []
+
         self._current_items = []
         self._history_index = -1
         self._show_preview = False
@@ -596,6 +652,35 @@ class ChooserPanel:
         self._on_close = None
         if callback is not None:
             callback()
+
+    def destroy(self) -> None:
+        """Fully destroy the panel and webview, releasing all resources.
+
+        Called during script reload when the HTML/i18n may have changed
+        and the WKWebView must be recreated from scratch.
+        """
+        # Close first to handle hide + state cleanup
+        self.close()
+
+        # Now tear down the retained objects
+        if self._webview is not None:
+            self._webview.setNavigationDelegate_(None)
+            try:
+                config = self._webview.configuration()
+                if config:
+                    config.userContentController().removeScriptMessageHandlerForName_("chooser")
+            except Exception:
+                pass
+        if self._panel is not None:
+            self._panel.setDelegate_(None)
+            self._panel.orderOut_(None)
+        self._panel = None
+        self._webview = None
+        self._message_handler = None
+        self._navigation_delegate = None
+        self._panel_delegate = None
+        self._page_loaded = False
+        self._pending_js = []
 
     def toggle(self, on_close: Optional[Callable] = None) -> None:
         """Toggle the chooser panel visibility."""


### PR DESCRIPTION
## Summary
- `close()` now hides the panel (`orderOut_`) instead of destroying the WKWebView, breaking `_panel_ref` back-references to prevent retain cycles while hidden
- `show()` detects a hidden panel and reconnects refs + resets UI via JS, skipping the expensive WKWebView creation + 34KB HTML disk write + page load (~200-500ms cold start)
- New `destroy()` method for full teardown, used only by `engine.reload()` when HTML/i18n may have changed
- Updated CLAUDE.md with Launcher panel lifecycle documentation

## Test plan
- [x] All 239 chooser tests pass
- [x] Full test suite passes (3733 passed, 5 pre-existing failures unrelated)
- [x] Lint clean (`ruff check`)
- [ ] Manual: press Launcher hotkey repeatedly — second+ opens should be near-instant
- [ ] Manual: reload scripts (`> Reload` command) — panel should rebuild from scratch
- [ ] Manual: Universal Action mode works correctly after close/reopen cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)