### PR TITLE
fix(chooser): enable usage-based sorting for Universal Action items

### DIFF
--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -193,6 +193,7 @@ class ChooserPanel:
     _DEFERRED_ACTION_DELAY = 0.15  # seconds to let previous app regain focus
     _DEFAULT_ASYNC_DEBOUNCE = 0.15  # seconds
     _DEFAULT_ASYNC_TIMEOUT = 5.0  # seconds
+    _UA_USAGE_PREFIX = "_ua"  # Synthetic query prefix for UA mode usage tracking
 
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
@@ -812,7 +813,7 @@ class ChooserPanel:
 
         # Apply usage-based boosting
         if self._usage_tracker and self._current_items:
-            self._boost_by_usage(query)
+            self._boost_by_usage(self._usage_query(query))
 
         # Update calculator sticky mode
         if self._has_calc_results():
@@ -872,6 +873,16 @@ class ChooserPanel:
             scored.append((-usage, i, item))
         scored.sort(key=lambda x: (x[0], x[1]))
         self._current_items = [item for _, _, item in scored]
+
+    def _usage_query(self, query: str) -> str:
+        """Return the query key for usage tracking.
+
+        In Universal Action mode, empty queries use a synthetic prefix so
+        that usage learning still works when the user hasn't typed anything.
+        """
+        if not query and self._context_text is not None:
+            return self._UA_USAGE_PREFIX
+        return query
 
     @staticmethod
     def _default_action_hints():
@@ -1066,7 +1077,7 @@ class ChooserPanel:
                 self._current_items.extend(items[:remaining])
 
             if self._usage_tracker and self._current_items:
-                self._boost_by_usage(self._last_query)
+                self._boost_by_usage(self._usage_query(self._last_query))
 
             self._push_items_to_js(
                 source=source if self._active_source is source else None,
@@ -1345,7 +1356,9 @@ class ChooserPanel:
 
             # Record usage for learning
             if self._usage_tracker and item.item_id:
-                self._usage_tracker.record(self._last_query, item.item_id)
+                self._usage_tracker.record(
+                    self._usage_query(self._last_query), item.item_id
+                )
 
             # Record query history
             if self._query_history and self._last_query and self._last_query.strip():

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -540,6 +540,74 @@ class TestUsageTrackerIntegration:
 
         assert tracker.score("saf", "app:Safari") == 1
 
+    def test_ua_mode_boosts_with_empty_query(self):
+        """In Universal Action mode, usage boost works even with empty query."""
+        import os
+        import tempfile
+
+        tmpdir = tempfile.mkdtemp()
+        path = os.path.join(tmpdir, "usage.json")
+        tracker = UsageTracker(path=path)
+
+        panel = ChooserPanel(usage_tracker=tracker)
+        panel._eval_js = MagicMock()
+        panel._page_loaded = True
+
+        items = [
+            ChooserItem(title="Proofread", item_id="ua:enhance:proofread"),
+            ChooserItem(title="Translate", item_id="ua:enhance:translate"),
+            ChooserItem(title="Define", item_id="ua:cmd:define"),
+        ]
+        panel.register_source(
+            ChooserSource(
+                name="_universal_action",
+                search=lambda q: items,
+                priority=999,
+            )
+        )
+        panel._exclusive_source = "_universal_action"
+        panel._context_text = "some selected text"
+
+        # Record "Define" as frequently selected in UA mode
+        tracker.record("_ua", "ua:cmd:define")
+        tracker.record("_ua", "ua:cmd:define")
+        tracker.record("_ua", "ua:cmd:define")
+
+        # Search with empty query — "Define" should be boosted to the top
+        panel._do_search("")
+        ids = [item.item_id for item in panel._current_items]
+        assert len(ids) == 3
+        assert ids[0] == "ua:cmd:define"
+
+    def test_ua_mode_execute_records_with_synthetic_prefix(self):
+        """Selecting an item in UA mode records usage under the '_ua' prefix."""
+        import os
+        import tempfile
+
+        tmpdir = tempfile.mkdtemp()
+        path = os.path.join(tmpdir, "usage.json")
+        tracker = UsageTracker(path=path)
+
+        panel = ChooserPanel(usage_tracker=tracker)
+        panel._eval_js = MagicMock()
+        panel._page_loaded = True
+        panel._last_query = ""
+        panel._context_text = "some selected text"
+        panel._current_items = [
+            ChooserItem(
+                title="Proofread",
+                item_id="ua:enhance:proofread",
+                action=lambda: None,
+            ),
+        ]
+        panel.close = MagicMock()
+
+        with patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)):
+            panel._execute_item(0)
+
+        # Should be recorded under "_ua" prefix, not empty string
+        assert tracker.score("_ua", "ua:enhance:proofread") == 1
+
 
 class TestCloseReactivation:
     def test_close_reactivates_previous_app(self):


### PR DESCRIPTION
## Summary
- UsageTracker was ineffective in UA mode because empty queries caused `score()` and `record()` to return early
- Added synthetic prefix `_ua` for usage tracking when the chooser is in Universal Action mode, so frequently selected actions are boosted to the top over time
- Applied the fix to all three call sites: sync boost, async merge boost, and item selection recording

## Test plan
- [x] New test: UA mode boosts items with empty query using synthetic prefix
- [x] New test: selecting an item in UA mode records usage under `_ua` prefix
- [x] Existing usage tracker tests still pass
- [x] Full test suite passes (3813 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)