### PR TITLE
fix: release WKWebView resources on panel close to reduce memory

### DIFF
--- a/src/wenzi/ui/result_window_web.py
+++ b/src/wenzi/ui/result_window_web.py
@@ -1620,6 +1620,12 @@ class ResultPreviewPanel:
 
         if old_panel is not None:
             try:
+                # Stop the old WKWebView and load empty content to release
+                # canvas/IOSurface memory in the shared Web Content process.
+                for subview in (old_panel.contentView().subviews() or []):
+                    if hasattr(subview, 'stopLoading_'):
+                        subview.stopLoading_(None)
+                        subview.loadHTMLString_baseURL_("", None)
                 old_panel.close()
             except Exception:
                 pass

--- a/src/wenzi/ui/stats_panel.py
+++ b/src/wenzi/ui/stats_panel.py
@@ -142,6 +142,14 @@ class StatsChartPanel:
         """Close panel and restore accessory mode."""
         try:
             if self._webview is not None:
+                # Destroy Chart.js instances to release canvas memory
+                # in the shared Web Content process.
+                self._webview.evaluateJavaScript_completionHandler_(
+                    "Object.values(chartInstances).forEach("
+                    "c => { if (c) c.destroy(); });"
+                    "chartInstances = {};",
+                    None,
+                )
                 self._webview.stopLoading_(None)
                 self._webview = None
             if self._panel is not None:


### PR DESCRIPTION
## Summary
- **StatsChartPanel**: destroy all Chart.js instances via JS before closing the webview, releasing canvas pixel buffers held in the shared Web Content process
- **ResultPreviewPanel**: stop loading and clear old child WKWebViews before replacing them in `_open_webview_panel()`, preventing orphaned DOM trees and IOSurface rendering buffers from lingering

## Context
Activity Monitor showed the `WenZi Lite Web Content` process at 422.5 MB. All WKWebViews share a single Web Content process via the shared non-persistent data store. Chart.js canvas buffers and orphaned child webviews were not being explicitly released on panel close, causing memory to accumulate over time.

## Test plan
- [x] `uv run ruff check` — passes
- [x] `uv run pytest tests/ -v` — 3754 passed (5 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)