### PR TITLE
fix: make Settings a normal window and visible in window switcher

### DIFF
--- a/src/wenzi/scripting/api/window.py
+++ b/src/wenzi/scripting/api/window.py
@@ -353,10 +353,8 @@ class WindowAPI:
         workspace = NSWorkspace.sharedWorkspace()
 
         for app in workspace.runningApplications():
-            if app.activationPolicy() != NSApplicationActivationPolicyRegular:
-                continue
             pid = app.processIdentifier()
-            if pid == own_pid:
+            if pid != own_pid and app.activationPolicy() != NSApplicationActivationPolicyRegular:
                 continue
             app_name = app.localizedName() or ""
             bundle_url = app.bundleURL()

--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -352,7 +352,6 @@ class SettingsWebPanel:
             NSPanel,
             NSResizableWindowMask,
             NSScreen,
-            NSStatusWindowLevel,
             NSTitledWindowMask,
         )
         from Foundation import NSMakeRect
@@ -381,8 +380,8 @@ class SettingsWebPanel:
             NSBackingStoreBuffered,
             False,
         )
-        panel.setLevel_(NSStatusWindowLevel)
-        panel.setFloatingPanel_(True)
+        panel.setLevel_(0)  # NSNormalWindowLevel
+        panel.setFloatingPanel_(False)
         panel.setHidesOnDeactivate_(False)
         panel.setTitle_("Settings")
 


### PR DESCRIPTION
## Summary
- Change Settings panel from `NSStatusWindowLevel` to `NSNormalWindowLevel` so it behaves like a regular window instead of always-on-top.
- Remove own-process exclusion in `WindowAPI.list()` so WenZi's own windows (e.g. Settings) appear in the window switcher plugin.

## Test plan
- [ ] Open Settings, verify it no longer stays on top of other windows
- [ ] Open window switcher (`w`), verify Settings window appears in the list
- [ ] Verify chooser panel itself does not appear in the list (filtered by empty title)

🤖 Generated with [Claude Code](https://claude.com/claude-code)