### PR TITLE
fix: use ctypes CGEventTap to eliminate PyObjC bridge event retention

### DIFF
--- a/src/wenzi/_cgeventtap.py
+++ b/src/wenzi/_cgeventtap.py
@@ -1,0 +1,181 @@
+"""Low-level ctypes bindings for CGEventTap — no PyObjC bridge.
+
+Using ctypes instead of PyObjC for CGEventTapCreate avoids the PyObjC
+callback bridge retaining CGEventRef wrappers indefinitely.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+from ctypes import CFUNCTYPE, c_bool, c_int32, c_int64, c_uint32, c_uint64, c_void_p
+
+# ---------------------------------------------------------------------------
+# Load frameworks
+# ---------------------------------------------------------------------------
+_cg = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreGraphics"))
+_cf = ctypes.cdll.LoadLibrary(ctypes.util.find_library("CoreFoundation"))
+
+# ---------------------------------------------------------------------------
+# Callback type
+# ---------------------------------------------------------------------------
+CGEventTapCallBack = CFUNCTYPE(c_void_p, c_void_p, c_uint32, c_void_p, c_void_p)
+
+# ---------------------------------------------------------------------------
+# Constants (hardcoded — no Quartz import)
+# ---------------------------------------------------------------------------
+kCGSessionEventTap = 1
+kCGHeadInsertEventTap = 0
+
+kCGEventTapOptionDefault = 0
+kCGEventTapOptionListenOnly = 1
+
+kCGEventKeyDown = 10
+kCGEventKeyUp = 11
+kCGEventFlagsChanged = 12
+
+kCGEventTapDisabledByTimeout = 0xFFFFFFFE
+
+kCGKeyboardEventKeycode = 9
+
+kCGAnnotatedSessionEventTap = 2
+
+kCGEventSourceStateCombinedSessionState = 0
+
+kCGEventFlagMaskCommand = 1 << 20
+kCGEventFlagMaskControl = 1 << 18
+kCGEventFlagMaskAlternate = 1 << 19
+kCGEventFlagMaskShift = 1 << 17
+
+kCFRunLoopDefaultMode = c_void_p.in_dll(_cf, "kCFRunLoopDefaultMode")
+
+# ---------------------------------------------------------------------------
+# Function signatures
+# ---------------------------------------------------------------------------
+
+# CGEventTapCreate(tap, place, options, eventsOfInterest, callback, userInfo)
+_cg.CGEventTapCreate.restype = c_void_p
+_cg.CGEventTapCreate.argtypes = [
+    c_uint32,           # CGEventTapLocation
+    c_uint32,           # CGEventTapPlacement
+    c_uint32,           # CGEventTapOptions
+    c_uint64,           # CGEventMask
+    CGEventTapCallBack, # callback
+    c_void_p,           # userInfo
+]
+
+# CGEventTapEnable(tap, enable)
+_cg.CGEventTapEnable.restype = None
+_cg.CGEventTapEnable.argtypes = [c_void_p, c_bool]
+
+# CGEventGetIntegerValueField(event, field) -> int64
+_cg.CGEventGetIntegerValueField.restype = c_int64
+_cg.CGEventGetIntegerValueField.argtypes = [c_void_p, c_uint32]
+
+# CGEventGetFlags(event) -> uint64
+_cg.CGEventGetFlags.restype = c_uint64
+_cg.CGEventGetFlags.argtypes = [c_void_p]
+
+# CGEventSetFlags(event, flags)
+_cg.CGEventSetFlags.restype = None
+_cg.CGEventSetFlags.argtypes = [c_void_p, c_uint64]
+
+# CGEventSourceFlagsState(stateID) -> uint64
+_cg.CGEventSourceFlagsState.restype = c_uint64
+_cg.CGEventSourceFlagsState.argtypes = [c_int32]
+
+# CGEventCreateKeyboardEvent(source, virtualKey, keyDown) -> CGEventRef
+_cg.CGEventCreateKeyboardEvent.restype = c_void_p
+_cg.CGEventCreateKeyboardEvent.argtypes = [c_void_p, c_uint32, c_bool]
+
+# CGEventPost(tap, event)
+_cg.CGEventPost.restype = None
+_cg.CGEventPost.argtypes = [c_uint32, c_void_p]
+
+# CFMachPortCreateRunLoopSource(allocator, port, order) -> CFRunLoopSourceRef
+_cf.CFMachPortCreateRunLoopSource.restype = c_void_p
+_cf.CFMachPortCreateRunLoopSource.argtypes = [c_void_p, c_void_p, c_int64]
+
+# CFRunLoopGetCurrent() -> CFRunLoopRef
+_cf.CFRunLoopGetCurrent.restype = c_void_p
+_cf.CFRunLoopGetCurrent.argtypes = []
+
+# CFRunLoopAddSource(rl, source, mode)
+_cf.CFRunLoopAddSource.restype = None
+_cf.CFRunLoopAddSource.argtypes = [c_void_p, c_void_p, c_void_p]
+
+# CFRunLoopRun()
+_cf.CFRunLoopRun.restype = None
+_cf.CFRunLoopRun.argtypes = []
+
+# CFRunLoopStop(rl)
+_cf.CFRunLoopStop.restype = None
+_cf.CFRunLoopStop.argtypes = [c_void_p]
+
+# CFRelease(cf)
+_cf.CFRelease.restype = None
+_cf.CFRelease.argtypes = [c_void_p]
+
+# ---------------------------------------------------------------------------
+# Module-level Python functions
+# ---------------------------------------------------------------------------
+
+
+def CGEventTapCreate(tap, place, options, events_of_interest, callback, user_info):
+    return _cg.CGEventTapCreate(tap, place, options, events_of_interest, callback, user_info)
+
+
+def CGEventTapEnable(tap, enable):
+    _cg.CGEventTapEnable(tap, enable)
+
+
+def CGEventGetIntegerValueField(event, field):
+    return _cg.CGEventGetIntegerValueField(event, field)
+
+
+def CGEventGetFlags(event):
+    return _cg.CGEventGetFlags(event)
+
+
+def CGEventSetFlags(event, flags):
+    _cg.CGEventSetFlags(event, flags)
+
+
+def CGEventSourceFlagsState(state_id):
+    return _cg.CGEventSourceFlagsState(state_id)
+
+
+def CGEventCreateKeyboardEvent(source, virtual_key, key_down):
+    return _cg.CGEventCreateKeyboardEvent(source, virtual_key, key_down)
+
+
+def CGEventPost(tap, event):
+    _cg.CGEventPost(tap, event)
+
+
+def CFMachPortCreateRunLoopSource(allocator, port, order):
+    return _cf.CFMachPortCreateRunLoopSource(allocator, port, order)
+
+
+def CFRunLoopGetCurrent():
+    return _cf.CFRunLoopGetCurrent()
+
+
+def CFRunLoopAddSource(rl, source, mode):
+    _cf.CFRunLoopAddSource(rl, source, mode)
+
+
+def CFRunLoopRun():
+    _cf.CFRunLoopRun()
+
+
+def CFRunLoopStop(rl):
+    _cf.CFRunLoopStop(rl)
+
+
+def CFRelease(cf):
+    _cf.CFRelease(cf)
+
+
+def CGEventMaskBit(event_type):
+    """Pure Python implementation of CGEventMaskBit."""
+    return 1 << event_type

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -12,9 +12,6 @@ import logging
 import threading
 from typing import Callable, Dict, List, Optional
 
-import objc
-
-
 logger = logging.getLogger(__name__)
 
 # --- Virtual keycode mappings ---
@@ -227,168 +224,147 @@ class _QuartzAllKeysListener:
         self._tap = None
         self._loop = None
         self._thread: Optional[threading.Thread] = None
+        self._ctypes_cb = None  # prevent GC of ctypes callback
         # Track modifier key states to detect press vs release.
         # Snapshot current flags so a modifier held across listener
         # restart is not misinterpreted as a new press.
         try:
-            import Quartz as _Q
-            self._mod_flags_prev = _Q.CGEventSourceFlagsState(
-                _Q.kCGEventSourceStateCombinedSessionState
+            from wenzi import _cgeventtap as _cg
+            self._mod_flags_prev = _cg.CGEventSourceFlagsState(
+                _cg.kCGEventSourceStateCombinedSessionState
             )
         except Exception:
             self._mod_flags_prev = 0
 
     def _callback(self, proxy, event_type, event, refcon):
-        with objc.autorelease_pool():
-            try:
-                import Quartz
+        from wenzi import _cgeventtap as cg
 
-                if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                    logger.warning("CGEventTap disabled by timeout, re-enabling")
-                    if self._tap is not None:
-                        Quartz.CGEventTapEnable(self._tap, True)
-                    # Re-sync modifier flags: if a modifier key was released
-                    # while the tap was disabled, the release event is lost
-                    # forever.  Poll the current system flags and fire synthetic
-                    # releases for any modifiers that went away.
-                    try:
-                        new_flags = Quartz.CGEventSourceFlagsState(
-                            Quartz.kCGEventSourceStateCombinedSessionState
-                        )
-                        seen_masks: set = set()
-                        for _name, (_vk, _mask) in _MOD_VK.items():
-                            if _mask in seen_masks:
-                                continue
-                            seen_masks.add(_mask)
-                            if (self._mod_flags_prev & _mask) and not (new_flags & _mask):
-                                self._on_release(_name)
-                        if (self._mod_flags_prev & _FN_FLAG) and not (new_flags & _FN_FLAG):
-                            self._on_release("fn")
-                        self._mod_flags_prev = new_flags
-                    except Exception:
-                        logger.warning(
-                            "Failed to re-sync modifier flags", exc_info=True
-                        )
-                    return event
+        try:
+            if event_type == cg.kCGEventTapDisabledByTimeout:
+                logger.warning("CGEventTap disabled by timeout, re-enabling")
+                if self._tap is not None:
+                    cg.CGEventTapEnable(self._tap, True)
+                # Re-sync modifier flags: if a modifier key was released
+                # while the tap was disabled, the release event is lost
+                # forever.  Poll the current system flags and fire synthetic
+                # releases for any modifiers that went away.
+                try:
+                    new_flags = cg.CGEventSourceFlagsState(
+                        cg.kCGEventSourceStateCombinedSessionState
+                    )
+                    seen_masks: set = set()
+                    for _name, (_vk, _mask) in _MOD_VK.items():
+                        if _mask in seen_masks:
+                            continue
+                        seen_masks.add(_mask)
+                        if (self._mod_flags_prev & _mask) and not (new_flags & _mask):
+                            self._on_release(_name)
+                    if (self._mod_flags_prev & _FN_FLAG) and not (new_flags & _FN_FLAG):
+                        self._on_release("fn")
+                    self._mod_flags_prev = new_flags
+                except Exception:
+                    logger.warning(
+                        "Failed to re-sync modifier flags", exc_info=True
+                    )
+                return event
 
-                # Extract all data from the event up front so we can
-                # release the CGEventRef early.  CGEventRef is a CF type
-                # freed by CFRelease (not autorelease), so the Python
-                # wrapper must be deleted to trigger CFRelease.
-                keycode = Quartz.CGEventGetIntegerValueField(
-                    event, Quartz.kCGKeyboardEventKeycode
-                )
-                flags = Quartz.CGEventGetFlags(event) if event_type == Quartz.kCGEventFlagsChanged else 0
+            keycode = cg.CGEventGetIntegerValueField(
+                event, cg.kCGKeyboardEventKeycode
+            )
+            flags = cg.CGEventGetFlags(event) if event_type == cg.kCGEventFlagsChanged else 0
 
-                if self._listen_only:
-                    # Listen-only: return value is ignored by the system,
-                    # so delete the wrapper now and return None.
-                    del event
+            if event_type == cg.kCGEventKeyDown:
+                name = _VK_TO_NAME.get(keycode)
+                if name:
+                    swallow = self._on_press(name)
+                    if swallow and not self._listen_only:
+                        return None
 
-                if event_type == Quartz.kCGEventKeyDown:
-                    name = _VK_TO_NAME.get(keycode)
-                    if name:
-                        swallow = self._on_press(name)
-                        if swallow and not self._listen_only:
-                            return None
+            elif event_type == cg.kCGEventKeyUp:
+                name = _VK_TO_NAME.get(keycode)
+                if name:
+                    self._on_release(name)
 
-                elif event_type == Quartz.kCGEventKeyUp:
-                    name = _VK_TO_NAME.get(keycode)
-                    if name:
+            elif event_type == cg.kCGEventFlagsChanged:
+                name = _VK_TO_NAME.get(keycode)
+                if name and name in _MOD_VK:
+                    _vk, mask = _MOD_VK[name]
+                    was_down = bool(self._mod_flags_prev & mask)
+                    is_down = bool(flags & mask)
+                    self._mod_flags_prev = flags
+                    if is_down and not was_down:
+                        self._on_press(name)
+                    elif was_down and not is_down:
                         self._on_release(name)
+                elif keycode == _FN_KEYCODE:
+                    was_down = bool(self._mod_flags_prev & _FN_FLAG)
+                    is_down = bool(flags & _FN_FLAG)
+                    self._mod_flags_prev = flags
+                    if is_down and not was_down:
+                        self._on_press("fn")
+                    elif was_down and not is_down:
+                        self._on_release("fn")
+                else:
+                    # Unknown modifier key; just update tracked flags
+                    self._mod_flags_prev = flags
 
-                elif event_type == Quartz.kCGEventFlagsChanged:
-                    name = _VK_TO_NAME.get(keycode)
-                    if name and name in _MOD_VK:
-                        _vk, mask = _MOD_VK[name]
-                        was_down = bool(self._mod_flags_prev & mask)
-                        is_down = bool(flags & mask)
-                        self._mod_flags_prev = flags
-                        if is_down and not was_down:
-                            self._on_press(name)
-                        elif was_down and not is_down:
-                            self._on_release(name)
-                    elif keycode == _FN_KEYCODE:
-                        was_down = bool(self._mod_flags_prev & _FN_FLAG)
-                        is_down = bool(flags & _FN_FLAG)
-                        self._mod_flags_prev = flags
-                        if is_down and not was_down:
-                            self._on_press("fn")
-                        elif was_down and not is_down:
-                            self._on_release("fn")
-                    else:
-                        # Unknown modifier key; just update tracked flags
-                        self._mod_flags_prev = flags
+        except Exception:
+            logger.warning("_QuartzAllKeysListener callback exception", exc_info=True)
 
-            except Exception:
-                logger.warning("_QuartzAllKeysListener callback exception", exc_info=True)
-
-            # Listen-only: event was already del'd, return None (ignored
-            # by the system).  Active: return the original event to pass
-            # it through to the focused application.
-            return None if self._listen_only else event
+        # Listen-only: return None (ignored by the system).
+        # Active: return the original event to pass it through.
+        return None if self._listen_only else event
 
     def start(self) -> None:
-        import Quartz
-        _pre_resolve_quartz()
+        from wenzi import _cgeventtap as cg
 
-        _listen_only = self._listen_only
-        _CGEventMaskBit = Quartz.CGEventMaskBit
-        _kCGEventKeyDown = Quartz.kCGEventKeyDown
-        _kCGEventKeyUp = Quartz.kCGEventKeyUp
-        _kCGEventFlagsChanged = Quartz.kCGEventFlagsChanged
-        _CGEventTapCreate = Quartz.CGEventTapCreate
-        _kCGSessionEventTap = Quartz.kCGSessionEventTap
-        _kCGHeadInsertEventTap = Quartz.kCGHeadInsertEventTap
-        _kCGEventTapOptionListenOnly = Quartz.kCGEventTapOptionListenOnly
-        _CFMachPortCreateRunLoopSource = Quartz.CFMachPortCreateRunLoopSource
-        _CFRunLoopGetCurrent = Quartz.CFRunLoopGetCurrent
-        _CFRunLoopAddSource = Quartz.CFRunLoopAddSource
-        _kCFRunLoopDefaultMode = Quartz.kCFRunLoopDefaultMode
-        _CGEventTapEnable = Quartz.CGEventTapEnable
-        _CFRunLoopRun = Quartz.CFRunLoopRun
+        def _raw_cb(proxy, event_type, event, refcon):
+            return self._callback(proxy, event_type, event, refcon) or 0
+        self._ctypes_cb = cg.CGEventTapCallBack(_raw_cb)  # prevent GC!
+
+        mask = (
+            cg.CGEventMaskBit(cg.kCGEventKeyDown)
+            | cg.CGEventMaskBit(cg.kCGEventKeyUp)
+            | cg.CGEventMaskBit(cg.kCGEventFlagsChanged)
+        )
+        option = cg.kCGEventTapOptionListenOnly if self._listen_only else cg.kCGEventTapOptionDefault
 
         def _run():
-            with objc.autorelease_pool():
-                mask = (
-                    _CGEventMaskBit(_kCGEventKeyDown)
-                    | _CGEventMaskBit(_kCGEventKeyUp)
-                    | _CGEventMaskBit(_kCGEventFlagsChanged)
+            self._tap = cg.CGEventTapCreate(
+                cg.kCGSessionEventTap,
+                cg.kCGHeadInsertEventTap,
+                option,
+                mask,
+                self._ctypes_cb,
+                None,
+            )
+            if not self._tap:
+                logger.error(
+                    "Failed to create Quartz event tap. "
+                    "Check accessibility permissions in System Settings."
                 )
-                self._tap = _CGEventTapCreate(
-                    _kCGSessionEventTap,
-                    _kCGHeadInsertEventTap,
-                    _kCGEventTapOptionListenOnly if _listen_only else Quartz.kCGEventTapOptionDefault,
-                    mask,
-                    self._callback,
-                    None,
-                )
-                if self._tap is None:
-                    logger.error(
-                        "Failed to create Quartz event tap. "
-                        "Check accessibility permissions in System Settings."
-                    )
-                    return
+                return
 
-                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-                self._loop = _CFRunLoopGetCurrent()
-                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-                _CGEventTapEnable(self._tap, True)
-                logger.info("Quartz all-keys listener started (listen_only=%s)", _listen_only)
-                _CFRunLoopRun()
+            source = cg.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+            self._loop = cg.CFRunLoopGetCurrent()
+            cg.CFRunLoopAddSource(self._loop, source, cg.kCFRunLoopDefaultMode.value)
+            cg.CGEventTapEnable(self._tap, True)
+            logger.info("Quartz all-keys listener started (listen_only=%s)", self._listen_only)
+            cg.CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
-        import Quartz
+        from wenzi import _cgeventtap as cg
 
         if self._tap is not None:
-            Quartz.CGEventTapEnable(self._tap, False)
+            cg.CGEventTapEnable(self._tap, False)
         if self._loop is not None:
-            Quartz.CFRunLoopStop(self._loop)
+            cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        self._ctypes_cb = None
         logger.info("Quartz all-keys listener stopped")
 
 
@@ -410,6 +386,7 @@ class TapHotkeyListener:
         self._tap = None
         self._loop = None
         self._thread: Optional[threading.Thread] = None
+        self._ctypes_cb = None  # prevent GC of ctypes callback
 
     def _run_activate(self):
         try:
@@ -418,90 +395,80 @@ class TapHotkeyListener:
             logger.error("on_activate callback error: %s", e)
 
     def _callback(self, proxy, event_type, event, refcon):
-        with objc.autorelease_pool():
-            try:
-                import Quartz
+        from wenzi import _cgeventtap as cg
 
-                if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                    logger.warning("CGEventTap disabled by timeout, re-enabling")
-                    if self._tap is not None:
-                        Quartz.CGEventTapEnable(self._tap, True)
-                    return event
-
-                if event_type != Quartz.kCGEventKeyDown:
-                    return event
-
-                keycode = Quartz.CGEventGetIntegerValueField(
-                    event, Quartz.kCGKeyboardEventKeycode
-                )
-                flags = Quartz.CGEventGetFlags(event) & _MOD_MASK
-
-                if keycode == self._keycode and flags == self._mod_flags:
-                    logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
-                    threading.Thread(
-                        target=self._run_activate, daemon=True,
-                    ).start()
-                    return None  # Swallow the event
-
+        try:
+            if event_type == cg.kCGEventTapDisabledByTimeout:
+                logger.warning("CGEventTap disabled by timeout, re-enabling")
+                if self._tap is not None:
+                    cg.CGEventTapEnable(self._tap, True)
                 return event
-            except Exception:
-                logger.warning("[TapHotkey] _callback exception", exc_info=True)
+
+            if event_type != cg.kCGEventKeyDown:
                 return event
+
+            keycode = cg.CGEventGetIntegerValueField(
+                event, cg.kCGKeyboardEventKeycode
+            )
+            flags = cg.CGEventGetFlags(event) & _MOD_MASK
+
+            if keycode == self._keycode and flags == self._mod_flags:
+                logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
+                threading.Thread(
+                    target=self._run_activate, daemon=True,
+                ).start()
+                return None  # Swallow the event
+
+            return event
+        except Exception:
+            logger.warning("[TapHotkey] _callback exception", exc_info=True)
+            return event
 
     def start(self) -> None:
-        import Quartz
-        _pre_resolve_quartz()
+        from wenzi import _cgeventtap as cg
 
-        _CGEventMaskBit = Quartz.CGEventMaskBit
-        _kCGEventKeyDown = Quartz.kCGEventKeyDown
-        _CGEventTapCreate = Quartz.CGEventTapCreate
-        _kCGSessionEventTap = Quartz.kCGSessionEventTap
-        _kCGHeadInsertEventTap = Quartz.kCGHeadInsertEventTap
-        _kCGEventTapOptionDefault = Quartz.kCGEventTapOptionDefault
-        _CFMachPortCreateRunLoopSource = Quartz.CFMachPortCreateRunLoopSource
-        _CFRunLoopGetCurrent = Quartz.CFRunLoopGetCurrent
-        _CFRunLoopAddSource = Quartz.CFRunLoopAddSource
-        _kCFRunLoopDefaultMode = Quartz.kCFRunLoopDefaultMode
-        _CGEventTapEnable = Quartz.CGEventTapEnable
-        _CFRunLoopRun = Quartz.CFRunLoopRun
+        def _raw_cb(proxy, event_type, event, refcon):
+            return self._callback(proxy, event_type, event, refcon) or 0
+        self._ctypes_cb = cg.CGEventTapCallBack(_raw_cb)  # prevent GC!
+
+        mask = cg.CGEventMaskBit(cg.kCGEventKeyDown)
 
         def _run():
-            with objc.autorelease_pool():
-                mask = _CGEventMaskBit(_kCGEventKeyDown)
-                self._tap = _CGEventTapCreate(
-                    _kCGSessionEventTap,
-                    _kCGHeadInsertEventTap,
-                    _kCGEventTapOptionDefault,
-                    mask,
-                    self._callback,
-                    None,
+            self._tap = cg.CGEventTapCreate(
+                cg.kCGSessionEventTap,
+                cg.kCGHeadInsertEventTap,
+                cg.kCGEventTapOptionDefault,
+                mask,
+                self._ctypes_cb,
+                None,
+            )
+            if not self._tap:
+                logger.error(
+                    "Failed to create Quartz event tap for hotkey. "
+                    "Check accessibility permissions in System Settings."
                 )
-                if self._tap is None:
-                    logger.error(
-                        "Failed to create Quartz event tap for hotkey. "
-                        "Check accessibility permissions in System Settings."
-                    )
-                    return
+                return
 
-                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-                self._loop = _CFRunLoopGetCurrent()
-                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-                _CGEventTapEnable(self._tap, True)
-                logger.info("TapHotkeyListener started: %s", self._hotkey_str)
-                _CFRunLoopRun()
+            source = cg.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+            self._loop = cg.CFRunLoopGetCurrent()
+            cg.CFRunLoopAddSource(self._loop, source, cg.kCFRunLoopDefaultMode.value)
+            cg.CGEventTapEnable(self._tap, True)
+            logger.info("TapHotkeyListener started: %s", self._hotkey_str)
+            cg.CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
-        import Quartz
+        from wenzi import _cgeventtap as cg
 
         if self._tap is not None:
-            Quartz.CGEventTapEnable(self._tap, False)
+            cg.CGEventTapEnable(self._tap, False)
         if self._loop is not None:
-            Quartz.CFRunLoopStop(self._loop)
+            cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        self._ctypes_cb = None
         logger.info("TapHotkeyListener stopped")
 
 
@@ -523,6 +490,7 @@ class KeyRemapListener:
         self._loop = None
         self._thread: Optional[threading.Thread] = None
         self._prev_flags: int = 0
+        self._ctypes_cb = None  # prevent GC of ctypes callback
 
     def add(self, source_vk: int, target_vk: int, is_modifier: bool, mod_flag: int) -> None:
         """Add a remap.  Can be called while running."""
@@ -537,97 +505,102 @@ class KeyRemapListener:
         return self._tap is not None
 
     def _callback(self, proxy, event_type, event, refcon):
-        with objc.autorelease_pool():
-            try:
-                import Quartz
+        from wenzi import _cgeventtap as cg
 
-                if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                    logger.warning("KeyRemapListener tap disabled by timeout, re-enabling")
-                    if self._tap is not None:
-                        Quartz.CGEventTapEnable(self._tap, True)
-                    return event
-
-                if event_type == Quartz.kCGEventFlagsChanged:
-                    keycode = Quartz.CGEventGetIntegerValueField(
-                        event, Quartz.kCGKeyboardEventKeycode
-                    )
-                    remap = self._remaps.get(keycode)
-                    if remap and remap[1]:  # is_modifier source
-                        target_vk, _, mod_flag = remap
-                        flags = Quartz.CGEventGetFlags(event)
-                        was_down = bool(self._prev_flags & mod_flag)
-                        is_down = bool(flags & mod_flag)
-                        self._prev_flags = flags
-                        if is_down != was_down:
-                            evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
-                            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
-                            return None  # Swallow the original modifier event
-                    return event
-
-                if event_type in (Quartz.kCGEventKeyDown, Quartz.kCGEventKeyUp):
-                    keycode = Quartz.CGEventGetIntegerValueField(
-                        event, Quartz.kCGKeyboardEventKeycode
-                    )
-                    remap = self._remaps.get(keycode)
-                    if remap and not remap[1]:  # non-modifier source
-                        target_vk = remap[0]
-                        is_down = event_type == Quartz.kCGEventKeyDown
-                        evt_flags = Quartz.CGEventGetFlags(event)
-                        evt = Quartz.CGEventCreateKeyboardEvent(None, target_vk, is_down)
-                        Quartz.CGEventSetFlags(evt, evt_flags)
-                        Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, evt)
-                        return None  # Swallow the original key event
-                    return event
-
+        try:
+            if event_type == cg.kCGEventTapDisabledByTimeout:
+                logger.warning("KeyRemapListener tap disabled by timeout, re-enabling")
+                if self._tap is not None:
+                    cg.CGEventTapEnable(self._tap, True)
                 return event
-            except Exception:
-                logger.warning("[KeyRemap] _callback exception", exc_info=True)
+
+            if event_type == cg.kCGEventFlagsChanged:
+                keycode = cg.CGEventGetIntegerValueField(
+                    event, cg.kCGKeyboardEventKeycode
+                )
+                remap = self._remaps.get(keycode)
+                if remap and remap[1]:  # is_modifier source
+                    target_vk, _, mod_flag = remap
+                    flags = cg.CGEventGetFlags(event)
+                    was_down = bool(self._prev_flags & mod_flag)
+                    is_down = bool(flags & mod_flag)
+                    self._prev_flags = flags
+                    if is_down != was_down:
+                        evt = cg.CGEventCreateKeyboardEvent(None, target_vk, is_down)
+                        cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, evt)
+                        cg.CFRelease(evt)
+                        return None  # Swallow the original modifier event
                 return event
+
+            if event_type in (cg.kCGEventKeyDown, cg.kCGEventKeyUp):
+                keycode = cg.CGEventGetIntegerValueField(
+                    event, cg.kCGKeyboardEventKeycode
+                )
+                remap = self._remaps.get(keycode)
+                if remap and not remap[1]:  # non-modifier source
+                    target_vk = remap[0]
+                    is_down = event_type == cg.kCGEventKeyDown
+                    evt_flags = cg.CGEventGetFlags(event)
+                    evt = cg.CGEventCreateKeyboardEvent(None, target_vk, is_down)
+                    cg.CGEventSetFlags(evt, evt_flags)
+                    cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, evt)
+                    cg.CFRelease(evt)
+                    return None  # Swallow the original key event
+                return event
+
+            return event
+        except Exception:
+            logger.warning("[KeyRemap] _callback exception", exc_info=True)
+            return event
 
     def start(self) -> None:
-        import Quartz
-        _pre_resolve_quartz()
+        from wenzi import _cgeventtap as cg
+
+        def _raw_cb(proxy, event_type, event, refcon):
+            return self._callback(proxy, event_type, event, refcon) or 0
+        self._ctypes_cb = cg.CGEventTapCallBack(_raw_cb)  # prevent GC!
+
+        mask = (
+            cg.CGEventMaskBit(cg.kCGEventFlagsChanged)
+            | cg.CGEventMaskBit(cg.kCGEventKeyDown)
+            | cg.CGEventMaskBit(cg.kCGEventKeyUp)
+        )
 
         def _run():
-            with objc.autorelease_pool():
-                mask = (
-                    Quartz.CGEventMaskBit(Quartz.kCGEventFlagsChanged)
-                    | Quartz.CGEventMaskBit(Quartz.kCGEventKeyDown)
-                    | Quartz.CGEventMaskBit(Quartz.kCGEventKeyUp)
+            self._tap = cg.CGEventTapCreate(
+                cg.kCGSessionEventTap,
+                cg.kCGHeadInsertEventTap,
+                cg.kCGEventTapOptionDefault,
+                mask,
+                self._ctypes_cb,
+                None,
+            )
+            if not self._tap:
+                logger.error(
+                    "Failed to create CGEventTap for key remap. "
+                    "Check accessibility permissions."
                 )
-                self._tap = Quartz.CGEventTapCreate(
-                    Quartz.kCGSessionEventTap,
-                    Quartz.kCGHeadInsertEventTap,
-                    Quartz.kCGEventTapOptionDefault,
-                    mask,
-                    self._callback,
-                    None,
-                )
-                if self._tap is None:
-                    logger.error(
-                        "Failed to create CGEventTap for key remap. "
-                        "Check accessibility permissions."
-                    )
-                    return
-                source = Quartz.CFMachPortCreateRunLoopSource(None, self._tap, 0)
-                self._loop = Quartz.CFRunLoopGetCurrent()
-                Quartz.CFRunLoopAddSource(self._loop, source, Quartz.kCFRunLoopDefaultMode)
-                Quartz.CGEventTapEnable(self._tap, True)
-                logger.info("KeyRemapListener started with %d remap(s)", len(self._remaps))
-                Quartz.CFRunLoopRun()
+                return
+            source = cg.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+            self._loop = cg.CFRunLoopGetCurrent()
+            cg.CFRunLoopAddSource(self._loop, source, cg.kCFRunLoopDefaultMode.value)
+            cg.CGEventTapEnable(self._tap, True)
+            logger.info("KeyRemapListener started with %d remap(s)", len(self._remaps))
+            cg.CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
-        import Quartz
+        from wenzi import _cgeventtap as cg
 
         if self._tap is not None:
-            Quartz.CGEventTapEnable(self._tap, False)
+            cg.CGEventTapEnable(self._tap, False)
         if self._loop is not None:
-            Quartz.CFRunLoopStop(self._loop)
+            cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        self._ctypes_cb = None
         logger.info("KeyRemapListener stopped")
 
 

--- a/src/wenzi/scripting/ocr.py
+++ b/src/wenzi/scripting/ocr.py
@@ -34,36 +34,39 @@ def recognize_text(
         languages = ["zh-Hans", "zh-Hant", "en-US"]
 
     try:
-        from Foundation import NSURL
-        from Quartz import VNImageRequestHandler, VNRecognizeTextRequest
+        import objc
 
-        image_url = NSURL.fileURLWithPath_(image_path)
-        handler = VNImageRequestHandler.alloc().initWithURL_options_(
-            image_url, None,
-        )
+        with objc.autorelease_pool():
+            from Foundation import NSURL
+            from Quartz import VNImageRequestHandler, VNRecognizeTextRequest
 
-        request = VNRecognizeTextRequest.alloc().init()
-        request.setRecognitionLevel_(_RECOGNITION_LEVEL_FAST)
-        request.setRecognitionLanguages_(languages)
+            image_url = NSURL.fileURLWithPath_(image_path)
+            handler = VNImageRequestHandler.alloc().initWithURL_options_(
+                image_url, None,
+            )
 
-        success = handler.performRequests_error_([request], None)
-        if not success:
-            logger.debug("Vision request failed for %s", image_path)
-            return ""
+            request = VNRecognizeTextRequest.alloc().init()
+            request.setRecognitionLevel_(_RECOGNITION_LEVEL_FAST)
+            request.setRecognitionLanguages_(languages)
 
-        results = request.results()
-        if not results:
-            return ""
+            success = handler.performRequests_error_([request], None)
+            if not success:
+                logger.debug("Vision request failed for %s", image_path)
+                return ""
 
-        lines = []
-        for observation in results:
-            candidates = observation.topCandidates_(1)
-            if candidates:
-                text = str(candidates[0].string())
-                if text:
-                    lines.append(text)
+            results = request.results()
+            if not results:
+                return ""
 
-        return "\n".join(lines)
+            lines = []
+            for observation in results:
+                candidates = observation.topCandidates_(1)
+                if candidates:
+                    text = str(candidates[0].string())
+                    if text:
+                        lines.append(text)
+
+            return "\n".join(lines)
     except Exception:
         logger.debug("OCR failed for %s", image_path, exc_info=True)
         return ""

--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -17,8 +17,6 @@ import threading
 import time
 from typing import TYPE_CHECKING, Optional
 
-import objc
-
 if TYPE_CHECKING:
     from wenzi.scripting.sources.snippet_source import SnippetStore
 
@@ -52,13 +50,14 @@ _carbon = ctypes.cdll.LoadLibrary(ctypes.util.find_library("Carbon"))
 
 
 def _get_unicode_string(event) -> str:
-    """Extract the Unicode string from a Quartz CGEvent using ctypes."""
-    import objc
+    """Extract the Unicode string from a Quartz CGEvent using ctypes.
 
+    *event* is a raw pointer (integer) from the ctypes CGEventTap callback.
+    """
     length = ctypes.c_uint32(0)
     buf = (ctypes.c_uint16 * _KEYBOARD_BUF_SIZE)()
     _carbon.CGEventKeyboardGetUnicodeString(
-        ctypes.c_void_p(objc.pyobjc_id(event)),
+        ctypes.c_void_p(event),
         ctypes.c_uint32(_KEYBOARD_BUF_SIZE),
         ctypes.byref(length),
         buf,
@@ -84,6 +83,7 @@ class SnippetExpander:
         self._tap = None
         self._loop = None
         self._thread: Optional[threading.Thread] = None
+        self._ctypes_cb = None  # prevent GC of ctypes callback
         self._expanding = False  # Guard against re-entrance during expansion
         self._suppressed = False  # True while our own panels are key
 
@@ -103,60 +103,52 @@ class SnippetExpander:
 
     def start(self) -> None:
         """Start listening for keystrokes."""
-        import Quartz
-        from wenzi.hotkey import _pre_resolve_quartz
+        from wenzi import _cgeventtap as cg
 
-        _pre_resolve_quartz()
+        def _raw_cb(proxy, event_type, event, refcon):
+            self._callback(proxy, event_type, event, refcon)
+            return 0  # listen-only, return value ignored
+        self._ctypes_cb = cg.CGEventTapCallBack(_raw_cb)  # prevent GC!
 
-        _CGEventMaskBit = Quartz.CGEventMaskBit
-        _kCGEventKeyDown = Quartz.kCGEventKeyDown
-        _CGEventTapCreate = Quartz.CGEventTapCreate
-        _kCGSessionEventTap = Quartz.kCGSessionEventTap
-        _kCGHeadInsertEventTap = Quartz.kCGHeadInsertEventTap
-        _kCGEventTapOptionListenOnly = Quartz.kCGEventTapOptionListenOnly
-        _CFMachPortCreateRunLoopSource = Quartz.CFMachPortCreateRunLoopSource
-        _CFRunLoopGetCurrent = Quartz.CFRunLoopGetCurrent
-        _CFRunLoopAddSource = Quartz.CFRunLoopAddSource
-        _kCFRunLoopDefaultMode = Quartz.kCFRunLoopDefaultMode
-        _CGEventTapEnable = Quartz.CGEventTapEnable
-        _CFRunLoopRun = Quartz.CFRunLoopRun
+        mask = cg.CGEventMaskBit(cg.kCGEventKeyDown)
 
         def _run():
-            with objc.autorelease_pool():
-                mask = _CGEventMaskBit(_kCGEventKeyDown)
-                self._tap = _CGEventTapCreate(
-                    _kCGSessionEventTap,
-                    _kCGHeadInsertEventTap,
-                    _kCGEventTapOptionListenOnly,
-                    mask,
-                    self._callback,
-                    None,
+            self._tap = cg.CGEventTapCreate(
+                cg.kCGSessionEventTap,
+                cg.kCGHeadInsertEventTap,
+                cg.kCGEventTapOptionListenOnly,
+                mask,
+                self._ctypes_cb,
+                None,
+            )
+            if not self._tap:
+                logger.error(
+                    "SnippetExpander: failed to create event tap. "
+                    "Check accessibility permissions."
                 )
-                if self._tap is None:
-                    logger.error(
-                        "SnippetExpander: failed to create event tap. "
-                        "Check accessibility permissions."
-                    )
-                    return
+                return
 
-                source = _CFMachPortCreateRunLoopSource(None, self._tap, 0)
-                self._loop = _CFRunLoopGetCurrent()
-                _CFRunLoopAddSource(self._loop, source, _kCFRunLoopDefaultMode)
-                _CGEventTapEnable(self._tap, True)
-                logger.info("SnippetExpander started")
-                _CFRunLoopRun()
+            source = cg.CFMachPortCreateRunLoopSource(None, self._tap, 0)
+            self._loop = cg.CFRunLoopGetCurrent()
+            cg.CFRunLoopAddSource(self._loop, source, cg.kCFRunLoopDefaultMode.value)
+            cg.CGEventTapEnable(self._tap, True)
+            logger.info("SnippetExpander started")
+            cg.CFRunLoopRun()
 
         self._thread = threading.Thread(target=_run, daemon=True)
         self._thread.start()
 
     def stop(self) -> None:
         """Stop listening."""
-        import Quartz
+        from wenzi import _cgeventtap as cg
 
+        if self._tap is not None:
+            cg.CGEventTapEnable(self._tap, False)
         if self._loop is not None:
-            Quartz.CFRunLoopStop(self._loop)
+            cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        self._ctypes_cb = None
         if self._thread is not None:
             self._thread.join(timeout=2.0)
             self._thread = None
@@ -168,63 +160,58 @@ class SnippetExpander:
 
     def _callback(self, proxy, event_type, event, refcon):
         """CGEventTap callback — runs on the tap's background thread."""
-        with objc.autorelease_pool():
-            try:
-                import Quartz
+        from wenzi import _cgeventtap as cg
 
-                if event_type == Quartz.kCGEventTapDisabledByTimeout:
-                    logger.warning("SnippetExpander tap disabled by timeout, re-enabling")
-                    if self._tap is not None:
-                        Quartz.CGEventTapEnable(self._tap, True)
-                    return event
+        try:
+            if event_type == cg.kCGEventTapDisabledByTimeout:
+                logger.warning("SnippetExpander tap disabled by timeout, re-enabling")
+                if self._tap is not None:
+                    cg.CGEventTapEnable(self._tap, True)
+                return None
 
-                if self._expanding or self._suppressed:
-                    return None
+            if self._expanding or self._suppressed:
+                return None
 
-                # Extract all data from event, then release the CF ref.
-                # CGEventRef is freed by CFRelease (not autorelease), so
-                # we must del the Python wrapper to trigger CFRelease.
-                keycode = Quartz.CGEventGetIntegerValueField(
-                    event, Quartz.kCGKeyboardEventKeycode,
-                )
-                flags = Quartz.CGEventGetFlags(event)
-                char = _get_unicode_string(event)
-                del event  # release CGEventRef immediately
+            keycode = cg.CGEventGetIntegerValueField(
+                event, cg.kCGKeyboardEventKeycode,
+            )
+            flags = cg.CGEventGetFlags(event)
+            char = _get_unicode_string(event)
 
-                # Ignore events with Cmd/Ctrl/Alt modifiers (shortcuts, not text)
-                mod_mask = (
-                    Quartz.kCGEventFlagMaskCommand
-                    | Quartz.kCGEventFlagMaskControl
-                    | Quartz.kCGEventFlagMaskAlternate
-                )
-                if flags & mod_mask:
-                    with self._lock:
-                        self._buffer = ""
-                    return None
-
-                # Navigation / control keys clear the buffer
-                if keycode in _CLEAR_KEYCODES:
-                    with self._lock:
-                        self._buffer = ""
-                    return None
-
-                if not char or not char.isprintable():
-                    return None
-
-                # Append to buffer
+            # Ignore events with Cmd/Ctrl/Alt modifiers (shortcuts, not text)
+            mod_mask = (
+                cg.kCGEventFlagMaskCommand
+                | cg.kCGEventFlagMaskControl
+                | cg.kCGEventFlagMaskAlternate
+            )
+            if flags & mod_mask:
                 with self._lock:
-                    self._buffer += char
-                    if len(self._buffer) > _MAX_BUFFER:
-                        self._buffer = self._buffer[-_MAX_BUFFER:]
-                    buf = self._buffer
+                    self._buffer = ""
+                return None
 
-                # Check for keyword match at the end of buffer
-                self._check_expansion(buf)
+            # Navigation / control keys clear the buffer
+            if keycode in _CLEAR_KEYCODES:
+                with self._lock:
+                    self._buffer = ""
+                return None
 
-            except Exception:
-                logger.warning("SnippetExpander callback exception", exc_info=True)
+            if not char or not char.isprintable():
+                return None
 
-            return None
+            # Append to buffer
+            with self._lock:
+                self._buffer += char
+                if len(self._buffer) > _MAX_BUFFER:
+                    self._buffer = self._buffer[-_MAX_BUFFER:]
+                buf = self._buffer
+
+            # Check for keyword match at the end of buffer
+            self._check_expansion(buf)
+
+        except Exception:
+            logger.warning("SnippetExpander callback exception", exc_info=True)
+
+        return None
 
     def _check_expansion(self, buf: str) -> None:
         """Check if the buffer ends with a snippet keyword and trigger expansion."""
@@ -311,12 +298,14 @@ class SnippetExpander:
 
     @staticmethod
     def _send_backspaces(count: int) -> None:
-        """Send *count* backspace keystrokes via Quartz CGEvent."""
-        import Quartz
+        """Send *count* backspace keystrokes via CGEvent."""
+        from wenzi import _cgeventtap as cg
 
         for _ in range(count):
-            down = Quartz.CGEventCreateKeyboardEvent(None, _VK_DELETE, True)
-            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, down)
-            up = Quartz.CGEventCreateKeyboardEvent(None, _VK_DELETE, False)
-            Quartz.CGEventPost(Quartz.kCGAnnotatedSessionEventTap, up)
+            down = cg.CGEventCreateKeyboardEvent(None, _VK_DELETE, True)
+            cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, down)
+            cg.CFRelease(down)
+            up = cg.CGEventCreateKeyboardEvent(None, _VK_DELETE, False)
+            cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, up)
+            cg.CFRelease(up)
             time.sleep(0.01)

--- a/tests/scripting/test_snippet_expander.py
+++ b/tests/scripting/test_snippet_expander.py
@@ -289,12 +289,9 @@ class TestGetUnicodeString:
         """Ensure out-of-bounds read is prevented when length > buf_size."""
         from wenzi.scripting.snippet_expander import _get_unicode_string
 
-        mock_event = MagicMock()
-        mock_objc = MagicMock()
-        mock_objc.pyobjc_id.return_value = 0
+        # event is now a raw pointer (integer) — use 0 as a dummy
         with (
             patch("wenzi.scripting.snippet_expander._carbon") as mock_carbon,
-            patch.dict("sys.modules", {"objc": mock_objc}),
         ):
             def fake_get(event_ptr, max_len, length_ptr, buf):
                 # Simulate the API reporting a length larger than buffer
@@ -303,7 +300,7 @@ class TestGetUnicodeString:
                     buf[i] = ord("A") + (i % 26)
 
             mock_carbon.CGEventKeyboardGetUnicodeString.side_effect = fake_get
-            result = _get_unicode_string(mock_event)
+            result = _get_unicode_string(0)
 
         # Should return at most 16 chars (buf_size), not 32
         assert len(result) <= 16
@@ -311,18 +308,15 @@ class TestGetUnicodeString:
     def test_empty_event_returns_empty_string(self):
         from wenzi.scripting.snippet_expander import _get_unicode_string
 
-        mock_event = MagicMock()
-        mock_objc = MagicMock()
-        mock_objc.pyobjc_id.return_value = 0
+        # event is now a raw pointer (integer) — use 0 as a dummy
         with (
             patch("wenzi.scripting.snippet_expander._carbon") as mock_carbon,
-            patch.dict("sys.modules", {"objc": mock_objc}),
         ):
             def fake_get(event_ptr, max_len, length_ptr, buf):
                 length_ptr._obj.value = 0
 
             mock_carbon.CGEventKeyboardGetUnicodeString.side_effect = fake_get
-            result = _get_unicode_string(mock_event)
+            result = _get_unicode_string(0)
 
         assert result == ""
 

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -236,7 +236,7 @@ class TestQuartzAllKeysListener:
         """stop() must disable the CGEventTap so it stops intercepting events
         immediately, preventing queued/swallowed keystrokes."""
         from wenzi.hotkey import _QuartzAllKeysListener
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = _QuartzAllKeysListener(
             on_press=MagicMock(), on_release=MagicMock()
@@ -250,9 +250,9 @@ class TestQuartzAllKeysListener:
             pytest.MonkeyPatch.context() as mp,
         ):
             calls = []
-            mp.setattr(Quartz, "CGEventTapEnable",
+            mp.setattr(cg, "CGEventTapEnable",
                         lambda tap, en: calls.append(("disable", tap, en)))
-            mp.setattr(Quartz, "CFRunLoopStop",
+            mp.setattr(cg, "CFRunLoopStop",
                         lambda loop: calls.append(("stop", loop)))
             listener.stop()
 
@@ -265,7 +265,7 @@ class TestQuartzAllKeysListener:
         """When CGEventTap is disabled by timeout, missed modifier releases
         should be detected by polling CGEventSourceFlagsState."""
         from wenzi.hotkey import _QuartzAllKeysListener, _FN_FLAG
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         on_release = MagicMock()
         listener = _QuartzAllKeysListener(
@@ -277,15 +277,12 @@ class TestQuartzAllKeysListener:
         listener._mod_flags_prev = _FN_FLAG
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(Quartz, "CGEventTapEnable", lambda tap, en: None)
+            mp.setattr(cg, "CGEventTapEnable", lambda tap, en: None)
             # Current flags show fn is no longer held
-            mp.setattr(Quartz, "CGEventSourceFlagsState", lambda src: 0)
-            mp.setattr(
-                Quartz, "kCGEventSourceStateCombinedSessionState", 0
-            )
+            mp.setattr(cg, "CGEventSourceFlagsState", lambda src: 0)
 
             listener._callback(
-                None, Quartz.kCGEventTapDisabledByTimeout, None, None
+                None, 0xFFFFFFFE, None, None
             )
 
         on_release.assert_called_once_with("fn")
@@ -294,7 +291,7 @@ class TestQuartzAllKeysListener:
     def test_tap_timeout_no_false_release(self):
         """When modifier is still held during tap timeout, no release fires."""
         from wenzi.hotkey import _QuartzAllKeysListener, _FN_FLAG
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         on_release = MagicMock()
         listener = _QuartzAllKeysListener(
@@ -305,15 +302,12 @@ class TestQuartzAllKeysListener:
         listener._mod_flags_prev = _FN_FLAG
 
         with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(Quartz, "CGEventTapEnable", lambda tap, en: None)
+            mp.setattr(cg, "CGEventTapEnable", lambda tap, en: None)
             # fn is still held
-            mp.setattr(Quartz, "CGEventSourceFlagsState", lambda src: _FN_FLAG)
-            mp.setattr(
-                Quartz, "kCGEventSourceStateCombinedSessionState", 0
-            )
+            mp.setattr(cg, "CGEventSourceFlagsState", lambda src: _FN_FLAG)
 
             listener._callback(
-                None, Quartz.kCGEventTapDisabledByTimeout, None, None
+                None, 0xFFFFFFFE, None, None
             )
 
         on_release.assert_not_called()
@@ -334,7 +328,7 @@ class TestTapHotkeyListener:
 
     def test_stop_disables_tap_before_stopping_runloop(self):
         """stop() must disable the CGEventTap to avoid swallowing events."""
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = TapHotkeyListener("ctrl+v", MagicMock())
         fake_tap = MagicMock()
@@ -344,9 +338,9 @@ class TestTapHotkeyListener:
 
         with pytest.MonkeyPatch.context() as mp:
             calls = []
-            mp.setattr(Quartz, "CGEventTapEnable",
+            mp.setattr(cg, "CGEventTapEnable",
                         lambda tap, en: calls.append(("disable", tap, en)))
-            mp.setattr(Quartz, "CFRunLoopStop",
+            mp.setattr(cg, "CFRunLoopStop",
                         lambda loop: calls.append(("stop", loop)))
             listener.stop()
 
@@ -991,36 +985,47 @@ class TestKeyRemapListener:
 
     def test_modifier_remap_keydown(self):
         """FlagsChanged event for modifier press → synthesize target keydown."""
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = KeyRemapListener()
         listener.add(60, 80, True, 0x020000)  # shift_r → f19
         listener._prev_flags = 0
 
         posted_events = []
+        created_events = []
+
+        def mock_create(source, vk, key_down):
+            token = f"evt_{vk}_{key_down}"
+            created_events.append(token)
+            return token
 
         def mock_post(tap, evt):
-            vk = Quartz.CGEventGetIntegerValueField(evt, Quartz.kCGKeyboardEventKeycode)
-            is_down = Quartz.CGEventGetType(evt) == Quartz.kCGEventKeyDown
-            posted_events.append((vk, is_down))
+            posted_events.append(evt)
 
-        # Build a FlagsChanged event with shift flag set (key down)
-        event = Quartz.CGEventCreateKeyboardEvent(None, 60, True)
-        Quartz.CGEventSetType(event, Quartz.kCGEventFlagsChanged)
-        Quartz.CGEventSetFlags(event, 0x020000)
-        Quartz.CGEventSetIntegerValueField(event, Quartz.kCGKeyboardEventKeycode, 60)
+        def mock_get_int(event, field):
+            # Return keycode 60 for the input event
+            if field == cg.kCGKeyboardEventKeycode:
+                return 60
+            return 0
 
-        import unittest.mock
-        with unittest.mock.patch.object(Quartz, "CGEventPost", side_effect=mock_post):
-            result = listener._callback(None, Quartz.kCGEventFlagsChanged, event, None)
+        def mock_get_flags(event):
+            return 0x020000  # shift flag set (key down)
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(cg, "CGEventGetIntegerValueField", mock_get_int)
+            mp.setattr(cg, "CGEventGetFlags", mock_get_flags)
+            mp.setattr(cg, "CGEventCreateKeyboardEvent", mock_create)
+            mp.setattr(cg, "CGEventPost", mock_post)
+            mp.setattr(cg, "CFRelease", lambda evt: None)
+            result = listener._callback(None, cg.kCGEventFlagsChanged, 0xDEAD, None)
 
         assert result is None  # Swallowed
         assert len(posted_events) == 1
-        assert posted_events[0] == (80, True)  # F19 keydown
+        assert posted_events[0] == "evt_80_True"  # F19 keydown
 
     def test_modifier_remap_keyup(self):
         """FlagsChanged event for modifier release → synthesize target keyup."""
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = KeyRemapListener()
         listener.add(60, 80, True, 0x020000)
@@ -1028,54 +1033,77 @@ class TestKeyRemapListener:
 
         posted_events = []
 
-        def mock_post(tap, evt):
-            vk = Quartz.CGEventGetIntegerValueField(evt, Quartz.kCGKeyboardEventKeycode)
-            is_down = Quartz.CGEventGetType(evt) == Quartz.kCGEventKeyDown
-            posted_events.append((vk, is_down))
+        def mock_create(source, vk, key_down):
+            return f"evt_{vk}_{key_down}"
 
-        # Flags cleared → key up
-        event = Quartz.CGEventCreateKeyboardEvent(None, 60, False)
-        Quartz.CGEventSetType(event, Quartz.kCGEventFlagsChanged)
-        Quartz.CGEventSetFlags(event, 0)
-        Quartz.CGEventSetIntegerValueField(event, Quartz.kCGKeyboardEventKeycode, 60)
+        def mock_get_int(event, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 60
+            return 0
 
-        import unittest.mock
-        with unittest.mock.patch.object(Quartz, "CGEventPost", side_effect=mock_post):
-            result = listener._callback(None, Quartz.kCGEventFlagsChanged, event, None)
+        def mock_get_flags(event):
+            return 0  # Flags cleared → key up
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(cg, "CGEventGetIntegerValueField", mock_get_int)
+            mp.setattr(cg, "CGEventGetFlags", mock_get_flags)
+            mp.setattr(cg, "CGEventCreateKeyboardEvent", mock_create)
+            mp.setattr(cg, "CGEventPost", lambda tap, evt: posted_events.append(evt))
+            mp.setattr(cg, "CFRelease", lambda evt: None)
+            result = listener._callback(None, cg.kCGEventFlagsChanged, 0xDEAD, None)
 
         assert result is None
         assert len(posted_events) == 1
-        assert posted_events[0] == (80, False)  # F19 keyup
+        assert posted_events[0] == "evt_80_False"  # F19 keyup
 
     def test_unremapped_key_passes_through(self):
         """Keys not in the remap table should pass through unchanged."""
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = KeyRemapListener()
         listener.add(60, 80, True, 0x020000)
 
-        event = Quartz.CGEventCreateKeyboardEvent(None, 0, True)  # 'a' key
-        result = listener._callback(None, Quartz.kCGEventKeyDown, event, None)
-        assert result is event  # Passed through
+        event = 0xBEEF  # raw pointer placeholder
+
+        def mock_get_int(ev, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 0  # 'a' key
+            return 0
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(cg, "CGEventGetIntegerValueField", mock_get_int)
+            result = listener._callback(None, cg.kCGEventKeyDown, event, None)
+
+        assert result == event  # Passed through
 
     def test_regular_key_remap(self):
         """KeyDown for regular key remap → synthesize target."""
-        import Quartz
+        import wenzi._cgeventtap as cg
 
         listener = KeyRemapListener()
         listener.add(105, 53, False, 0)  # f13 → esc
 
         posted_events = []
 
-        def mock_post(tap, evt):
-            vk = Quartz.CGEventGetIntegerValueField(evt, Quartz.kCGKeyboardEventKeycode)
-            posted_events.append(vk)
+        def mock_create(source, vk, key_down):
+            return f"evt_{vk}_{key_down}"
 
-        event = Quartz.CGEventCreateKeyboardEvent(None, 105, True)
+        def mock_get_int(event, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 105
+            return 0
 
-        import unittest.mock
-        with unittest.mock.patch.object(Quartz, "CGEventPost", side_effect=mock_post):
-            result = listener._callback(None, Quartz.kCGEventKeyDown, event, None)
+        def mock_get_flags(event):
+            return 0
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(cg, "CGEventGetIntegerValueField", mock_get_int)
+            mp.setattr(cg, "CGEventGetFlags", mock_get_flags)
+            mp.setattr(cg, "CGEventCreateKeyboardEvent", mock_create)
+            mp.setattr(cg, "CGEventSetFlags", lambda evt, flags: None)
+            mp.setattr(cg, "CGEventPost", lambda tap, evt: posted_events.append(evt))
+            mp.setattr(cg, "CFRelease", lambda evt: None)
+            result = listener._callback(None, cg.kCGEventKeyDown, 0xDEAD, None)
 
         assert result is None
-        assert posted_events == [53]
+        assert posted_events == ["evt_53_True"]


### PR DESCRIPTION
## Summary

- **Root cause**: PyObjC's `CGEventTapCreate` callback bridge internally retains `CGEventRef` wrappers — `leaks` confirms they're reachable (not leaked), held by the bridge's internal bookkeeping. ~42 MB (180K HIDEvent + 94K CGEvent) accumulates over 7 hours.
- **Fix**: New `wenzi/_cgeventtap.py` module provides pure ctypes bindings for `CGEventTapCreate`, `CFRunLoop`, and all `CGEvent*` functions. Callbacks receive raw `c_void_p` pointers — no PyObjC wrappers, no `CFRetain`, no retention.
- **Also**: Wrap `recognize_text()` in `objc.autorelease_pool()` to drain Vision framework objects on the OCR thread.

### Changed files
| File | Change |
|------|--------|
| `_cgeventtap.py` | **New** — pure ctypes bindings (no PyObjC) |
| `hotkey.py` | 3 classes switched to ctypes CGEventTap |
| `snippet_expander.py` | Switched to ctypes CGEventTap |
| `ocr.py` | Added `autorelease_pool` |
| `test_hotkey.py` | Updated mocks for ctypes |
| `test_snippet_expander.py` | Updated for raw-pointer interface |

## Test plan

- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v` — 3759 passed
- [ ] Manual: run WenZi Lite for 1+ hours, `heap <pid> -s | grep HIDEvent` — count should stay near zero
- [ ] Manual: verify keyboard input, hotkeys, key remapping, snippet expansion all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)