### PR TITLE
fix(settings): add missing update_enhance_mode to SettingsWebPanel

### DIFF
--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -197,6 +197,10 @@ class SettingsWebPanel:
             f"_updateSttSelection({payload})", None
         )
 
+    def update_enhance_mode(self, mode_id: str) -> None:
+        """Update enhance mode selection in the webview."""
+        self.update_state({"current_enhance_mode": mode_id})
+
     def _set_element_text(self, element_id: str, value: str) -> None:
         """Set textContent of a DOM element by ID."""
         if self._webview is None or not self.is_visible:


### PR DESCRIPTION
## Summary
- Changing enhance mode from the preview panel while the settings window was open crashed the app with `AttributeError: 'SettingsWebPanel' object has no attribute 'update_enhance_mode'`
- Added the missing method that delegates to `update_state({"current_enhance_mode": mode_id})`, which the JS side already handles

## Test plan
- [x] Existing 52 settings web panel tests pass
- [ ] Open settings → switch enhance mode from preview panel → verify no crash and settings UI updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)