### PR TITLE
fix: drain autorelease pools in CGEventTap callbacks and reclaim WebView memory on hide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,13 +133,40 @@ All `chat.completions.create` calls **must** include `max_tokens` to prevent run
 
 When adding a new LLM call, always set `max_tokens` to a reasonable upper bound for the expected output.
 
+## CGEventTap Autorelease Pool
+
+CGEventTap callbacks run on background threads via `CFRunLoopRun()`. PyObjC creates autoreleased Objective-C wrapper objects (HIDEvent, CGEvent, CGSEventAppendix) for each event that passes through the callback. Without explicit pool management, these objects accumulate indefinitely on the thread.
+
+**Rule:** Always wrap CGEventTap `_callback` methods AND `_run` thread entry points with `objc.autorelease_pool()`:
+
+```python
+import objc
+
+def _callback(self, proxy, event_type, event, refcon):
+    with objc.autorelease_pool():
+        # ... process event ...
+        return event
+
+def _run():
+    with objc.autorelease_pool():
+        # ... create tap, run loop ...
+        CFRunLoopRun()
+```
+
+The per-callback pool is what prevents the leak. The `_run` pool is a defensive measure for the thread's top-level scope.
+
+See `hotkey.py` (`_QuartzAllKeysListener`, `TapHotkeyListener`, `KeyRemapListener`) and `snippet_expander.py` (`SnippetExpander`) for reference implementations.
+
 ## Launcher (Chooser) Panel Lifecycle
 
 The chooser panel (`ChooserPanel`) uses a **hide/reuse** strategy for performance. WKWebView creation + HTML loading is expensive (~200-500ms), so the panel is kept alive across open/close cycles:
 
-- **`close()`** — hides the panel (`orderOut_`) and breaks `_panel_ref` back-references to prevent retain cycles. The NSPanel, WKWebView, and delegates remain alive for reuse.
+- **`close()`** — hides the panel (`orderOut_`), breaks `_panel_ref` back-references to prevent retain cycles, then loads empty HTML to release IOSurface compositing layer buffers. Sets `_page_loaded = False`.
 - **`destroy()`** — fully tears down the panel and webview. Only called during `engine.reload()` when HTML/i18n may have changed.
-- **`show()`** — if a hidden panel exists (`self._panel is not None and self._page_loaded`), it reconnects refs and resets UI via JS instead of rebuilding from scratch.
+- **`show()`** has three paths:
+  1. **Hot path** (`_page_loaded` is True) — reconnects refs and resets UI via JS. Fastest, no HTML reload.
+  2. **Warm path** (panel + webview alive, `_page_loaded` is False) — reconnects refs and reloads the cached `_chooser.html` from disk. The panel is hidden (alpha=0) until `_on_page_loaded` reveals it (alpha=1).
+  3. **Cold path** (no panel) — builds everything from scratch.
 
 When modifying `close()`, do NOT set `self._panel = None` or `self._webview = None` — this would break the reuse path and force a cold start on every open. To prevent retain cycles while hidden, nil out `_panel_ref` on the message handler, navigation delegate, and panel delegate instead.
 

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -12,6 +12,8 @@ import logging
 import threading
 from typing import Callable, Dict, List, Optional
 
+import objc
+
 
 logger = logging.getLogger(__name__)
 
@@ -237,81 +239,82 @@ class _QuartzAllKeysListener:
             self._mod_flags_prev = 0
 
     def _callback(self, proxy, event_type, event, refcon):
-        try:
-            import Quartz
+        with objc.autorelease_pool():
+            try:
+                import Quartz
 
-            if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                logger.warning("CGEventTap disabled by timeout, re-enabling")
-                if self._tap is not None:
-                    Quartz.CGEventTapEnable(self._tap, True)
-                # Re-sync modifier flags: if a modifier key was released
-                # while the tap was disabled, the release event is lost
-                # forever.  Poll the current system flags and fire synthetic
-                # releases for any modifiers that went away.
-                try:
-                    new_flags = Quartz.CGEventSourceFlagsState(
-                        Quartz.kCGEventSourceStateCombinedSessionState
-                    )
-                    seen_masks: set = set()
-                    for _name, (_vk, _mask) in _MOD_VK.items():
-                        if _mask in seen_masks:
-                            continue
-                        seen_masks.add(_mask)
-                        if (self._mod_flags_prev & _mask) and not (new_flags & _mask):
-                            self._on_release(_name)
-                    if (self._mod_flags_prev & _FN_FLAG) and not (new_flags & _FN_FLAG):
-                        self._on_release("fn")
-                    self._mod_flags_prev = new_flags
-                except Exception:
-                    logger.warning(
-                        "Failed to re-sync modifier flags", exc_info=True
-                    )
-                return event
+                if event_type == Quartz.kCGEventTapDisabledByTimeout:
+                    logger.warning("CGEventTap disabled by timeout, re-enabling")
+                    if self._tap is not None:
+                        Quartz.CGEventTapEnable(self._tap, True)
+                    # Re-sync modifier flags: if a modifier key was released
+                    # while the tap was disabled, the release event is lost
+                    # forever.  Poll the current system flags and fire synthetic
+                    # releases for any modifiers that went away.
+                    try:
+                        new_flags = Quartz.CGEventSourceFlagsState(
+                            Quartz.kCGEventSourceStateCombinedSessionState
+                        )
+                        seen_masks: set = set()
+                        for _name, (_vk, _mask) in _MOD_VK.items():
+                            if _mask in seen_masks:
+                                continue
+                            seen_masks.add(_mask)
+                            if (self._mod_flags_prev & _mask) and not (new_flags & _mask):
+                                self._on_release(_name)
+                        if (self._mod_flags_prev & _FN_FLAG) and not (new_flags & _FN_FLAG):
+                            self._on_release("fn")
+                        self._mod_flags_prev = new_flags
+                    except Exception:
+                        logger.warning(
+                            "Failed to re-sync modifier flags", exc_info=True
+                        )
+                    return event
 
-            keycode = Quartz.CGEventGetIntegerValueField(
-                event, Quartz.kCGKeyboardEventKeycode
-            )
+                keycode = Quartz.CGEventGetIntegerValueField(
+                    event, Quartz.kCGKeyboardEventKeycode
+                )
 
-            if event_type == Quartz.kCGEventKeyDown:
-                name = _VK_TO_NAME.get(keycode)
-                if name:
-                    swallow = self._on_press(name)
-                    if swallow and not self._listen_only:
-                        return None
+                if event_type == Quartz.kCGEventKeyDown:
+                    name = _VK_TO_NAME.get(keycode)
+                    if name:
+                        swallow = self._on_press(name)
+                        if swallow and not self._listen_only:
+                            return None
 
-            elif event_type == Quartz.kCGEventKeyUp:
-                name = _VK_TO_NAME.get(keycode)
-                if name:
-                    self._on_release(name)
-
-            elif event_type == Quartz.kCGEventFlagsChanged:
-                flags = Quartz.CGEventGetFlags(event)
-                name = _VK_TO_NAME.get(keycode)
-                if name and name in _MOD_VK:
-                    _vk, mask = _MOD_VK[name]
-                    was_down = bool(self._mod_flags_prev & mask)
-                    is_down = bool(flags & mask)
-                    self._mod_flags_prev = flags
-                    if is_down and not was_down:
-                        self._on_press(name)
-                    elif was_down and not is_down:
+                elif event_type == Quartz.kCGEventKeyUp:
+                    name = _VK_TO_NAME.get(keycode)
+                    if name:
                         self._on_release(name)
-                elif keycode == _FN_KEYCODE:
-                    was_down = bool(self._mod_flags_prev & _FN_FLAG)
-                    is_down = bool(flags & _FN_FLAG)
-                    self._mod_flags_prev = flags
-                    if is_down and not was_down:
-                        self._on_press("fn")
-                    elif was_down and not is_down:
-                        self._on_release("fn")
-                else:
-                    # Unknown modifier key; just update tracked flags
-                    self._mod_flags_prev = flags
 
-        except Exception:
-            logger.warning("_QuartzAllKeysListener callback exception", exc_info=True)
+                elif event_type == Quartz.kCGEventFlagsChanged:
+                    flags = Quartz.CGEventGetFlags(event)
+                    name = _VK_TO_NAME.get(keycode)
+                    if name and name in _MOD_VK:
+                        _vk, mask = _MOD_VK[name]
+                        was_down = bool(self._mod_flags_prev & mask)
+                        is_down = bool(flags & mask)
+                        self._mod_flags_prev = flags
+                        if is_down and not was_down:
+                            self._on_press(name)
+                        elif was_down and not is_down:
+                            self._on_release(name)
+                    elif keycode == _FN_KEYCODE:
+                        was_down = bool(self._mod_flags_prev & _FN_FLAG)
+                        is_down = bool(flags & _FN_FLAG)
+                        self._mod_flags_prev = flags
+                        if is_down and not was_down:
+                            self._on_press("fn")
+                        elif was_down and not is_down:
+                            self._on_release("fn")
+                    else:
+                        # Unknown modifier key; just update tracked flags
+                        self._mod_flags_prev = flags
 
-        return event
+            except Exception:
+                logger.warning("_QuartzAllKeysListener callback exception", exc_info=True)
+
+            return event
 
     def start(self) -> None:
         import Quartz
@@ -334,32 +337,33 @@ class _QuartzAllKeysListener:
         _CFRunLoopRun = Quartz.CFRunLoopRun
 
         def _run():
-            mask = (
-                _CGEventMaskBit(_kCGEventKeyDown)
-                | _CGEventMaskBit(_kCGEventKeyUp)
-                | _CGEventMaskBit(_kCGEventFlagsChanged)
-            )
-            self._tap = _CGEventTapCreate(
-                _kCGSessionEventTap,
-                _kCGHeadInsertEventTap,
-                _kCGEventTapOptionListenOnly if _listen_only else Quartz.kCGEventTapOptionDefault,
-                mask,
-                self._callback,
-                None,
-            )
-            if self._tap is None:
-                logger.error(
-                    "Failed to create Quartz event tap. "
-                    "Check accessibility permissions in System Settings."
+            with objc.autorelease_pool():
+                mask = (
+                    _CGEventMaskBit(_kCGEventKeyDown)
+                    | _CGEventMaskBit(_kCGEventKeyUp)
+                    | _CGEventMaskBit(_kCGEventFlagsChanged)
                 )
-                return
+                self._tap = _CGEventTapCreate(
+                    _kCGSessionEventTap,
+                    _kCGHeadInsertEventTap,
+                    _kCGEventTapOptionListenOnly if _listen_only else Quartz.kCGEventTapOptionDefault,
+                    mask,
+                    self._callback,
+                    None,
+                )
+                if self._tap is None:
+                    logger.error(
+                        "Failed to create Quartz event tap. "
+                        "Check accessibility permissions in System Settings."
+                    )
+                    return
 
-            source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-            self._loop = _CFRunLoopGetCurrent()
-            _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-            _CGEventTapEnable(self._tap, True)
-            logger.info("Quartz all-keys listener started (listen_only=%s)", _listen_only)
-            _CFRunLoopRun()
+                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
+                self._loop = _CFRunLoopGetCurrent()
+                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
+                _CGEventTapEnable(self._tap, True)
+                logger.info("Quartz all-keys listener started (listen_only=%s)", _listen_only)
+                _CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
@@ -402,38 +406,39 @@ class TapHotkeyListener:
             logger.error("on_activate callback error: %s", e)
 
     def _callback(self, proxy, event_type, event, refcon):
-        try:
-            import Quartz
+        with objc.autorelease_pool():
+            try:
+                import Quartz
 
-            if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                logger.warning("CGEventTap disabled by timeout, re-enabling")
-                if self._tap is not None:
-                    Quartz.CGEventTapEnable(self._tap, True)
+                if event_type == Quartz.kCGEventTapDisabledByTimeout:
+                    logger.warning("CGEventTap disabled by timeout, re-enabling")
+                    if self._tap is not None:
+                        Quartz.CGEventTapEnable(self._tap, True)
+                    return event
+
+                if event_type != Quartz.kCGEventKeyDown:
+                    return event
+
+                keycode = Quartz.CGEventGetIntegerValueField(
+                    event, Quartz.kCGKeyboardEventKeycode
+                )
+                flags = Quartz.CGEventGetFlags(event) & _MOD_MASK
+
+                if keycode == self._keycode and flags == self._mod_flags:
+                    logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
+                    # Dispatch to a separate thread so the CGEventTap callback
+                    # returns immediately.  AX queries (used by window management)
+                    # require cross-process IPC that can time out inside the tap
+                    # callback, especially for Electron apps (Chrome, Slack).
+                    threading.Thread(
+                        target=self._run_activate, daemon=True,
+                    ).start()
+                    return None  # Swallow the event
+
                 return event
-
-            if event_type != Quartz.kCGEventKeyDown:
+            except Exception:
+                logger.warning("[TapHotkey] _callback exception", exc_info=True)
                 return event
-
-            keycode = Quartz.CGEventGetIntegerValueField(
-                event, Quartz.kCGKeyboardEventKeycode
-            )
-            flags = Quartz.CGEventGetFlags(event) & _MOD_MASK
-
-            if keycode == self._keycode and flags == self._mod_flags:
-                logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
-                # Dispatch to a separate thread so the CGEventTap callback
-                # returns immediately.  AX queries (used by window management)
-                # require cross-process IPC that can time out inside the tap
-                # callback, especially for Electron apps (Chrome, Slack).
-                threading.Thread(
-                    target=self._run_activate, daemon=True,
-                ).start()
-                return None  # Swallow the event
-
-            return event
-        except Exception:
-            logger.warning("[TapHotkey] _callback exception", exc_info=True)
-            return event
 
     def start(self) -> None:
         import Quartz
@@ -453,28 +458,29 @@ class TapHotkeyListener:
         _CFRunLoopRun = Quartz.CFRunLoopRun
 
         def _run():
-            mask = _CGEventMaskBit(_kCGEventKeyDown)
-            self._tap = _CGEventTapCreate(
-                _kCGSessionEventTap,
-                _kCGHeadInsertEventTap,
-                _kCGEventTapOptionDefault,
-                mask,
-                self._callback,
-                None,
-            )
-            if self._tap is None:
-                logger.error(
-                    "Failed to create Quartz event tap for hotkey. "
-                    "Check accessibility permissions in System Settings."
+            with objc.autorelease_pool():
+                mask = _CGEventMaskBit(_kCGEventKeyDown)
+                self._tap = _CGEventTapCreate(
+                    _kCGSessionEventTap,
+                    _kCGHeadInsertEventTap,
+                    _kCGEventTapOptionDefault,
+                    mask,
+                    self._callback,
+                    None,
                 )
-                return
+                if self._tap is None:
+                    logger.error(
+                        "Failed to create Quartz event tap for hotkey. "
+                        "Check accessibility permissions in System Settings."
+                    )
+                    return
 
-            source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-            self._loop = _CFRunLoopGetCurrent()
-            _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-            _CGEventTapEnable(self._tap, True)
-            logger.info("TapHotkeyListener started: %s", self._hotkey_str)
-            _CFRunLoopRun()
+                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
+                self._loop = _CFRunLoopGetCurrent()
+                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
+                _CGEventTapEnable(self._tap, True)
+                logger.info("TapHotkeyListener started: %s", self._hotkey_str)
+                _CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
@@ -523,83 +529,85 @@ class KeyRemapListener:
         return self._tap is not None
 
     def _callback(self, proxy, event_type, event, refcon):
-        try:
-            import Quartz
+        with objc.autorelease_pool():
+            try:
+                import Quartz
 
-            if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                logger.warning("KeyRemapListener tap disabled by timeout, re-enabling")
-                if self._tap is not None:
-                    Quartz.CGEventTapEnable(self._tap, True)
-                return event
+                if event_type == Quartz.kCGEventTapDisabledByTimeout:
+                    logger.warning("KeyRemapListener tap disabled by timeout, re-enabling")
+                    if self._tap is not None:
+                        Quartz.CGEventTapEnable(self._tap, True)
+                    return event
 
-            if event_type == Quartz.kCGEventFlagsChanged:
-                keycode = Quartz.CGEventGetIntegerValueField(
-                    event, Quartz.kCGKeyboardEventKeycode
-                )
-                remap = self._remaps.get(keycode)
-                if remap and remap[1]:  # is_modifier source
-                    target_vk, _, mod_flag = remap
-                    flags = Quartz.CGEventGetFlags(event)
-                    was_down = bool(self._prev_flags & mod_flag)
-                    is_down = bool(flags & mod_flag)
-                    self._prev_flags = flags
-                    if is_down != was_down:
+                if event_type == Quartz.kCGEventFlagsChanged:
+                    keycode = Quartz.CGEventGetIntegerValueField(
+                        event, Quartz.kCGKeyboardEventKeycode
+                    )
+                    remap = self._remaps.get(keycode)
+                    if remap and remap[1]:  # is_modifier source
+                        target_vk, _, mod_flag = remap
+                        flags = Quartz.CGEventGetFlags(event)
+                        was_down = bool(self._prev_flags & mod_flag)
+                        is_down = bool(flags & mod_flag)
+                        self._prev_flags = flags
+                        if is_down != was_down:
+                            evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
+                            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
+                            return None  # Swallow the original modifier event
+                    return event
+
+                if event_type in (Quartz.kCGEventKeyDown, Quartz.kCGEventKeyUp):
+                    keycode = Quartz.CGEventGetIntegerValueField(
+                        event, Quartz.kCGKeyboardEventKeycode
+                    )
+                    remap = self._remaps.get(keycode)
+                    if remap and not remap[1]:  # non-modifier source
+                        target_vk = remap[0]
+                        is_down = event_type == Quartz.kCGEventKeyDown
                         evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
+                        # Preserve modifier flags from the original event
+                        evt_flags = Quartz.CGEventGetFlags(event)
+                        Quartz.CGEventSetFlags(evt, evt_flags)
                         Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
-                        return None  # Swallow the original modifier event
-                return event
+                        return None  # Swallow the original key event
+                    return event
 
-            if event_type in (Quartz.kCGEventKeyDown, Quartz.kCGEventKeyUp):
-                keycode = Quartz.CGEventGetIntegerValueField(
-                    event, Quartz.kCGKeyboardEventKeycode
-                )
-                remap = self._remaps.get(keycode)
-                if remap and not remap[1]:  # non-modifier source
-                    target_vk = remap[0]
-                    is_down = event_type == Quartz.kCGEventKeyDown
-                    evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
-                    # Preserve modifier flags from the original event
-                    evt_flags = Quartz.CGEventGetFlags(event)
-                    Quartz.CGEventSetFlags(evt, evt_flags)
-                    Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
-                    return None  # Swallow the original key event
                 return event
-
-            return event
-        except Exception:
-            logger.warning("[KeyRemap] _callback exception", exc_info=True)
-            return event
+            except Exception:
+                logger.warning("[KeyRemap] _callback exception", exc_info=True)
+                return event
 
     def start(self) -> None:
         import Quartz
         _pre_resolve_quartz()
 
         def _run():
-            mask = (
-                Quartz.CGEventMaskBit(Quartz.kCGEventFlagsChanged)
-                | Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown)
-                | Quartz.CGEventMaskBit(Quartz.kCGEventKeyUp)
-            )
-            self._tap = Quartz.CGEventTapCreate(
-                Quartz.kCGSessionEventTap,
-                Quartz.kCGHeadInsertEventTap,
-                Quartz.kCGEventTapOptionDefault,
-                mask,
-                self._callback,
-                None,
-            )
-            if self._tap is None:
-                logger.error(
-                    "Failed to create CGEventTap for key remap. "
-                    "Check accessibility permissions."
+            with objc.autorelease_pool():
+                mask = (
+                    Quartz.CGEventMaskBit(Quartz.kCGEventFlagsChanged)
+                    | Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown)
+                    | Quartz.CGEventMaskBit(Quartz.kCGEventKeyUp)
                 )
-                return
-            source = Quartz.CFMachPortCreateRunLoopSource(None, self._tap, 0)
-            self._loop = Quartz.CFRunLoopGetCurrent()
-            Quartz.CFRunLoopAddSource(self._loop, source, Quartz.kCFRunLoopDefaultMode)
-            Quartz.CGEventTapEnable(self._tap, True)
-            logger.info("KeyRemapListener started with %d remap(s)", len(self._remaps))
-            Quartz.CFRunLoopRun()
+                self._tap = Quartz.CGEventTapCreate(
+                    Quartz.kCGSessionEventTap,
+                    Quartz.kCGHeadInsertEventTap,
+                    Quartz.kCGEventTapOptionDefault,
+                    mask,
+                    self._callback,
+                    None,
+                )
+                if self._tap is None:
+                    logger.error(
+                        "Failed to create CGEventTap for key remap. "
+                        "Check accessibility permissions."
+                    )
+                    return
+                source = Quartz.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+                self._loop = Quartz.CFRunLoopGetCurrent()
+                Quartz.CFRunLoopAddSource(self._loop, source, Quartz.kCFRunLoopDefaultMode)
+                Quartz.CGEventTapEnable(self._tap, True)
+                logger.info("KeyRemapListener started with %d remap(s)", len(self._remaps))
+                Quartz.CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()

--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -17,6 +17,8 @@ import threading
 import time
 from typing import TYPE_CHECKING, Optional
 
+import objc
+
 if TYPE_CHECKING:
     from wenzi.scripting.sources.snippet_source import SnippetStore
 
@@ -120,28 +122,29 @@ class SnippetExpander:
         _CFRunLoopRun = Quartz.CFRunLoopRun
 
         def _run():
-            mask = _CGEventMaskBit(_kCGEventKeyDown)
-            self._tap = _CGEventTapCreate(
-                _kCGSessionEventTap,
-                _kCGHeadInsertEventTap,
-                _kCGEventTapOptionListenOnly,
-                mask,
-                self._callback,
-                None,
-            )
-            if self._tap is None:
-                logger.error(
-                    "SnippetExpander: failed to create event tap. "
-                    "Check accessibility permissions."
+            with objc.autorelease_pool():
+                mask = _CGEventMaskBit(_kCGEventKeyDown)
+                self._tap = _CGEventTapCreate(
+                    _kCGSessionEventTap,
+                    _kCGHeadInsertEventTap,
+                    _kCGEventTapOptionListenOnly,
+                    mask,
+                    self._callback,
+                    None,
                 )
-                return
+                if self._tap is None:
+                    logger.error(
+                        "SnippetExpander: failed to create event tap. "
+                        "Check accessibility permissions."
+                    )
+                    return
 
-            source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-            self._loop = _CFRunLoopGetCurrent()
-            _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-            _CGEventTapEnable(self._tap, True)
-            logger.info("SnippetExpander started")
-            _CFRunLoopRun()
+                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
+                self._loop = _CFRunLoopGetCurrent()
+                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
+                _CGEventTapEnable(self._tap, True)
+                logger.info("SnippetExpander started")
+                _CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
@@ -165,59 +168,60 @@ class SnippetExpander:
 
     def _callback(self, proxy, event_type, event, refcon):
         """CGEventTap callback — runs on the tap's background thread."""
-        try:
-            import Quartz
+        with objc.autorelease_pool():
+            try:
+                import Quartz
 
-            if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                logger.warning("SnippetExpander tap disabled by timeout, re-enabling")
-                if self._tap is not None:
-                    Quartz.CGEventTapEnable(self._tap, True)
-                return event
+                if event_type == Quartz.kCGEventTapDisabledByTimeout:
+                    logger.warning("SnippetExpander tap disabled by timeout, re-enabling")
+                    if self._tap is not None:
+                        Quartz.CGEventTapEnable(self._tap, True)
+                    return event
 
-            if self._expanding or self._suppressed:
-                return event
+                if self._expanding or self._suppressed:
+                    return event
 
-            keycode = Quartz.CGEventGetIntegerValueField(
-                event, Quartz.kCGKeyboardEventKeycode,
-            )
-            flags = Quartz.CGEventGetFlags(event)
+                keycode = Quartz.CGEventGetIntegerValueField(
+                    event, Quartz.kCGKeyboardEventKeycode,
+                )
+                flags = Quartz.CGEventGetFlags(event)
 
-            # Ignore events with Cmd/Ctrl/Alt modifiers (shortcuts, not text)
-            mod_mask = (
-                Quartz.kCGEventFlagMaskCommand
-                | Quartz.kCGEventFlagMaskControl
-                | Quartz.kCGEventFlagMaskAlternate
-            )
-            if flags & mod_mask:
+                # Ignore events with Cmd/Ctrl/Alt modifiers (shortcuts, not text)
+                mod_mask = (
+                    Quartz.kCGEventFlagMaskCommand
+                    | Quartz.kCGEventFlagMaskControl
+                    | Quartz.kCGEventFlagMaskAlternate
+                )
+                if flags & mod_mask:
+                    with self._lock:
+                        self._buffer = ""
+                    return event
+
+                # Navigation / control keys clear the buffer
+                if keycode in _CLEAR_KEYCODES:
+                    with self._lock:
+                        self._buffer = ""
+                    return event
+
+                # Extract the actual character typed
+                char = _get_unicode_string(event)
+                if not char or not char.isprintable():
+                    return event
+
+                # Append to buffer
                 with self._lock:
-                    self._buffer = ""
-                return event
+                    self._buffer += char
+                    if len(self._buffer) > _MAX_BUFFER:
+                        self._buffer = self._buffer[-_MAX_BUFFER:]
+                    buf = self._buffer
 
-            # Navigation / control keys clear the buffer
-            if keycode in _CLEAR_KEYCODES:
-                with self._lock:
-                    self._buffer = ""
-                return event
+                # Check for keyword match at the end of buffer
+                self._check_expansion(buf)
 
-            # Extract the actual character typed
-            char = _get_unicode_string(event)
-            if not char or not char.isprintable():
-                return event
+            except Exception:
+                logger.warning("SnippetExpander callback exception", exc_info=True)
 
-            # Append to buffer
-            with self._lock:
-                self._buffer += char
-                if len(self._buffer) > _MAX_BUFFER:
-                    self._buffer = self._buffer[-_MAX_BUFFER:]
-                buf = self._buffer
-
-            # Check for keyword match at the end of buffer
-            self._check_expansion(buf)
-
-        except Exception:
-            logger.warning("SnippetExpander callback exception", exc_info=True)
-
-        return event
+            return event
 
     def _check_expansion(self, buf: str) -> None:
         """Check if the buffer ends with a snippet keyword and trigger expansion."""

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -595,6 +595,16 @@ class ChooserPanel:
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             self._reset_panel_ui(initial_query, placeholder)
+        elif self._panel is not None and self._webview is not None:
+            # Warm path: panel + webview alive but page was unloaded
+            # (empty HTML) to reclaim IOSurface memory.  Reload the
+            # cached HTML — _on_page_loaded will handle pending query,
+            # placeholder, and context.  Hide the panel (alpha=0) until
+            # the page finishes loading to avoid a blank flash.
+            self._reconnect_panel_refs()
+            self._position_on_mouse_screen()
+            self._panel.setAlphaValue_(0.0)
+            self._reload_chooser_html()
         else:
             # First show — build from scratch
             self._build_panel()
@@ -700,6 +710,14 @@ class ChooserPanel:
         # Hide the panel (keep it alive)
         if self._panel is not None:
             self._panel.orderOut_(None)
+
+        # Load empty HTML to release IOSurface compositing layer buffers.
+        # The WKWebView stays alive for fast re-show; only the rendered
+        # content is discarded.  _page_loaded is set to False so the next
+        # show() will reload the HTML from the cached temp file.
+        if self._webview is not None:
+            self._webview.loadHTMLString_baseURL_("", None)
+            self._page_loaded = False
 
         self._current_items = []
         self._history_index = -1
@@ -1538,6 +1556,16 @@ class ChooserPanel:
 
     def _on_page_loaded(self) -> None:
         """Called when WKWebView finishes loading the HTML."""
+        # Guard against the blank-page navigation fired by close().
+        # If show() is called before the blank load completes,
+        # _reconnect_panel_refs restores the delegate ref and this
+        # callback would fire for the empty page.  Ignore it.
+        if self._webview is not None:
+            url = self._webview.URL()
+            url_str = str(url.absoluteString()) if url is not None else ""
+            if not url_str or url_str == "about:blank":
+                return
+
         # Inject i18n translations before flushing pending JS
         self._inject_i18n()
 
@@ -1564,6 +1592,11 @@ class ChooserPanel:
             escaped = json.dumps(self._context_text)
             label = json.dumps(t("chooser.ua.context_label"))
             self._eval_js(f"setContextText({escaped}, {label})")
+
+        # Reveal the panel if it was hidden (alpha=0) during the warm-start
+        # path.  This is a no-op on the cold path where alpha is already 1.
+        if self._panel is not None:
+            self._panel.setAlphaValue_(1.0)
 
     @staticmethod
     def _ensure_edit_menu() -> None:
@@ -1605,6 +1638,37 @@ class ChooserPanel:
         )
         edit_item.setSubmenu_(edit_menu)
         main_menu.addItem_(edit_item)
+
+    def _reload_chooser_html(self) -> None:
+        """Reload the chooser HTML into an existing (but blanked) WKWebView.
+
+        Used by the warm-start path in :meth:`show` after :meth:`close`
+        loaded ``about:blank`` to release IOSurface memory.  The cached
+        HTML file on disk is reused — no need to regenerate it.
+        """
+        from Foundation import NSURL
+
+        from wenzi.config import DEFAULT_CACHE_DIR
+
+        cache_dir = os.path.expanduser(DEFAULT_CACHE_DIR)
+        html_path = os.path.join(cache_dir, "_chooser.html")
+
+        if not os.path.isfile(html_path):
+            # HTML file missing (shouldn't happen) — regenerate it in-place.
+            # Do NOT call destroy() here: we are inside show(), and destroy()
+            # would fire the _on_close callback out of order.
+            logger.warning("Chooser HTML cache missing, regenerating")
+            from wenzi.ui.templates import load_template
+
+            os.makedirs(cache_dir, exist_ok=True)
+            with open(html_path, "w", encoding="utf-8") as f:
+                f.write(load_template("chooser.html"))
+
+        home_dir = os.path.expanduser("~")
+        self._webview.loadFileURL_allowingReadAccessToURL_(
+            NSURL.fileURLWithPath_(html_path),
+            NSURL.fileURLWithPath_(home_dir),
+        )
 
     def _build_panel(self) -> None:
         """Create NSPanel + WKWebView."""


### PR DESCRIPTION
## Summary

- Wrap all CGEventTap `_callback` and `_run` methods with `objc.autorelease_pool()` to drain autoreleased ObjC objects (HIDEvent, CGEvent, CGSEventAppendix) per-event — fixes ~106 MB accumulation over 8 hours
- Load empty HTML in ChooserPanel `close()` to release WKWebView IOSurface compositing buffers (~370 MB); reload cached HTML on re-show via warm-start path with alpha=0→1 reveal
- Guard `_on_page_loaded` against blank-page navigation race
- Document autorelease pool rule and updated chooser lifecycle in CLAUDE.md

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v` — 3754 passed (5 pre-existing failures in updater/funasr)
- [ ] Manual: run WenZi Lite for 1+ hours, check `heap <pid> -s | grep HIDEvent` — count should stay low
- [ ] Manual: open/close chooser repeatedly, check `footprint <web-content-pid>` — graphics MB should drop after close

🤖 Generated with [Claude Code](https://claude.com/claude-code)