### PR TITLE
fix: release CGEventRef in listen-only tap callbacks via del + return None

### DIFF
--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -271,9 +271,19 @@ class _QuartzAllKeysListener:
                         )
                     return event
 
+                # Extract all data from the event up front so we can
+                # release the CGEventRef early.  CGEventRef is a CF type
+                # freed by CFRelease (not autorelease), so the Python
+                # wrapper must be deleted to trigger CFRelease.
                 keycode = Quartz.CGEventGetIntegerValueField(
                     event, Quartz.kCGKeyboardEventKeycode
                 )
+                flags = Quartz.CGEventGetFlags(event) if event_type == Quartz.kCGEventFlagsChanged else 0
+
+                if self._listen_only:
+                    # Listen-only: return value is ignored by the system,
+                    # so delete the wrapper now and return None.
+                    del event
 
                 if event_type == Quartz.kCGEventKeyDown:
                     name = _VK_TO_NAME.get(keycode)
@@ -288,7 +298,6 @@ class _QuartzAllKeysListener:
                         self._on_release(name)
 
                 elif event_type == Quartz.kCGEventFlagsChanged:
-                    flags = Quartz.CGEventGetFlags(event)
                     name = _VK_TO_NAME.get(keycode)
                     if name and name in _MOD_VK:
                         _vk, mask = _MOD_VK[name]
@@ -314,7 +323,10 @@ class _QuartzAllKeysListener:
             except Exception:
                 logger.warning("_QuartzAllKeysListener callback exception", exc_info=True)
 
-            return event
+            # Listen-only: event was already del'd, return None (ignored
+            # by the system).  Active: return the original event to pass
+            # it through to the focused application.
+            return None if self._listen_only else event
 
     def start(self) -> None:
         import Quartz
@@ -426,10 +438,6 @@ class TapHotkeyListener:
 
                 if keycode == self._keycode and flags == self._mod_flags:
                     logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
-                    # Dispatch to a separate thread so the CGEventTap callback
-                    # returns immediately.  AX queries (used by window management)
-                    # require cross-process IPC that can time out inside the tap
-                    # callback, especially for Electron apps (Chrome, Slack).
                     threading.Thread(
                         target=self._run_activate, daemon=True,
                     ).start()
@@ -564,9 +572,8 @@ class KeyRemapListener:
                     if remap and not remap[1]:  # non-modifier source
                         target_vk = remap[0]
                         is_down = event_type == Quartz.kCGEventKeyDown
-                        evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
-                        # Preserve modifier flags from the original event
                         evt_flags = Quartz.CGEventGetFlags(event)
+                        evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
                         Quartz.CGEventSetFlags(evt, evt_flags)
                         Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
                         return None  # Swallow the original key event

--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -179,12 +179,17 @@ class SnippetExpander:
                     return event
 
                 if self._expanding or self._suppressed:
-                    return event
+                    return None
 
+                # Extract all data from event, then release the CF ref.
+                # CGEventRef is freed by CFRelease (not autorelease), so
+                # we must del the Python wrapper to trigger CFRelease.
                 keycode = Quartz.CGEventGetIntegerValueField(
                     event, Quartz.kCGKeyboardEventKeycode,
                 )
                 flags = Quartz.CGEventGetFlags(event)
+                char = _get_unicode_string(event)
+                del event  # release CGEventRef immediately
 
                 # Ignore events with Cmd/Ctrl/Alt modifiers (shortcuts, not text)
                 mod_mask = (
@@ -195,18 +200,16 @@ class SnippetExpander:
                 if flags & mod_mask:
                     with self._lock:
                         self._buffer = ""
-                    return event
+                    return None
 
                 # Navigation / control keys clear the buffer
                 if keycode in _CLEAR_KEYCODES:
                     with self._lock:
                         self._buffer = ""
-                    return event
+                    return None
 
-                # Extract the actual character typed
-                char = _get_unicode_string(event)
                 if not char or not char.isprintable():
-                    return event
+                    return None
 
                 # Append to buffer
                 with self._lock:
@@ -221,7 +224,7 @@ class SnippetExpander:
             except Exception:
                 logger.warning("SnippetExpander callback exception", exc_info=True)
 
-            return event
+            return None
 
     def _check_expansion(self, buf: str) -> None:
         """Check if the buffer ends with a snippet keyword and trigger expansion."""


### PR DESCRIPTION
## Summary

- `objc.autorelease_pool()` has no effect on CGEventRef (CF type freed by `CFRelease`, not autorelease)
- For **listen-only** taps (`_QuartzAllKeysListener` in listen_only mode, `SnippetExpander`): extract data from event, `del event` to trigger `CFRelease`, return `None` (system ignores return value for passive taps)
- For **active** taps: must return the original event on pass-through paths — cannot `del event` before returning

Fixes the remaining ~0.8 event/sec leak from listen-only taps observed after PR #153.

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/test_hotkey.py tests/scripting/test_snippet_expander.py` — 101 passed
- [ ] Manual: verify keyboard input works normally with WenZi running
- [ ] Manual: `heap <pid> -s | grep HIDEvent` after 30+ min — count should be lower than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)