### PR TITLE
feat: add ip138 engine and chooser prefix-source hints

### DIFF
--- a/plugins/search_engines/__init__.py
+++ b/plugins/search_engines/__init__.py
@@ -34,7 +34,6 @@ class SearchEngine:
     url: str
     homepage: str = ""
     subtitle: str = ""
-    badge: str = ""
     icon_url: str = ""
 
 
@@ -46,7 +45,6 @@ _DEFAULT_ENGINES = (
         url="https://www.google.com/search?q={query}",
         homepage="https://www.google.com",
         subtitle="General web search",
-        badge="G",
         icon_url="https://www.google.com/favicon.ico",
     ),
     SearchEngine(
@@ -56,7 +54,6 @@ _DEFAULT_ENGINES = (
         url="https://github.com/search?q={query}&type=repositories",
         homepage="https://github.com",
         subtitle="Repository and code search",
-        badge="GH",
         icon_url="https://github.com/favicon.ico",
     ),
     SearchEngine(
@@ -66,7 +63,6 @@ _DEFAULT_ENGINES = (
         url="https://etherscan.io/search?f=0&q={query}",
         homepage="https://etherscan.io",
         subtitle="Address, token, and transaction lookup",
-        badge="ETH",
         icon_url="https://etherscan.io/favicon.ico",
     ),
 )
@@ -106,7 +102,6 @@ def _parse_engine(raw: dict) -> SearchEngine | None:
         url=url,
         homepage=str(raw.get("homepage", "")).strip(),
         subtitle=str(raw.get("subtitle", "")).strip(),
-        badge=str(raw.get("badge", "")).strip(),
         icon_url=str(raw.get("icon_url", "")).strip(),
     )
 
@@ -151,8 +146,6 @@ def _copy_text(wz, text: str, message: str) -> None:
 
 
 def _engine_badge(engine: SearchEngine) -> str:
-    if engine.badge:
-        return engine.badge
     if engine.prefix:
         return engine.prefix.upper()[:4]
     return engine.name.upper()[:4]

--- a/plugins/search_engines/engines.toml
+++ b/plugins/search_engines/engines.toml
@@ -14,7 +14,6 @@ prefix = "g"
 url = "https://www.google.com/search?q={query}"
 homepage = "https://www.google.com"
 subtitle = "General web search"
-badge = "G"
 icon_url = "https://www.google.com/favicon.ico"
 
 [[engines]]
@@ -24,7 +23,6 @@ prefix = "gh"
 url = "https://github.com/search?q={query}&type=repositories"
 homepage = "https://github.com"
 subtitle = "Repository and code search"
-badge = "GH"
 icon_url = "https://github.com/favicon.ico"
 
 [[engines]]
@@ -34,7 +32,6 @@ prefix = "x"
 url = "https://x.com/search?q={query}&src=typed_query"
 homepage = "https://x.com"
 subtitle = "Search posts and profiles"
-badge = "X"
 icon_url = "https://x.com/favicon.ico"
 
 [[engines]]
@@ -44,5 +41,13 @@ prefix = "eth"
 url = "https://etherscan.io/search?f=0&q={query}"
 homepage = "https://etherscan.io"
 subtitle = "Address, token, and transaction lookup"
-badge = "ETH"
 icon_url = "https://etherscan.io/favicon.ico"
+
+[[engines]]
+id = "ip138"
+name = "IP138"
+prefix = "ip"
+url = "https://ip138.com/iplookup.php?ip={raw}&action=2"
+homepage = "https://ip138.com"
+subtitle = "IP address geolocation lookup"
+icon_url = "https://ip138.com/favicon.ico"

--- a/src/wenzi/scripting/sources/__init__.py
+++ b/src/wenzi/scripting/sources/__init__.py
@@ -76,6 +76,7 @@ class ChooserItem:
     confirm_delete: bool = False  # Two-step delete confirmation
     icon_badge: str = ""  # Short text rendered as badge on icon corner
     icon_accessory: str = ""  # Raw HTML injected into icon container
+    complete_text: Optional[str] = None  # If set, Enter fills search box with this text instead of closing
 
 
 @dataclass

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -13,7 +13,7 @@ import os
 from typing import Callable, Dict, List, NamedTuple, Optional
 
 from wenzi.i18n import t
-from wenzi.scripting.sources import ChooserItem, ChooserSource
+from wenzi.scripting.sources import ChooserItem, ChooserSource, fuzzy_match
 from wenzi.ui_helpers import get_frontmost_app, reactivate_app
 
 logger = logging.getLogger(__name__)
@@ -867,6 +867,11 @@ class ChooserPanel:
                 all_items.extend(src.search(query))
             except Exception:
                 logger.exception("Chooser source %s search error", src.name)
+
+        # Inject prefix-source hints when no source is activated
+        if source is None and query.strip():
+            all_items.extend(self._match_prefix_sources(query.strip()))
+
         self._current_items = all_items[: self._MAX_TOTAL_RESULTS]
 
         # Apply usage-based boosting
@@ -920,6 +925,41 @@ class ChooserPanel:
                     self._schedule_debounced_search(asrc, query, generation, delay)
         else:
             self._set_loading(False)
+
+    def _match_prefix_sources(self, query: str) -> List[ChooserItem]:
+        """Return ChooserItems for registered prefixed sources matching *query*.
+
+        Each item's ``complete_text`` is set to ``"<prefix> "`` so that
+        pressing Enter activates the source instead of closing the panel.
+        """
+        hits: list[tuple[int, ChooserItem]] = []
+        for src in self._sources.values():
+            if not src.prefix:
+                continue
+            fields = [src.prefix]
+            if src.display_name:
+                fields.append(src.display_name)
+            fields.append(src.name)
+            if src.description:
+                fields.append(src.description)
+            matched, score = False, 0
+            for f in fields:
+                m, s = fuzzy_match(query, f)
+                if m and s > score:
+                    matched, score = m, s
+            if matched:
+                label = src.display_name or src.name
+                hits.append((
+                    score,
+                    ChooserItem(
+                        title=label,
+                        subtitle=f"{src.prefix}  —  {src.description}" if src.description else src.prefix,
+                        item_id=f"source-hint:{src.name}",
+                        complete_text=src.prefix + " ",
+                    ),
+                ))
+        hits.sort(key=lambda x: -x[0])
+        return [item for _, item in hits]
 
     def _boost_by_usage(self, query: str) -> None:
         """Re-sort items by usage frequency while preserving source order."""
@@ -1431,6 +1471,11 @@ class ChooserPanel:
                     "item_id": item.item_id,
                 },
             )
+
+            # If the item has complete_text, fill search box instead of closing
+            if item.complete_text is not None:
+                self._eval_js(f"setInputValue({json.dumps(item.complete_text, ensure_ascii=False)})")
+                return
 
             from PyObjCTools import AppHelper
 

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -142,16 +142,21 @@ class TestSearchLogic:
         assert panel._current_items[0].title == "hello world"
 
     def test_bare_prefix_does_not_activate_source(self):
-        """Typing just the prefix (without trailing space) should NOT activate source."""
+        """Typing just the prefix (without trailing space) should NOT activate
+        source, but should return a source hint item with complete_text."""
         panel = _make_panel()
         items = [ChooserItem(title="item1"), ChooserItem(title="item2")]
         panel.register_source(
             _make_source("clipboard", prefix="cb", items=items)
         )
         panel._do_search("cb")
-        # Bare prefix without space falls through to general search,
-        # which skips prefix sources — no results
-        assert panel._current_items == []
+        # Bare prefix without space does NOT activate the source (no items
+        # from the source itself), but a prefix-hint item is injected so the
+        # user can press Enter to activate it.
+        assert len(panel._current_items) == 1
+        hint = panel._current_items[0]
+        assert hint.item_id == "source-hint:clipboard"
+        assert hint.complete_text == "cb "
 
     def test_prefix_with_space_only_activates_source(self):
         """Typing prefix + space should activate source with empty query."""


### PR DESCRIPTION
## Summary
- Add ip138 IP geolocation lookup engine to search_engines plugin (prefix: `ip`)
- Remove unused `badge` field from `SearchEngine` dataclass and `engines.toml`
- Add `complete_text` field to `ChooserItem` — when set, pressing Enter fills the search box instead of closing the panel
- Fuzzy-match registered source prefixes/names/descriptions during general search, so typing a partial prefix (e.g. "ip") shows a hint item that activates the source on Enter

## Test plan
- [x] Existing chooser tests updated and passing
- [ ] Type `ip 196.190.88.242` in chooser → opens ip138 lookup
- [ ] Type `ip` (no space) in chooser → shows IP138 source hint → Enter fills `ip ` and activates source
- [ ] Verify other search engines still work (g, gh, x, eth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)