### PR TITLE
refactor: second-pass simplification

### DIFF
--- a/src/wenzi/audio/recorder.py
+++ b/src/wenzi/audio/recorder.py
@@ -244,7 +244,7 @@ class Recorder:
 
         audio = np.concatenate(frames)
         duration = len(audio) / self.sample_rate
-        rms = int(np.sqrt(np.mean(audio.astype(np.float64) ** 2)))
+        rms = int(np.sqrt(np.mean(audio.astype(np.int32) ** 2)))
         logger.info(
             "Recording stopped, captured %d samples (%.1fs), RMS=%d",
             len(audio), duration, rms,
@@ -286,7 +286,7 @@ class Recorder:
             logger.warning("Max session size reached, dropping frames")
             return
 
-        self._current_rms = float(np.sqrt(np.mean(frame.astype(np.float64) ** 2)))
+        self._current_rms = float(np.sqrt(np.mean(frame.astype(np.int32) ** 2)))
         self._total_bytes += frame_bytes
         copied = frame.copy()
         try:

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -434,6 +434,38 @@ class RecordingIndicatorPanel:
         except Exception as e:
             logger.warning("Failed to hide recording indicator: %s", e)
 
+    def _rebuild_content_view(self, new_width: int, new_height: int) -> None:
+        """Resize the panel, recreate the content view, re-center, and restart the timer.
+
+        Shared helper for update_mode() and update_device_name().
+        """
+        from AppKit import NSScreen
+        from Foundation import NSTimer
+
+        self._clear_view_backref()
+        content_view = self._indicator_view.create_view(new_width, new_height)
+        self._panel.setContentSize_((float(new_width), float(new_height)))
+        self._panel.setContentView_(content_view)
+
+        # Re-center on screen
+        screen = NSScreen.mainScreen()
+        if screen:
+            sf = screen.visibleFrame()
+            x = sf.origin.x + (sf.size.width - new_width) / 2
+            y = sf.origin.y + (sf.size.height - new_height) / 2
+            self._panel.setFrameOrigin_((x, y))
+
+        # Restart refresh timer with new content view
+        if self._timer is not None:
+            self._timer.invalidate()
+        self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+            _REFRESH_INTERVAL,
+            content_view,
+            b"refresh:",
+            None,
+            True,
+        )
+
     def update_mode(self, name: str, can_prev: bool, can_next: bool) -> None:
         """Update the mode label and nav arrow state on the indicator.
 
@@ -455,41 +487,11 @@ class RecordingIndicatorPanel:
 
         if self._panel is not None:
             try:
-                from AppKit import NSScreen
-
                 current_width = self._panel.frame().size.width
                 if current_width < _PANEL_WIDTH_WITH_MODE:
-                    current_height = self._panel.frame().size.height
-                    self._panel.setContentSize_(
-                        (float(_PANEL_WIDTH_WITH_MODE), float(current_height))
-                    )
-                    # Clear old view's back-reference before creating new one
-                    self._clear_view_backref()
-                    # Recreate content view at new width
-                    content_view = self._indicator_view.create_view(
-                        _PANEL_WIDTH_WITH_MODE, int(current_height)
-                    )
-                    self._panel.setContentView_(content_view)
-
-                    # Re-center on screen
-                    screen = NSScreen.mainScreen()
-                    if screen:
-                        sf = screen.visibleFrame()
-                        x = sf.origin.x + (sf.size.width - _PANEL_WIDTH_WITH_MODE) / 2
-                        y = sf.origin.y + (sf.size.height - current_height) / 2
-                        self._panel.setFrameOrigin_((x, y))
-
-                    # Restart refresh timer with new content view
-                    from Foundation import NSTimer
-
-                    if self._timer is not None:
-                        self._timer.invalidate()
-                    self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                        _REFRESH_INTERVAL,
-                        content_view,
-                        b"refresh:",
-                        None,
-                        True,
+                    current_height = int(self._panel.frame().size.height)
+                    self._rebuild_content_view(
+                        _PANEL_WIDTH_WITH_MODE, current_height
                     )
             except Exception:
                 logger.debug("Failed to resize panel for mode display", exc_info=True)
@@ -513,41 +515,12 @@ class RecordingIndicatorPanel:
             return
 
         try:
-            from AppKit import NSScreen
-            from Foundation import NSTimer
-
             self._indicator_view._device_name = device_name
             # Reset cached label attrs so they are rebuilt on next draw
             self._indicator_view._label_attrs = None
 
-            new_height = _PANEL_HEIGHT_WITH_LABEL
             current_width = int(self._panel.frame().size.width)
-
-            # Clear old view's back-reference before creating new one
-            self._clear_view_backref()
-            # Resize panel and content view (preserve current width)
-            content_view = self._indicator_view.create_view(current_width, new_height)
-            self._panel.setContentSize_((float(current_width), float(new_height)))
-            self._panel.setContentView_(content_view)
-
-            # Re-center on screen
-            screen = NSScreen.mainScreen()
-            if screen:
-                sf = screen.visibleFrame()
-                x = sf.origin.x + (sf.size.width - current_width) / 2
-                y = sf.origin.y + (sf.size.height - new_height) / 2
-                self._panel.setFrameOrigin_((x, y))
-
-            # Restart refresh timer with new content view
-            if self._timer is not None:
-                self._timer.invalidate()
-            self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                _REFRESH_INTERVAL,
-                content_view,
-                b"refresh:",
-                None,
-                True,
-            )
+            self._rebuild_content_view(current_width, _PANEL_HEIGHT_WITH_LABEL)
 
             logger.debug("Recording indicator updated with device: %s", device_name)
         except Exception:

--- a/src/wenzi/config.py
+++ b/src/wenzi/config.py
@@ -23,22 +23,6 @@ MODIFIER_KEY_CHOICES = [
 _VALID_MODIFIER_KEYS = {k for k, _ in MODIFIER_KEY_CHOICES}
 
 
-def get_modifier_key_choices():
-    """Return modifier key choices with translated display labels."""
-    from wenzi.i18n import t
-    return [
-        ("space", t("config.modifier_key.space")),
-        ("cmd", t("config.modifier_key.cmd")),
-        ("cmd_r", t("config.modifier_key.cmd_r")),
-        ("ctrl", t("config.modifier_key.ctrl")),
-        ("ctrl_r", t("config.modifier_key.ctrl_r")),
-        ("alt", t("config.modifier_key.alt")),
-        ("alt_r", t("config.modifier_key.alt_r")),
-        ("shift", t("config.modifier_key.shift")),
-        ("shift_r", t("config.modifier_key.shift_r")),
-        ("esc", t("config.modifier_key.esc")),
-    ]
-
 # XDG Base Directory paths
 DEFAULT_CONFIG_DIR = os.path.join("~", ".config", "WenZi")
 DEFAULT_DATA_DIR = os.path.join("~", ".local", "share", "WenZi")
@@ -65,8 +49,6 @@ DEFAULT_CHOOSER_USAGE_PATH = os.path.join(DEFAULT_DATA_DIR, "chooser_usage.json"
 DEFAULT_CHOOSER_HISTORY_PATH = os.path.join(DEFAULT_DATA_DIR, "chooser_history.json")
 DEFAULT_SCRIPT_DATA_PATH = os.path.join(DEFAULT_DATA_DIR, "script_data.json")
 DEFAULT_SNIPPET_LAST_CATEGORY_PATH = os.path.join(DEFAULT_DATA_DIR, "snippet_last_category")
-DEFAULT_KEYCHAIN_VAULT_PATH = os.path.join(DEFAULT_DATA_DIR, "keychain.json")
-
 # Cache files (can be safely deleted and regenerated)
 DEFAULT_ICON_CACHE_DIR = os.path.join(DEFAULT_CACHE_DIR, "icon_cache")
 

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -1125,15 +1125,6 @@ class RecordingFlow:
         if not animate:
             AppHelper.callAfter(self._app._recording_indicator.hide)
 
-    def start_recording_indicator(self, device_name: str | None = None) -> None:
-        """Show visual indicator (for external callers)."""
-        from PyObjCTools import AppHelper
-        AppHelper.callAfter(self._app._recording_indicator.show, device_name)
-
-    def stop_recording_indicator(self, animate: bool = False) -> None:
-        """Stop polling and optionally hide indicator (for external callers)."""
-        self._stop_indicator(animate)
-
     def _reset_to_idle(self) -> None:
         """Common cleanup: hide overlays/indicator and restore idle status."""
         self._app._busy = False

--- a/src/wenzi/enhance/conversation_history.py
+++ b/src/wenzi/enhance/conversation_history.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from wenzi.config import DEFAULT_DATA_DIR
 from wenzi.enhance.text_diff import inline_diff
@@ -509,6 +509,64 @@ class ConversationHistory:
         """
         return self.update_record(timestamp, final_text=new_final_text)
 
+    def _rewrite_matching_record(
+        self,
+        timestamp: str,
+        transform: Callable[[Dict[str, Any]], Optional[str]],
+    ) -> bool:
+        """Find a record by timestamp and rewrite the file with a transform.
+
+        Reads all lines, finds the first record matching *timestamp*, calls
+        *transform(record)* on the parsed dict.  If transform returns a
+        string, it replaces the original line; if it returns ``None``, the
+        line is dropped (deleted).
+
+        Uses atomic file replacement via a temporary file + ``os.replace()``.
+
+        Returns:
+            True if a matching record was found (and the file rewritten).
+        """
+        if not os.path.exists(self._history_path):
+            return False
+
+        try:
+            with open(self._history_path, "r", encoding="utf-8") as f:
+                lines = f.readlines()
+        except Exception as e:
+            logger.warning("Failed to read conversation history: %s", e)
+            return False
+
+        found = False
+        new_lines: List[str] = []
+        for line in lines:
+            stripped = line.strip()
+            if not stripped:
+                new_lines.append(line)
+                continue
+            try:
+                record = json.loads(stripped)
+            except json.JSONDecodeError:
+                new_lines.append(line)
+                continue
+
+            if record.get("timestamp") == timestamp and not found:
+                found = True
+                replacement = transform(record)
+                if replacement is not None:
+                    new_lines.append(replacement)
+            else:
+                new_lines.append(line)
+
+        if not found:
+            return False
+
+        tmp_path = self._history_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            f.writelines(new_lines)
+        os.replace(tmp_path, self._history_path)
+
+        return True
+
     def update_record(self, timestamp: str, **fields: Any) -> bool:
         """Update one or more fields of a record identified by timestamp.
 
@@ -524,46 +582,17 @@ class ConversationHistory:
         """
         if not fields:
             return False
-        if not os.path.exists(self._history_path):
-            return False
 
-        try:
-            with open(self._history_path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
-        except Exception as e:
-            logger.warning("Failed to read conversation history: %s", e)
-            return False
-
-        found = False
         edit_ts = datetime.now(timezone.utc).isoformat()
-        new_lines: List[str] = []
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                new_lines.append(line)
-                continue
-            try:
-                record = json.loads(stripped)
-            except json.JSONDecodeError:
-                new_lines.append(line)
-                continue
 
-            if record.get("timestamp") == timestamp and not found:
-                for key, value in fields.items():
-                    record[key] = value
-                record["edited_at"] = edit_ts
-                new_lines.append(json.dumps(record, ensure_ascii=False) + "\n")
-                found = True
-            else:
-                new_lines.append(line)
+        def _transform(record: Dict[str, Any]) -> Optional[str]:
+            for key, value in fields.items():
+                record[key] = value
+            record["edited_at"] = edit_ts
+            return json.dumps(record, ensure_ascii=False) + "\n"
 
-        if not found:
+        if not self._rewrite_matching_record(timestamp, _transform):
             return False
-
-        tmp_path = self._history_path + ".tmp"
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.writelines(new_lines)
-        os.replace(tmp_path, self._history_path)
 
         cache_fields = {**fields, "edited_at": edit_ts}
         self._update_cache_record(timestamp, cache_fields)
@@ -583,42 +612,12 @@ class ConversationHistory:
         Returns:
             True if record was found and deleted, False otherwise.
         """
-        if not os.path.exists(self._history_path):
+
+        def _transform(record: Dict[str, Any]) -> Optional[str]:
+            return None
+
+        if not self._rewrite_matching_record(timestamp, _transform):
             return False
-
-        try:
-            with open(self._history_path, "r", encoding="utf-8") as f:
-                lines = f.readlines()
-        except Exception as e:
-            logger.warning("Failed to read conversation history: %s", e)
-            return False
-
-        found = False
-        new_lines: List[str] = []
-        for line in lines:
-            stripped = line.strip()
-            if not stripped:
-                new_lines.append(line)
-                continue
-            try:
-                record = json.loads(stripped)
-            except json.JSONDecodeError:
-                new_lines.append(line)
-                continue
-
-            if record.get("timestamp") == timestamp and not found:
-                found = True
-                # Skip this line (delete)
-            else:
-                new_lines.append(line)
-
-        if not found:
-            return False
-
-        tmp_path = self._history_path + ".tmp"
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            f.writelines(new_lines)
-        os.replace(tmp_path, self._history_path)
 
         self._delete_cache_record(timestamp)
         if self._full_cache is not None:

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -61,6 +61,16 @@ _VK_TO_NAME.update({vk: name for name, (vk, _flag) in _MOD_VK.items()})
 # All known key names (for validation)
 _ALL_KEY_NAMES = set(_KEYCODE_MAP) | set(_SPECIAL_VK) | set(_MOD_VK) | {"option", "command"}
 
+def _normalize_key_name(name: str) -> str:
+    """Normalize a key name: strip, lowercase, and map aliases."""
+    n = name.strip().lower()
+    if n == "option":
+        n = "alt"
+    elif n == "command":
+        n = "cmd"
+    return n
+
+
 # Snapshot built-in maps so script-registered keys can be cleanly reverted
 _BUILTIN_SPECIAL_VK = dict(_SPECIAL_VK)
 _BUILTIN_VK_TO_NAME = dict(_VK_TO_NAME)
@@ -101,11 +111,7 @@ def unregister_custom_keys() -> None:
 
 def _name_to_vk(name: str) -> int:
     """Convert a key name to its macOS virtual keycode."""
-    name = name.strip().lower()
-    if name == "option":
-        name = "alt"
-    elif name == "command":
-        name = "cmd"
+    name = _normalize_key_name(name)
     if name in _KEYCODE_MAP:
         return _KEYCODE_MAP[name]
     if name in _SPECIAL_VK:
@@ -120,11 +126,6 @@ def _is_fn_key(name: str) -> bool:
 
 
 _MODIFIER_VKS = frozenset(vk for vk, _flag in _MOD_VK.values())
-
-
-def _is_modifier_vk(vk: int) -> bool:
-    """Check if a virtual keycode is a modifier key."""
-    return vk in _MODIFIER_VKS
 
 
 def _is_modifier_like_vk(vk: int) -> bool:
@@ -151,10 +152,7 @@ def _parse_hotkey_for_quartz(hotkey_str: str) -> tuple[int, int]:
     mod_flags = 0
     trigger_keys = []
     for part in parts:
-        if part == "option":
-            part = "alt"
-        elif part == "command":
-            part = "cmd"
+        part = _normalize_key_name(part)
         if part in _MOD_FLAGS:
             mod_flags |= _MOD_FLAGS[part]
         elif part in _KEYCODE_MAP:
@@ -727,11 +725,7 @@ class MultiHotkeyListener:
 
         self._has_non_modifier_trigger = False
         for name in key_names:
-            n = name.strip().lower()
-            if n == "option":
-                n = "alt"
-            elif n == "command":
-                n = "cmd"
+            n = _normalize_key_name(name)
             vk = _name_to_vk(n)
             self._target_vks[vk] = n
             self._enabled_names.add(n)
@@ -836,11 +830,7 @@ class MultiHotkeyListener:
 
     def enable_key(self, key_name: str) -> None:
         """Enable a key dynamically."""
-        n = key_name.strip().lower()
-        if n == "option":
-            n = "alt"
-        elif n == "command":
-            n = "cmd"
+        n = _normalize_key_name(key_name)
         vk = _name_to_vk(n)
         self._target_vks[vk] = n
         self._enabled_names.add(n)
@@ -848,11 +838,7 @@ class MultiHotkeyListener:
 
     def disable_key(self, key_name: str) -> None:
         """Disable a key dynamically."""
-        n = key_name.strip().lower()
-        if n == "option":
-            n = "alt"
-        elif n == "command":
-            n = "cmd"
+        n = _normalize_key_name(key_name)
         vk = _name_to_vk(n)
         self._target_vks.pop(vk, None)
         self._enabled_names.discard(n)
@@ -862,21 +848,13 @@ class MultiHotkeyListener:
 
     def set_restart_key(self, key_name: str) -> None:
         """Change the restart key at runtime."""
-        n = key_name.strip().lower()
-        if n == "option":
-            n = "alt"
-        elif n == "command":
-            n = "cmd"
+        n = _normalize_key_name(key_name)
         self._restart_key = n
         logger.info("Restart key set to: %s", n)
 
     def set_cancel_key(self, key_name: str) -> None:
         """Change the cancel key at runtime."""
-        n = key_name.strip().lower()
-        if n == "option":
-            n = "alt"
-        elif n == "command":
-            n = "cmd"
+        n = _normalize_key_name(key_name)
         self._cancel_key = n
         logger.info("Cancel key set to: %s", n)
 

--- a/src/wenzi/scripting/clipboard_monitor.py
+++ b/src/wenzi/scripting/clipboard_monitor.py
@@ -331,15 +331,6 @@ class _ClipboardDB:
         row = cur.fetchone()
         return row[0] if row else ""
 
-    def latest_image_path(self) -> str:
-        """Return the image_path of the most recent entry, or ''."""
-        cur = self._conn.execute(
-            "SELECT image_path FROM entries ORDER BY timestamp DESC LIMIT 1",
-        )
-        row = cur.fetchone()
-        return row[0] if row else ""
-
-
 # ---------------------------------------------------------------------------
 # JSON migration helper
 # ---------------------------------------------------------------------------
@@ -466,11 +457,6 @@ class ClipboardMonitor:
     def image_dir(self) -> str:
         """Return the image directory used by this monitor instance."""
         return self._image_dir
-
-    @staticmethod
-    def default_image_dir() -> str:
-        """Return the default directory for clipboard image storage."""
-        return _DEFAULT_IMAGE_DIR
 
     @property
     def icon_cache_dir(self) -> str:

--- a/src/wenzi/scripting/sources/app_source.py
+++ b/src/wenzi/scripting/sources/app_source.py
@@ -79,30 +79,38 @@ def _get_app_icon_png(path: str) -> Optional[bytes]:
         from AppKit import (
             NSBitmapImageRep,
             NSCompositingOperationCopy,
-            NSImage,
+            NSDeviceRGBColorSpace,
+            NSGraphicsContext,
             NSPNGFileType,
             NSWorkspace,
         )
-        from Foundation import NSMakeRect, NSSize
+        from Foundation import NSMakeRect, NSZeroRect
 
         ws = NSWorkspace.sharedWorkspace()
         icon = ws.iconForFile_(path)
         if icon is None:
             return None
 
-        # Render into a fixed-size image to control pixel output
-        size = NSSize(_ICON_SIZE, _ICON_SIZE)
-        target = NSImage.alloc().initWithSize_(size)
-        target.lockFocus()
+        # Render into a bitmap rep (thread-safe, no deprecated lockFocus)
+        sz = _ICON_SIZE
+        rep = NSBitmapImageRep.alloc() \
+            .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
+                None, sz, sz, 8, 4, True, False,
+                NSDeviceRGBColorSpace, 0, 0,
+            )
+        if rep is None:
+            return None
+        ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
+        if ctx is None:
+            return None
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.setCurrentContext_(ctx)
         icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, _ICON_SIZE, _ICON_SIZE),
-            NSMakeRect(0, 0, icon.size().width, icon.size().height),
-            NSCompositingOperationCopy,
-            1.0,
+            NSMakeRect(0, 0, sz, sz), NSZeroRect,
+            NSCompositingOperationCopy, 1.0,
         )
-        target.unlockFocus()
+        NSGraphicsContext.restoreGraphicsState()
 
-        rep = NSBitmapImageRep.imageRepWithData_(target.TIFFRepresentation())
         png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
         return bytes(png_data) if png_data else None
     except Exception:
@@ -168,21 +176,39 @@ def _scan_apps() -> list[dict]:
     return apps
 
 
+_running_apps_cache: set[str] = set()
+_running_apps_time: float = 0.0
+_RUNNING_APPS_TTL: float = 2.0  # seconds
+
+
 def _get_running_app_names() -> set[str]:
-    """Return a set of currently running application names."""
+    """Return a set of currently running application names.
+
+    Results are cached for ``_RUNNING_APPS_TTL`` seconds so that rapid
+    keystroke-driven searches don't re-query NSWorkspace every time.
+    """
+    global _running_apps_cache, _running_apps_time
+
+    now = time.monotonic()
+    if now - _running_apps_time < _RUNNING_APPS_TTL:
+        return _running_apps_cache
+
     try:
         from AppKit import NSWorkspace
 
         workspace = NSWorkspace.sharedWorkspace()
         running = workspace.runningApplications()
-        return {
+        _running_apps_cache = {
             str(app.localizedName())
             for app in running
             if app.localizedName()
         }
     except Exception:
         logger.debug("Failed to get running apps", exc_info=True)
-        return set()
+        _running_apps_cache = set()
+
+    _running_apps_time = now
+    return _running_apps_cache
 
 
 def _launch_app(path: str) -> None:

--- a/src/wenzi/scripting/sources/bookmark_source.py
+++ b/src/wenzi/scripting/sources/bookmark_source.py
@@ -29,7 +29,7 @@ _DEFAULT_ICON_CACHE_DIR = os.path.expanduser(_CFG_ICON_CACHE_DIR)
 class Bookmark:
     """A single browser bookmark."""
 
-    __slots__ = ("name", "url", "folder_path", "browser", "profile")
+    __slots__ = ("name", "url", "folder_path", "browser", "profile", "_domain")
 
     def __init__(
         self,
@@ -44,15 +44,19 @@ class Bookmark:
         self.folder_path = folder_path
         self.browser = browser
         self.profile = profile
+        self._domain: Optional[str] = None
 
     def domain(self) -> str:
-        """Extract the domain from the URL."""
+        """Extract the domain from the URL (cached)."""
+        if self._domain is not None:
+            return self._domain
         try:
             from urllib.parse import urlparse
 
-            return urlparse(self.url).netloc
+            self._domain = urlparse(self.url).netloc
         except Exception:
-            return ""
+            self._domain = ""
+        return self._domain
 
 
 # ---------------------------------------------------------------------------

--- a/src/wenzi/scripting/sources/file_source.py
+++ b/src/wenzi/scripting/sources/file_source.py
@@ -46,6 +46,47 @@ def _icon_png_path_for_folder(icon_cache_dir: str, path: str) -> str:
     return os.path.join(icon_cache_dir, f"folder_{h}.png")
 
 
+def _resize_icon_to_png(icon, png_path: str, icon_cache_dir: str) -> None:
+    """Resize an NSImage icon to _ICON_SIZE and write it as PNG.
+
+    *icon* is an ``NSImage`` obtained from NSWorkspace.  The caller is
+    responsible for checking the disk cache beforehand.
+    """
+    from AppKit import (
+        NSBitmapImageRep,
+        NSCompositingOperationCopy,
+        NSDeviceRGBColorSpace,
+        NSGraphicsContext,
+        NSPNGFileType,
+    )
+    from Foundation import NSMakeRect, NSZeroRect
+
+    sz = _ICON_SIZE
+    rep = NSBitmapImageRep.alloc() \
+        .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
+            None, sz, sz, 8, 4, True, False,
+            NSDeviceRGBColorSpace, 0, 0,
+        )
+    if rep is None:
+        return
+    ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
+    if ctx is None:
+        return
+    NSGraphicsContext.saveGraphicsState()
+    NSGraphicsContext.setCurrentContext_(ctx)
+    icon.drawInRect_fromRect_operation_fraction_(
+        NSMakeRect(0, 0, sz, sz), NSZeroRect,
+        NSCompositingOperationCopy, 1.0,
+    )
+    NSGraphicsContext.restoreGraphicsState()
+
+    png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
+    if png_data:
+        os.makedirs(icon_cache_dir, exist_ok=True)
+        with open(png_path, "wb") as f:
+            f.write(bytes(png_data))
+
+
 def _extract_filetype_icon(ext: str, icon_cache_dir: str) -> None:
     """Extract icon for a file extension and write to disk cache.
 
@@ -56,37 +97,12 @@ def _extract_filetype_icon(ext: str, icon_cache_dir: str) -> None:
     if os.path.isfile(png_path):
         return
     try:
-        from AppKit import (
-            NSBitmapImageRep,
-            NSCompositingOperationCopy,
-            NSImage,
-            NSPNGFileType,
-            NSWorkspace,
-        )
-        from Foundation import NSMakeRect, NSSize
+        from AppKit import NSWorkspace
 
-        ws = NSWorkspace.sharedWorkspace()
-        icon = ws.iconForFileType_(ext)
+        icon = NSWorkspace.sharedWorkspace().iconForFileType_(ext)
         if icon is None:
             return
-
-        size = NSSize(_ICON_SIZE, _ICON_SIZE)
-        target = NSImage.alloc().initWithSize_(size)
-        target.lockFocus()
-        icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, _ICON_SIZE, _ICON_SIZE),
-            NSMakeRect(0, 0, icon.size().width, icon.size().height),
-            NSCompositingOperationCopy,
-            1.0,
-        )
-        target.unlockFocus()
-
-        rep = NSBitmapImageRep.imageRepWithData_(target.TIFFRepresentation())
-        png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
-        if png_data:
-            os.makedirs(icon_cache_dir, exist_ok=True)
-            with open(png_path, "wb") as f:
-                f.write(bytes(png_data))
+        _resize_icon_to_png(icon, png_path, icon_cache_dir)
     except Exception:
         logger.debug("Failed to extract icon for extension %s", ext, exc_info=True)
 
@@ -102,37 +118,12 @@ def _extract_folder_icon(path: str, icon_cache_dir: str) -> None:
     if os.path.isfile(png_path):
         return
     try:
-        from AppKit import (
-            NSBitmapImageRep,
-            NSCompositingOperationCopy,
-            NSImage,
-            NSPNGFileType,
-            NSWorkspace,
-        )
-        from Foundation import NSMakeRect, NSSize
+        from AppKit import NSWorkspace
 
-        ws = NSWorkspace.sharedWorkspace()
-        icon = ws.iconForFile_(path)
+        icon = NSWorkspace.sharedWorkspace().iconForFile_(path)
         if icon is None:
             return
-
-        size = NSSize(_ICON_SIZE, _ICON_SIZE)
-        target = NSImage.alloc().initWithSize_(size)
-        target.lockFocus()
-        icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, _ICON_SIZE, _ICON_SIZE),
-            NSMakeRect(0, 0, icon.size().width, icon.size().height),
-            NSCompositingOperationCopy,
-            1.0,
-        )
-        target.unlockFocus()
-
-        rep = NSBitmapImageRep.imageRepWithData_(target.TIFFRepresentation())
-        png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
-        if png_data:
-            os.makedirs(icon_cache_dir, exist_ok=True)
-            with open(png_path, "wb") as f:
-                f.write(bytes(png_data))
+        _resize_icon_to_png(icon, png_path, icon_cache_dir)
     except Exception:
         logger.debug("Failed to extract folder icon for %s", path, exc_info=True)
 

--- a/src/wenzi/transcription/apple.py
+++ b/src/wenzi/transcription/apple.py
@@ -34,7 +34,6 @@ STREAMING_FINAL_TIMEOUT = 10  # seconds to wait for final result after endAudio
 _SIRI_CHECK_TIMEOUT = 0.3  # seconds to wait for Siri-disabled error
 
 # macOS System Settings deep links
-SIRI_SETTINGS_URL = "x-apple.systempreferences:com.apple.Siri-Settings.extension"
 KEYBOARD_SETTINGS_URL = "x-apple.systempreferences:com.apple.Keyboard-Settings.extension"
 
 

--- a/src/wenzi/transcription/sherpa.py
+++ b/src/wenzi/transcription/sherpa.py
@@ -194,8 +194,11 @@ class SherpaOnnxTranscriber(BaseTranscriber):
         import wave
 
         with wave.open(io.BytesIO(wav_data), "rb") as wf:
-            assert wf.getnchannels() == 1
-            assert wf.getsampwidth() == 2
+            if wf.getnchannels() != 1:
+                raise ValueError(f"Expected mono audio, got {wf.getnchannels()} channels")
+            if wf.getsampwidth() != 2:
+                raise ValueError(f"Expected 16-bit audio, got {wf.getsampwidth() * 8}-bit")
+
             sample_rate = wf.getframerate()
             raw = wf.readframes(wf.getnframes())
 

--- a/src/wenzi/ui/history_browser_window_web.py
+++ b/src/wenzi/ui/history_browser_window_web.py
@@ -28,23 +28,10 @@ def _format_timestamp(ts: str) -> str:
 # NSObject subclasses (lazy-created, unique class names)
 # ---------------------------------------------------------------------------
 
-_HistoryBrowserWebCloseDelegate = None
-
-
 def _get_panel_close_delegate_class():
-    global _HistoryBrowserWebCloseDelegate
-    if _HistoryBrowserWebCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class HistoryBrowserWebCloseDelegate(NSObject):
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.close()
-
-        _HistoryBrowserWebCloseDelegate = HistoryBrowserWebCloseDelegate
-    return _HistoryBrowserWebCloseDelegate
+    return make_panel_close_delegate_class("HistoryBrowserWebCloseDelegate")
 
 
 _HistoryBrowserWebNavigationDelegate = None

--- a/src/wenzi/ui/log_viewer_window.py
+++ b/src/wenzi/ui/log_viewer_window.py
@@ -631,23 +631,8 @@ class LogViewerPanel:
             logger.exception("Failed to copy log path")
 
 
-_PanelCloseDelegate = None
-
-
 def _get_panel_close_delegate_class():
     """Lazily create and cache the NSObject subclass for NSWindowDelegate."""
-    global _PanelCloseDelegate
-    if _PanelCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class LogViewerCloseDelegate(NSObject):
-            """NSWindowDelegate that closes the log viewer when X is clicked."""
-
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.close()
-
-        _PanelCloseDelegate = LogViewerCloseDelegate
-    return _PanelCloseDelegate
+    return make_panel_close_delegate_class("LogViewerCloseDelegate")

--- a/src/wenzi/ui/result_window_web.py
+++ b/src/wenzi/ui/result_window_web.py
@@ -340,25 +340,16 @@ def _get_navigation_delegate_class():
 
 
 # ---------------------------------------------------------------------------
-# Close delegate (lazy-created to avoid PyObjC import at module level)
+# Close delegate (shared factory from web_utils)
 # ---------------------------------------------------------------------------
-_PanelCloseDelegate = None
 
 
 def _get_panel_close_delegate_class():
-    global _PanelCloseDelegate
-    if _PanelCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class WebResultPanelCloseDelegate(NSObject):
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.cancelClicked_(None)
-
-        _PanelCloseDelegate = WebResultPanelCloseDelegate
-    return _PanelCloseDelegate
+    return make_panel_close_delegate_class(
+        "WebResultPanelCloseDelegate", close_method="cancelClicked_"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1015,12 +1006,6 @@ class ResultPreviewPanel:
     @property
     def is_visible(self) -> bool:
         return self._panel is not None and self._panel.isVisible()
-
-    def bring_to_front(self) -> None:
-        if self._panel is not None and self._panel.isVisible():
-            self._panel.makeKeyAndOrderFront_(None)
-            from AppKit import NSApp
-            NSApp.activateIgnoringOtherApps_(True)
 
     def close(self) -> None:
         """Close the panel."""

--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -39,25 +39,14 @@ _BRIDGE_JS = """\
 """
 
 # ---------------------------------------------------------------------------
-# Close delegate (lazy-created to avoid PyObjC import at module level)
+# Close delegate (shared factory from web_utils)
 # ---------------------------------------------------------------------------
-_PanelCloseDelegate = None
 
 
 def _get_panel_close_delegate_class():
-    global _PanelCloseDelegate
-    if _PanelCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class SettingsWebPanelCloseDelegate(NSObject):
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.close()
-
-        _PanelCloseDelegate = SettingsWebPanelCloseDelegate
-    return _PanelCloseDelegate
+    return make_panel_close_delegate_class("SettingsWebPanelCloseDelegate")
 
 
 # ---------------------------------------------------------------------------

--- a/src/wenzi/ui/stats_panel.py
+++ b/src/wenzi/ui/stats_panel.py
@@ -17,25 +17,14 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Close delegate (lazy-created to avoid PyObjC import at module level)
+# Close delegate (shared factory from web_utils)
 # ---------------------------------------------------------------------------
-_PanelCloseDelegate = None
 
 
 def _get_panel_close_delegate_class():
-    global _PanelCloseDelegate
-    if _PanelCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class StatsChartCloseDelegate(NSObject):
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.close()
-
-        _PanelCloseDelegate = StatsChartCloseDelegate
-    return _PanelCloseDelegate
+    return make_panel_close_delegate_class("StatsChartCloseDelegate")
 
 
 def build_stats_payload(

--- a/src/wenzi/ui/vocab_build_window.py
+++ b/src/wenzi/ui/vocab_build_window.py
@@ -120,33 +120,6 @@ class VocabBuildProgressPanel:
 
         AppHelper.callAfter(_append)
 
-    def update_token_usage(
-        self, input_tokens: int, cached_tokens: int, output_tokens: int, total: int
-    ) -> None:
-        """Update the token usage label with confirmed totals. Thread-safe.
-
-        Resets the streaming character counter since the batch is done.
-        """
-        self._confirmed_tokens = total
-        self._stream_chars = 0
-        from PyObjCTools import AppHelper
-
-        def _update():
-            if self._token_label is not None:
-                cached_info = (
-                    t("vocab_build.tokens_cached", cached=f"{cached_tokens:,}")
-                    if cached_tokens else ""
-                )
-                self._token_label.setStringValue_(
-                    t("vocab_build.tokens_detail",
-                      total=f"{total:,}",
-                      input=f"{input_tokens:,}",
-                      cached_info=cached_info,
-                      output=f"{output_tokens:,}")
-                )
-
-        AppHelper.callAfter(_update)
-
     def clear_stream_text(self) -> None:
         """Clear the streaming output view and reset stream char counter. Thread-safe."""
         self._stream_chars = 0
@@ -294,23 +267,10 @@ class VocabBuildProgressPanel:
             callback()
 
 
-_PanelCloseDelegate = None
-
-
 def _get_panel_close_delegate_class():
     """Lazily create and cache the NSObject subclass for NSWindowDelegate."""
-    global _PanelCloseDelegate
-    if _PanelCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class VocabBuildPanelCloseDelegate(NSObject):
-            """NSWindowDelegate that triggers cancel when the panel close button is clicked."""
-
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref._on_close_button()
-
-        _PanelCloseDelegate = VocabBuildPanelCloseDelegate
-    return _PanelCloseDelegate
+    return make_panel_close_delegate_class(
+        "VocabBuildPanelCloseDelegate", close_method="_on_close_button"
+    )

--- a/src/wenzi/ui/vocab_manager_window.py
+++ b/src/wenzi/ui/vocab_manager_window.py
@@ -19,23 +19,10 @@ logger = logging.getLogger(__name__)
 # NSObject subclasses (lazy-created, unique class names)
 # ---------------------------------------------------------------------------
 
-_VocabManagerCloseDelegate = None
-
-
 def _get_panel_close_delegate_class():
-    global _VocabManagerCloseDelegate
-    if _VocabManagerCloseDelegate is None:
-        from Foundation import NSObject
+    from wenzi.ui.web_utils import make_panel_close_delegate_class
 
-        class VocabManagerCloseDelegate(NSObject):
-            _panel_ref = None
-
-            def windowWillClose_(self, notification):
-                if self._panel_ref is not None:
-                    self._panel_ref.close()
-
-        _VocabManagerCloseDelegate = VocabManagerCloseDelegate
-    return _VocabManagerCloseDelegate
+    return make_panel_close_delegate_class("VocabManagerCloseDelegate")
 
 
 _VocabManagerNavigationDelegate = None

--- a/src/wenzi/ui/web_utils.py
+++ b/src/wenzi/ui/web_utils.py
@@ -5,6 +5,45 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
+# ---------------------------------------------------------------------------
+# Panel close delegate factory
+# ---------------------------------------------------------------------------
+_close_delegate_cache: dict[str, type] = {}
+
+
+def make_panel_close_delegate_class(
+    class_name: str, *, close_method: str = "close"
+) -> type:
+    """Create (or return cached) NSObject subclass for panel close delegation.
+
+    Each ObjC class name must be unique across the process, so callers pass a
+    distinct *class_name*.  The generated ``windowWillClose_`` calls
+    ``getattr(self._panel_ref, close_method)()`` — most panels use ``"close"``
+    but some use ``"cancelClicked_"`` or ``"_on_close_button"``.
+    """
+    key = class_name
+    if key in _close_delegate_cache:
+        return _close_delegate_cache[key]
+
+    from Foundation import NSObject
+
+    # Build the method dynamically so *close_method* is captured in closure.
+    def _window_will_close(self, notification):  # noqa: ARG001
+        if self._panel_ref is not None:
+            method = getattr(self._panel_ref, close_method)
+            if close_method.endswith("_"):
+                method(None)
+            else:
+                method()
+
+    attrs = {
+        "_panel_ref": None,
+        "windowWillClose_": _window_will_close,
+    }
+    cls = type(class_name, (NSObject,), attrs)
+    _close_delegate_cache[key] = cls
+    return cls
+
 
 def time_range_cutoff(time_range: str) -> Optional[str]:
     """Return ISO timestamp cutoff for a time range value, or None for 'all'."""

--- a/tests/transcription/test_apple.py
+++ b/tests/transcription/test_apple.py
@@ -8,7 +8,6 @@ import pytest
 from wenzi.transcription.base import BaseTranscriber
 from wenzi.transcription.apple import (
     AppleSpeechTranscriber,
-    SIRI_SETTINGS_URL,
     _LANG_TO_LOCALE,
     _resolve_locale,
 )
@@ -143,12 +142,6 @@ class TestAppleSpeechTranscriberLanguageMapping:
     def test_full_locale_preserved(self):
         t = AppleSpeechTranscriber(language="en-GB")
         assert t._locale_id == "en-GB"
-
-
-class TestSiriSettingsUrl:
-    def test_url_is_string(self):
-        assert isinstance(SIRI_SETTINGS_URL, str)
-        assert SIRI_SETTINGS_URL.startswith("x-apple.systempreferences:")
 
 
 class TestCheckSiriAvailable:


### PR DESCRIPTION
## Summary

- **Dead code:** Remove 10 unused functions/methods/constants across 7 modules
- **Deduplication:** Extract shared close delegate factory (7 panels → 1), key normalization (7→1), icon resize (2→1), recording indicator rebuild, conversation history file rewrite
- **Performance:** int32 RMS in audio callback, cache running app names (2s TTL), cache bookmark domains
- **Correctness:** Replace `assert` with `ValueError` in sherpa.py, replace deprecated `lockFocus` with `NSGraphicsContext` in app_source/file_source

Net: **-154 lines** across 21 files. All 3,684 tests pass.

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -q` — 3,684 passed
- [x] Audio, scripting, enhance, transcription, and UI tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)