### PR TITLE
chore: add deploy-lite targets, bundle screenshot templates, bump to 0.1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev run-lite docs docs-serve lint test build build-fast build-lite build-lite-fast build-dmg build-lite-dmg clean sync-registry
+.PHONY: dev run-lite docs docs-serve lint test build build-fast build-lite build-lite-fast build-dmg build-lite-dmg deploy-lite deploy-lite-fast clean sync-registry
 
 # Overridable environment variables for development:
 # WENZI_CONFIG_DIR    — config directory path (default: ~/.config/WenZi)
@@ -59,6 +59,29 @@ build-dmg:
 
 build-lite-dmg:
 	./scripts/build-dmg.sh --lite
+
+# Build Lite (full), install to /Applications, restart the app
+deploy-lite: build-lite _install-lite
+
+# Build Lite (incremental), install to /Applications, restart the app
+deploy-lite-fast:
+	./scripts/build-lite.sh --fast --no-launch
+	@$(MAKE) --no-print-directory _install-lite
+
+# Internal: stop running instance, install to /Applications, relaunch
+_install-lite:
+	@BUNDLE_ID="io.github.airead.wenzi"; \
+	OLD_PID=$$(lsappinfo info -only pid -app "$$BUNDLE_ID" 2>/dev/null | grep -o '[0-9]*' || true); \
+	if [ -n "$$OLD_PID" ]; then \
+		echo "==> Stopping old instance (pid=$$OLD_PID)..."; \
+		kill "$$OLD_PID" 2>/dev/null || true; \
+		while kill -0 "$$OLD_PID" 2>/dev/null; do sleep 0.2; done; \
+	fi; \
+	echo "==> Installing to /Applications..."; \
+	rm -rf /Applications/WenZi-Lite.app; \
+	cp -R dist/WenZi-Lite.app /Applications/; \
+	echo "==> Launching /Applications/WenZi-Lite.app..."; \
+	open /Applications/WenZi-Lite.app
 
 # Remove build artifacts
 clean:

--- a/WenZi-Lite.spec
+++ b/WenZi-Lite.spec
@@ -30,6 +30,7 @@ a = Analysis(
         (os.path.join(_spec_dir, 'src/wenzi/locales'), 'wenzi/locales'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/vendor'), 'wenzi/ui/vendor'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/templates'), 'wenzi/ui/templates'),
+        (os.path.join(_spec_dir, 'src/wenzi/screenshot/templates'), 'wenzi/screenshot/templates'),
     ],
     hiddenimports=certifi_hiddenimports + [
         # wenzi core

--- a/WenZi.spec
+++ b/WenZi.spec
@@ -36,6 +36,7 @@ a = Analysis(
         (os.path.join(_spec_dir, 'src/wenzi/locales'), 'wenzi/locales'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/vendor'), 'wenzi/ui/vendor'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/templates'), 'wenzi/ui/templates'),
+        (os.path.join(_spec_dir, 'src/wenzi/screenshot/templates'), 'wenzi/screenshot/templates'),
     ],
     hiddenimports=mlx_hiddenimports + mlx_whisper_hiddenimports + sherpa_hiddenimports + librosa_hiddenimports + certifi_hiddenimports + [
         # wenzi core

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wenzi"
-version = "0.1.13"
+version = "0.1.14"
 description = "macOS menubar app: hold hotkey to record, release to transcribe and type"
 requires-python = ">=3.13"
 dependencies = [

--- a/scripts/build-lite.sh
+++ b/scripts/build-lite.sh
@@ -26,11 +26,21 @@ fi
 
 cd "$PROJECT_DIR"
 
+# Parse flags
+FAST=false
+NO_LAUNCH=false
+for arg in "$@"; do
+    case "$arg" in
+        --fast) FAST=true ;;
+        --no-launch) NO_LAUNCH=true ;;
+    esac
+done
+
 echo "==> Setting up Lite venv..."
 test -d .venv-lite || uv venv .venv-lite
 UV_PROJECT_ENVIRONMENT=.venv-lite uv sync --group dev
 
-if [ "${1:-}" = "--fast" ]; then
+if [ "$FAST" = true ]; then
     echo "==> Fast build (incremental, skipping clean)..."
     CLEAN_FLAG=""
 else
@@ -89,7 +99,9 @@ APP_SIZE=$(du -sh "$APP_PATH" | cut -f1)
 echo ""
 echo "==> Build complete: $APP_PATH ($APP_SIZE)"
 
-if [ "${1:-}" = "--fast" ]; then
+if [ "$NO_LAUNCH" = true ]; then
+    echo "    Run with: open $APP_PATH"
+elif [ "$FAST" = true ]; then
     # Kill the running instance (if any) and relaunch
     BUNDLE_ID="io.github.airead.wenzi"
     OLD_PID=$(lsappinfo info -only pid -app "$BUNDLE_ID" 2>/dev/null | grep -o '[0-9]*' || true)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 
 [manifest]
@@ -2624,7 +2624,7 @@ wheels = [
 
 [[package]]
 name = "wenzi"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },


### PR DESCRIPTION
## Summary
- Add `make deploy-lite` / `make deploy-lite-fast` targets that build Lite, install to `/Applications`, and restart the app
- Add `--no-launch` flag to `build-lite.sh` to prevent double-launch when used with deploy targets
- Bundle `screenshot/templates` in both `.spec` files (was missing, causing resource verification failure)
- Bump version to `0.1.14` to enable plugins requiring `>= 0.1.14`

## Test plan
- [x] `make deploy-lite-fast` builds, installs, and launches successfully
- [x] Screenshot templates pass resource verification
- [x] `uv run ruff check` passes
- [x] Pre-existing test failures only (5 in updater/model_registry, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)