### PR TITLE
feat: add pinyin search support for Chinese text in chooser

### DIFF
--- a/src/wenzi/scripting/sources/__init__.py
+++ b/src/wenzi/scripting/sources/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -112,6 +113,44 @@ class ChooserSource:
 
 
 # ---------------------------------------------------------------------------
+# Pinyin support (lazy-loaded)
+# ---------------------------------------------------------------------------
+
+_HAS_CJK = re.compile(r"[\u4e00-\u9fff]")
+_IS_ASCII = re.compile(r"^[a-zA-Z0-9]+$")
+
+# Cache: Chinese text → (full_pinyin, pinyin_initials)
+_pinyin_cache: Dict[str, Tuple[str, str]] = {}
+
+
+def _get_pinyin(text: str) -> Tuple[str, str]:
+    """Return (full_pinyin, pinyin_initials) for *text*.
+
+    full_pinyin:  "系统设置" → "xitongshezhi"
+    pinyin_initials: "系统设置" → "xtsh"
+
+    Non-CJK characters are kept as-is in both forms.
+    Results are cached for performance.
+    """
+    if text in _pinyin_cache:
+        return _pinyin_cache[text]
+
+    try:
+        from pypinyin import lazy_pinyin, Style
+
+        full_parts = lazy_pinyin(text, style=Style.NORMAL)
+        initial_parts = lazy_pinyin(text, style=Style.FIRST_LETTER)
+
+        full = "".join(full_parts).lower()
+        initials = "".join(initial_parts).lower()
+    except Exception:
+        full = initials = ""
+
+    _pinyin_cache[text] = (full, initials)
+    return full, initials
+
+
+# ---------------------------------------------------------------------------
 # Fuzzy matching
 # ---------------------------------------------------------------------------
 
@@ -124,7 +163,11 @@ def fuzzy_match(query: str, text: str) -> Tuple[bool, int]:
       - Exact prefix match (score 100)
       - Word-initials / CamelCase match (score 80)
       - Substring match (score 60)
+      - Pinyin full match (score 75) / initials match (score 70)
       - Scattered character match (score 40)
+
+    When *query* is ASCII and *text* contains Chinese characters, pinyin
+    matching is attempted automatically (e.g. "xtsh" matches "系统设置").
     """
     if not query:
         return False, 0
@@ -149,7 +192,28 @@ def fuzzy_match(query: str, text: str) -> Tuple[bool, int]:
     if sub_match:
         return True, 60
 
-    # 4. Scattered character match — query chars appear in order in text
+    # 4. Pinyin match — ASCII query against Chinese text
+    if _IS_ASCII.match(q) and _HAS_CJK.search(text):
+        full_py, init_py = _get_pinyin(text)
+        if full_py:
+            # Full pinyin prefix: "xitong" matches "系统设置"
+            if full_py.startswith(q):
+                return True, 75
+            # Full pinyin substring: "shezhi" matches "系统设置"
+            if q in full_py:
+                return True, 65
+        if init_py:
+            # Pinyin initials prefix: "xtsh" matches "系统设置"
+            if init_py.startswith(q):
+                return True, 70
+            # Pinyin initials scattered: "xsh" matches "系统设置" (xtsh)
+            if _chars_in_order(q, init_py):
+                return True, 50
+        # Scattered chars in full pinyin
+        if full_py and _chars_in_order(q, full_py):
+            return True, 40
+
+    # 5. Scattered character match — query chars appear in order in text
     if _chars_in_order(q, t):
         return True, 40
 

--- a/tests/scripting/test_chooser_sources.py
+++ b/tests/scripting/test_chooser_sources.py
@@ -217,3 +217,83 @@ class TestFuzzyMatchFields:
             "rsync aws", ("", "", "rsync -avz ops@aws-merger-00", ""),
         )
         assert matched is True
+
+
+class TestPinyinMatch:
+    """Pinyin search for Chinese text."""
+
+    def test_full_pinyin_prefix(self):
+        """Full pinyin prefix matches Chinese text."""
+        matched, score = fuzzy_match("xitong", "系统设置")
+        assert matched is True
+        assert score == 75
+
+    def test_full_pinyin_exact(self):
+        """Full pinyin matches entire Chinese text."""
+        matched, score = fuzzy_match("xitongshezhi", "系统设置")
+        assert matched is True
+        assert score == 75
+
+    def test_full_pinyin_substring(self):
+        """Pinyin substring matches Chinese text."""
+        matched, score = fuzzy_match("shezhi", "系统设置")
+        assert matched is True
+        assert score == 65
+
+    def test_pinyin_initials_prefix(self):
+        """Pinyin initials prefix matches Chinese text.
+
+        "系统设置" → initials "xtsz" (xi tong she zhi).
+        """
+        matched, score = fuzzy_match("xtsz", "系统设置")
+        assert matched is True
+        assert score == 70
+
+    def test_pinyin_initials_partial(self):
+        """Partial pinyin initials match via scattered chars in initials."""
+        matched, score = fuzzy_match("xsz", "系统设置")
+        assert matched is True
+        assert score == 50
+
+    def test_pinyin_scattered_full(self):
+        """Scattered chars in full pinyin match."""
+        matched, score = fuzzy_match("xtsh", "系统设置")
+        assert matched is True
+        assert score >= 40
+
+    def test_pinyin_case_insensitive(self):
+        """Pinyin matching is case-insensitive."""
+        matched, score = fuzzy_match("XTSZ", "系统设置")
+        assert matched is True
+        assert score == 70
+
+    def test_pinyin_no_match(self):
+        """Non-matching pinyin returns False."""
+        matched, _ = fuzzy_match("abc", "系统设置")
+        assert matched is False
+
+    def test_ascii_against_ascii_no_pinyin(self):
+        """ASCII query against ASCII text should not trigger pinyin path."""
+        matched, score = fuzzy_match("saf", "Safari")
+        assert matched is True
+        assert score == 100  # prefix match, not pinyin
+
+    def test_pinyin_mixed_text(self):
+        """Chinese text mixed with ASCII: '微信 WeChat'."""
+        matched, score = fuzzy_match("wx", "微信")
+        assert matched is True
+        assert score == 70  # pinyin initials
+
+    def test_pinyin_fields_match(self):
+        """fuzzy_match_fields works with pinyin across fields."""
+        matched, score = fuzzy_match_fields(
+            "xtsh", ("System Settings", "系统设置"),
+        )
+        assert matched is True
+        assert score > 0
+
+    def test_pinyin_score_ordering(self):
+        """Full pinyin prefix scores higher than initials."""
+        _, full_score = fuzzy_match("xitong", "系统设置")
+        _, init_score = fuzzy_match("xtsh", "系统设置")
+        assert full_score > init_score


### PR DESCRIPTION
Enable searching Chinese app names and other chooser items by typing pinyin (e.g. "xitong" or "xtsz" matches "系统设置"). Integrated into the core fuzzy_match() so all sources benefit automatically.