### PR TITLE
style: upgrade wz.alert to HUD-style with vibrancy and animations

### DIFF
--- a/src/wenzi/scripting/api/alert.py
+++ b/src/wenzi/scripting/api/alert.py
@@ -1,4 +1,4 @@
-"""vt.alert — floating on-screen alert overlay."""
+"""vt.alert — floating on-screen alert overlay (HUD-style)."""
 
 from __future__ import annotations
 
@@ -11,35 +11,22 @@ logger = logging.getLogger(__name__)
 _current_panel = None
 _current_close_timer = None
 
-
-def _dynamic_bg_color():
-    """Semi-transparent background that adapts to light/dark mode."""
-    from AppKit import NSColor
-
-    def _provider(appearance):
-        name = appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        if name and "Dark" in str(name):
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.15, 0.15, 0.15, 0.92)
-        return NSColor.colorWithSRGBRed_green_blue_alpha_(0.97, 0.97, 0.97, 0.92)
-
-    return NSColor.colorWithName_dynamicProvider_(None, _provider)
+# Layout constants
+_FONT_SIZE = 16.0
+_H_PADDING = 28
+_V_PADDING = 12
+_MAX_WIDTH = 600
+_MIN_WIDTH = 160
+_FADE_DURATION = 0.35
 
 
-def _dynamic_text_color():
-    """Text color that adapts to light/dark mode."""
-    from AppKit import NSColor
+def _measure_text(text: str, font):
+    """Measure text size using NSAttributedString for accurate CJK support."""
+    from Foundation import NSAttributedString, NSDictionary, NSFontAttributeName
 
-    def _provider(appearance):
-        name = appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        if name and "Dark" in str(name):
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 1.0)
-        return NSColor.colorWithSRGBRed_green_blue_alpha_(0.1, 0.1, 0.1, 1.0)
-
-    return NSColor.colorWithName_dynamicProvider_(None, _provider)
+    attrs = NSDictionary.dictionaryWithObject_forKey_(font, NSFontAttributeName)
+    astr = NSAttributedString.alloc().initWithString_attributes_(text, attrs)
+    return astr.size()
 
 
 def alert(text: str, duration: float = 2.0) -> None:
@@ -58,18 +45,22 @@ def _show_alert(text: str, duration: float) -> None:
     global _current_panel, _current_close_timer
 
     from AppKit import (
+        NSAnimationContext,
         NSBackingStoreBuffered,
         NSColor,
         NSFont,
+        NSFontWeightMedium,
         NSMakeRect,
         NSPanel,
         NSScreen,
         NSStatusWindowLevel,
         NSTextAlignmentCenter,
         NSTextField,
+        NSVisualEffectMaterial,
+        NSVisualEffectView,
     )
 
-    # Close existing alert
+    # Close existing alert immediately (no fade)
     if _current_panel is not None:
         _current_panel.orderOut_(None)
         _current_panel = None
@@ -77,14 +68,16 @@ def _show_alert(text: str, duration: float) -> None:
         _current_close_timer.cancel()
         _current_close_timer = None
 
-    # Measure text to size the panel
-    font = NSFont.systemFontOfSize_(18.0)
-    padding = 24
-    # Rough width estimate: 11px per character, min 200
-    text_width = max(len(text) * 11, 200)
-    panel_width = min(text_width + padding * 2, 600)
-    panel_height = 50
+    # Measure text accurately
+    font = NSFont.systemFontOfSize_weight_(_FONT_SIZE, NSFontWeightMedium)
+    text_size = _measure_text(text, font)
+    text_width = text_size.width
+    text_height = text_size.height
 
+    panel_width = min(max(text_width + _H_PADDING * 2, _MIN_WIDTH), _MAX_WIDTH)
+    panel_height = text_height + _V_PADDING * 2
+
+    # Borderless panel
     panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
         NSMakeRect(0, 0, panel_width, panel_height),
         0,  # NSBorderlessWindowMask
@@ -93,29 +86,37 @@ def _show_alert(text: str, duration: float) -> None:
     )
     panel.setLevel_(NSStatusWindowLevel + 1)
     panel.setOpaque_(False)
-    panel.setBackgroundColor_(_dynamic_bg_color())
+    panel.setBackgroundColor_(NSColor.clearColor())
     panel.setHasShadow_(True)
     panel.setIgnoresMouseEvents_(True)
     panel.setMovableByWindowBackground_(False)
     panel.setHidesOnDeactivate_(False)
     panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
 
-    # Round corners
-    panel.contentView().setWantsLayer_(True)
-    panel.contentView().layer().setCornerRadius_(10.0)
-    panel.contentView().layer().setMasksToBounds_(True)
+    # Vibrancy background (macOS frosted glass)
+    vibrancy = NSVisualEffectView.alloc().initWithFrame_(
+        NSMakeRect(0, 0, panel_width, panel_height)
+    )
+    vibrancy.setMaterial_(NSVisualEffectMaterial.HUDWindow)
+    vibrancy.setState_(1)  # NSVisualEffectStateActive — always active
+    vibrancy.setWantsLayer_(True)
+    vibrancy.layer().setCornerRadius_(panel_height / 2)  # pill shape
+    vibrancy.layer().setMasksToBounds_(True)
+    panel.contentView().addSubview_(vibrancy)
 
     # Text label
     label = NSTextField.labelWithString_(text)
-    label.setFrame_(NSMakeRect(padding, 8, panel_width - padding * 2, 34))
+    label.setFrame_(
+        NSMakeRect(_H_PADDING, _V_PADDING, panel_width - _H_PADDING * 2, text_height)
+    )
     label.setFont_(font)
-    label.setTextColor_(_dynamic_text_color())
+    label.setTextColor_(NSColor.labelColor())
     label.setAlignment_(NSTextAlignmentCenter)
     label.setBackgroundColor_(NSColor.clearColor())
     label.setBezeled_(False)
     label.setEditable_(False)
     label.setSelectable_(False)
-    panel.contentView().addSubview_(label)
+    vibrancy.addSubview_(label)
 
     # Position: center-top of main screen
     screen = NSScreen.mainScreen()
@@ -125,10 +126,17 @@ def _show_alert(text: str, duration: float) -> None:
         y = sf.origin.y + sf.size.height - panel_height - 100
         panel.setFrameOrigin_((x, y))
 
+    panel.setAlphaValue_(0.0)
     panel.orderFrontRegardless()
     _current_panel = panel
 
-    # Auto-dismiss
+    # Fade in
+    NSAnimationContext.beginGrouping()
+    NSAnimationContext.currentContext().setDuration_(0.15)
+    panel.animator().setAlphaValue_(1.0)
+    NSAnimationContext.endGrouping()
+
+    # Auto-dismiss with fade out
     def _close():
         from PyObjCTools import AppHelper
 
@@ -140,13 +148,32 @@ def _show_alert(text: str, duration: float) -> None:
 
 
 def _dismiss_alert(panel) -> None:
-    """Close the alert panel. Must run on main thread."""
+    """Fade out and close the alert panel. Must run on main thread."""
     global _current_panel, _current_close_timer
 
-    try:
-        panel.orderOut_(None)
-    except Exception:
-        pass
-    if _current_panel is panel:
-        _current_panel = None
-    _current_close_timer = None
+    from AppKit import NSAnimationContext
+
+    if _current_panel is not panel:
+        # A newer alert has replaced this one; just remove quietly
+        try:
+            panel.orderOut_(None)
+        except Exception:
+            pass
+        return
+
+    def _on_fade_complete():
+        global _current_panel, _current_close_timer
+        try:
+            panel.orderOut_(None)
+        except Exception:
+            pass
+        if _current_panel is panel:
+            _current_panel = None
+        _current_close_timer = None
+
+    NSAnimationContext.beginGrouping()
+    ctx = NSAnimationContext.currentContext()
+    ctx.setDuration_(_FADE_DURATION)
+    ctx.setCompletionHandler_(_on_fade_complete)
+    panel.animator().setAlphaValue_(0.0)
+    NSAnimationContext.endGrouping()


### PR DESCRIPTION
## Summary
- Replace plain semi-transparent background with `NSVisualEffectView` (HUDWindow material) for native macOS frosted glass
- Use `NSAttributedString` text measurement for accurate CJK character sizing (was `len(text) * 11`)
- Pill-shaped capsule (`cornerRadius = height/2`) instead of 10pt rounded rect
- Fade-in (0.15s) and fade-out (0.35s) via `NSAnimationContext`
- Medium-weight system font + `NSColor.labelColor()` for proper dark mode support

## Test plan
- [ ] Trigger `wz.alert("Hello")` — verify frosted glass pill appears center-top
- [ ] Trigger `wz.alert("中文测试消息")` — verify CJK text fits without clipping
- [ ] Verify fade-in on appear and fade-out on dismiss
- [ ] Test rapid successive alerts — new one should replace old immediately
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)