### PR TITLE
style: upgrade leader alert to HUD-style and fix wz.alert imports

### DIFF
--- a/src/wenzi/scripting/api/alert.py
+++ b/src/wenzi/scripting/api/alert.py
@@ -21,12 +21,21 @@ _FADE_DURATION = 0.35
 
 
 def _measure_text(text: str, font):
-    """Measure text size using NSAttributedString for accurate CJK support."""
-    from Foundation import NSAttributedString, NSDictionary, NSFontAttributeName
+    """Measure text size using NSAttributedString for accurate CJK support.
+
+    Returns (ceil_width, ceil_height).  A small buffer is added to width
+    because NSAttributedString.size() returns the typographic bounding box
+    which can be slightly narrower than what NSTextField actually renders.
+    """
+    import math
+
+    from AppKit import NSFontAttributeName
+    from Foundation import NSAttributedString, NSDictionary
 
     attrs = NSDictionary.dictionaryWithObject_forKey_(font, NSFontAttributeName)
     astr = NSAttributedString.alloc().initWithString_attributes_(text, attrs)
-    return astr.size()
+    size = astr.size()
+    return math.ceil(size.width) + 8, math.ceil(size.height)
 
 
 def alert(text: str, duration: float = 2.0) -> None:
@@ -56,7 +65,7 @@ def _show_alert(text: str, duration: float) -> None:
         NSStatusWindowLevel,
         NSTextAlignmentCenter,
         NSTextField,
-        NSVisualEffectMaterial,
+        NSVisualEffectMaterialHUDWindow,
         NSVisualEffectView,
     )
 
@@ -70,9 +79,7 @@ def _show_alert(text: str, duration: float) -> None:
 
     # Measure text accurately
     font = NSFont.systemFontOfSize_weight_(_FONT_SIZE, NSFontWeightMedium)
-    text_size = _measure_text(text, font)
-    text_width = text_size.width
-    text_height = text_size.height
+    text_width, text_height = _measure_text(text, font)
 
     panel_width = min(max(text_width + _H_PADDING * 2, _MIN_WIDTH), _MAX_WIDTH)
     panel_height = text_height + _V_PADDING * 2
@@ -97,7 +104,7 @@ def _show_alert(text: str, duration: float) -> None:
     vibrancy = NSVisualEffectView.alloc().initWithFrame_(
         NSMakeRect(0, 0, panel_width, panel_height)
     )
-    vibrancy.setMaterial_(NSVisualEffectMaterial.HUDWindow)
+    vibrancy.setMaterial_(NSVisualEffectMaterialHUDWindow)
     vibrancy.setState_(1)  # NSVisualEffectStateActive — always active
     vibrancy.setWantsLayer_(True)
     vibrancy.layer().setCornerRadius_(panel_height / 2)  # pill shape

--- a/src/wenzi/scripting/ui/leader_alert.py
+++ b/src/wenzi/scripting/ui/leader_alert.py
@@ -1,7 +1,7 @@
-"""Leader-key floating alert panel.
+"""Leader-key floating alert panel (HUD-style).
 
 Displays available sub-key mappings when a leader trigger key is held.
-Uses native NSPanel + NSTextField for a lightweight, dark-mode-aware overlay.
+Uses NSVisualEffectView for native macOS vibrancy with fade animations.
 """
 
 from __future__ import annotations
@@ -16,50 +16,18 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-def _dynamic_bg_color():
-    """Semi-transparent background that adapts to light/dark mode."""
-    from AppKit import NSColor
-
-    def _provider(appearance):
-        name = appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        if name and "Dark" in str(name):
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.15, 0.15, 0.15, 0.92)
-        return NSColor.colorWithSRGBRed_green_blue_alpha_(0.97, 0.97, 0.97, 0.92)
-
-    return NSColor.colorWithName_dynamicProvider_(None, _provider)
-
-
-def _dynamic_title_color():
-    """Title text color that adapts to light/dark mode."""
-    from AppKit import NSColor
-
-    def _provider(appearance):
-        name = appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        if name and "Dark" in str(name):
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.95, 0.95, 0.95, 1.0)
-        return NSColor.colorWithSRGBRed_green_blue_alpha_(0.1, 0.1, 0.1, 1.0)
-
-    return NSColor.colorWithName_dynamicProvider_(None, _provider)
-
-
-def _dynamic_item_color():
-    """Mapping item text color that adapts to light/dark mode."""
-    from AppKit import NSColor
-
-    def _provider(appearance):
-        name = appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        if name and "Dark" in str(name):
-            return NSColor.colorWithSRGBRed_green_blue_alpha_(0.75, 0.75, 0.75, 1.0)
-        return NSColor.colorWithSRGBRed_green_blue_alpha_(0.35, 0.35, 0.35, 1.0)
-
-    return NSColor.colorWithName_dynamicProvider_(None, _provider)
+# Layout constants
+_PANEL_WIDTH = 360
+_PADDING = 20
+_TITLE_HEIGHT = 26
+_ROW_HEIGHT = 28
+_BADGE_SIZE = 22
+_BADGE_CORNER = 6
+_GAP_AFTER_TITLE = 10
+_GAP_AFTER_SEP = 8
+_CORNER_RADIUS = 14
+_FADE_IN = 0.15
+_FADE_OUT = 0.2
 
 
 class LeaderAlertPanel:
@@ -80,94 +48,158 @@ class LeaderAlertPanel:
     ) -> None:
         """Create and display the leader alert. Must run on main thread."""
         from AppKit import (
+            NSAnimationContext,
             NSBackingStoreBuffered,
             NSColor,
             NSEvent,
             NSFont,
+            NSFontWeightMedium,
+            NSFontWeightSemibold,
             NSMakeRect,
             NSPanel,
             NSScreen,
             NSStatusWindowLevel,
+            NSTextAlignmentCenter,
             NSTextField,
+            NSView,
+            NSVisualEffectMaterialHUDWindow,
+            NSVisualEffectView,
         )
 
         if self._panel is not None:
             self.close()
 
-        padding = 16
-        line_height = 24
-        title_height = 28
-        num_lines = len(mappings)
-        panel_width = 320
-        panel_height = padding + title_height + num_lines * line_height + padding
+        num_rows = len(mappings)
+        panel_height = (
+            _PADDING
+            + _TITLE_HEIGHT
+            + _GAP_AFTER_TITLE
+            + 1  # separator
+            + _GAP_AFTER_SEP
+            + num_rows * _ROW_HEIGHT
+            + _PADDING
+        )
 
+        # --- Panel (borderless, transparent) ---
         panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
-            NSMakeRect(0, 0, panel_width, panel_height),
-            0,  # NSBorderlessWindowMask
+            NSMakeRect(0, 0, _PANEL_WIDTH, panel_height),
+            0,
             NSBackingStoreBuffered,
             False,
         )
         panel.setLevel_(NSStatusWindowLevel + 1)
         panel.setOpaque_(False)
-        panel.setBackgroundColor_(_dynamic_bg_color())
+        panel.setBackgroundColor_(NSColor.clearColor())
         panel.setHasShadow_(True)
         panel.setIgnoresMouseEvents_(True)
         panel.setMovableByWindowBackground_(False)
         panel.setHidesOnDeactivate_(False)
         panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
 
-        # Round corners
-        panel.contentView().setWantsLayer_(True)
-        panel.contentView().layer().setCornerRadius_(10.0)
-        panel.contentView().layer().setMasksToBounds_(True)
+        # --- Vibrancy background ---
+        vibrancy = NSVisualEffectView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, _PANEL_WIDTH, panel_height)
+        )
+        vibrancy.setMaterial_(NSVisualEffectMaterialHUDWindow)
+        vibrancy.setState_(1)  # NSVisualEffectStateActive
+        vibrancy.setWantsLayer_(True)
+        vibrancy.layer().setCornerRadius_(_CORNER_RADIUS)
+        vibrancy.layer().setMasksToBounds_(True)
+        panel.contentView().addSubview_(vibrancy)
 
-        content = panel.contentView()
-
-        # Title
-        y = panel_height - padding - title_height
-        title_font = NSFont.boldSystemFontOfSize_(15.0)
+        # --- Title ---
+        title_font = NSFont.systemFontOfSize_weight_(15.0, NSFontWeightSemibold)
+        y_cursor = panel_height - _PADDING - _TITLE_HEIGHT
         title = NSTextField.labelWithString_(t("leader_alert.title", key=trigger_key))
-        title.setFrame_(NSMakeRect(padding, y, panel_width - padding * 2, title_height))
+        title.setFrame_(
+            NSMakeRect(_PADDING, y_cursor, _PANEL_WIDTH - _PADDING * 2, _TITLE_HEIGHT)
+        )
         title.setFont_(title_font)
-        title.setTextColor_(_dynamic_title_color())
+        title.setTextColor_(NSColor.labelColor())
         title.setBackgroundColor_(NSColor.clearColor())
         title.setBezeled_(False)
         title.setEditable_(False)
         title.setSelectable_(False)
-        content.addSubview_(title)
+        vibrancy.addSubview_(title)
 
-        # Mapping lines (bottom-up layout)
-        item_font = NSFont.monospacedSystemFontOfSize_weight_(14.0, 0.0)
-        item_color = _dynamic_item_color()
+        # --- Separator ---
+        y_cursor -= _GAP_AFTER_TITLE
+        sep = NSView.alloc().initWithFrame_(
+            NSMakeRect(_PADDING, y_cursor, _PANEL_WIDTH - _PADDING * 2, 1)
+        )
+        sep.setWantsLayer_(True)
+        sep.layer().setBackgroundColor_(NSColor.separatorColor().CGColor())
+        vibrancy.addSubview_(sep)
+        y_cursor -= 1 + _GAP_AFTER_SEP
 
-        for i, m in enumerate(mappings):
-            y = panel_height - padding - title_height - (i + 1) * line_height
-            desc = m.desc or m.app or m.exec_cmd or t("leader_alert.default_action")
-            line_text = f"  [{m.key}]  {desc}"
+        # --- Mapping rows ---
+        key_font = NSFont.monospacedSystemFontOfSize_weight_(12.0, NSFontWeightMedium)
+        desc_font = NSFont.systemFontOfSize_weight_(14.0, 0.0)
+        badge_bg_cg = NSColor.colorWithSRGBRed_green_blue_alpha_(
+            0.5, 0.5, 0.5, 0.15
+        ).CGColor()
+        badge_x = _PADDING
+        desc_x = _PADDING + _BADGE_SIZE + 12
+        desc_width = _PANEL_WIDTH - desc_x - _PADDING
 
-            label = NSTextField.labelWithString_(line_text)
-            label.setFrame_(
-                NSMakeRect(padding, y, panel_width - padding * 2, line_height)
+        for m in mappings:
+            row_y = y_cursor - _ROW_HEIGHT
+            badge_y = row_y + (_ROW_HEIGHT - _BADGE_SIZE) / 2
+
+            # Badge background (rounded rect)
+            badge = NSView.alloc().initWithFrame_(
+                NSMakeRect(badge_x, badge_y, _BADGE_SIZE, _BADGE_SIZE)
             )
-            label.setFont_(item_font)
-            label.setTextColor_(item_color)
-            label.setBackgroundColor_(NSColor.clearColor())
-            label.setBezeled_(False)
-            label.setEditable_(False)
-            label.setSelectable_(False)
-            content.addSubview_(label)
+            badge.setWantsLayer_(True)
+            badge.layer().setBackgroundColor_(badge_bg_cg)
+            badge.layer().setCornerRadius_(_BADGE_CORNER)
+            vibrancy.addSubview_(badge)
 
-        # Position the panel on screen
+            # Badge key letter
+            key_label = NSTextField.labelWithString_(m.key.upper())
+            key_label.setFrame_(NSMakeRect(0, 0, _BADGE_SIZE, _BADGE_SIZE))
+            key_label.setFont_(key_font)
+            key_label.setAlignment_(NSTextAlignmentCenter)
+            key_label.setTextColor_(NSColor.labelColor())
+            key_label.setBackgroundColor_(NSColor.clearColor())
+            key_label.setBezeled_(False)
+            key_label.setEditable_(False)
+            key_label.setSelectable_(False)
+            badge.addSubview_(key_label)
+
+            # Description
+            desc_text = m.desc or m.app or m.exec_cmd or t("leader_alert.default_action")
+            desc_label = NSTextField.labelWithString_(desc_text)
+            desc_label.setFrame_(NSMakeRect(desc_x, row_y, desc_width, _ROW_HEIGHT))
+            desc_label.setFont_(desc_font)
+            desc_label.setTextColor_(NSColor.secondaryLabelColor())
+            desc_label.setBackgroundColor_(NSColor.clearColor())
+            desc_label.setBezeled_(False)
+            desc_label.setEditable_(False)
+            desc_label.setSelectable_(False)
+            vibrancy.addSubview_(desc_label)
+
+            y_cursor = row_y
+
+        # --- Position ---
         screen = NSScreen.mainScreen()
         if screen:
             sf = screen.frame()
             x, y = self._calculate_origin(
-                position, panel_width, panel_height, sf, NSEvent,
+                position, _PANEL_WIDTH, panel_height, sf, NSEvent,
             )
             panel.setFrameOrigin_((x, y))
 
+        # --- Fade in ---
+        panel.setAlphaValue_(0.0)
         panel.orderFrontRegardless()
         self._panel = panel
+
+        NSAnimationContext.beginGrouping()
+        NSAnimationContext.currentContext().setDuration_(_FADE_IN)
+        panel.animator().setAlphaValue_(1.0)
+        NSAnimationContext.endGrouping()
+
         logger.debug("Leader alert shown for %s", trigger_key)
 
     @staticmethod
@@ -207,11 +239,25 @@ class LeaderAlertPanel:
         return x, y
 
     def close(self) -> None:
-        """Close the panel. Must run on main thread."""
-        if self._panel is not None:
+        """Fade out and close the panel. Must run on main thread."""
+        if self._panel is None:
+            return
+        panel = self._panel
+        self._panel = None  # mark closed immediately for is_visible
+
+        from AppKit import NSAnimationContext
+
+        def _on_fade_done():
             try:
-                self._panel.orderOut_(None)
+                panel.orderOut_(None)
             except Exception:
                 pass
-            self._panel = None
-            logger.debug("Leader alert closed")
+
+        NSAnimationContext.beginGrouping()
+        ctx = NSAnimationContext.currentContext()
+        ctx.setDuration_(_FADE_OUT)
+        ctx.setCompletionHandler_(_on_fade_done)
+        panel.animator().setAlphaValue_(0.0)
+        NSAnimationContext.endGrouping()
+
+        logger.debug("Leader alert closed")


### PR DESCRIPTION
## Summary
- **Leader alert panel**: replace plain semi-transparent background with `NSVisualEffectView` (HUDWindow vibrancy), add rounded key badges, system semantic colors, separator line, and fade animations
- **wz.alert bugfix**: fix `NSFontAttributeName` import (was `Foundation`, should be `AppKit`), fix `NSVisualEffectMaterial.HUDWindow` → `NSVisualEffectMaterialHUDWindow` (PyObjC flat constant), and add ceil + buffer to text measurement to prevent right-side clipping

## Test plan
- [ ] Press Cmd+R — verify leader panel shows with frosted glass, key badges, separator, and fade-in
- [ ] Release Cmd+R — verify fade-out animation
- [ ] Trigger `wz.alert("Hello")` — verify it actually appears (was broken by import errors)
- [ ] Trigger `wz.alert("中文长文本测试")` — verify text is not clipped on the right
- [ ] Test in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)