### PR TITLE
fix: use dedicated WKWebsiteDataStore for rarely-opened panels

### DIFF
--- a/src/wenzi/scripting/ui/webview_panel.py
+++ b/src/wenzi/scripting/ui/webview_panel.py
@@ -692,7 +692,7 @@ class WebViewPanel:
 
         from wenzi.ui.web_utils import lightweight_webview_config
 
-        config = lightweight_webview_config()
+        config = lightweight_webview_config(shared=False)
         config.setUserContentController_(content_controller)
 
         # Register wz-file:// scheme handler for local file access from JS

--- a/src/wenzi/ui/history_browser_window_web.py
+++ b/src/wenzi/ui/history_browser_window_web.py
@@ -487,7 +487,7 @@ class HistoryBrowserPanel:
 
         from wenzi.ui.web_utils import lightweight_webview_config
 
-        config = lightweight_webview_config()
+        config = lightweight_webview_config(shared=False)
         content_controller = WKUserContentController.alloc().init()
 
         handler_cls = _get_message_handler_class()

--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -394,7 +394,7 @@ class SettingsWebPanel:
         # WKWebView with message handler and bridge script
         from wenzi.ui.web_utils import lightweight_webview_config
 
-        config = lightweight_webview_config()
+        config = lightweight_webview_config(shared=False)
         content_controller = WKUserContentController.alloc().init()
 
         handler_cls = _get_message_handler_class()

--- a/src/wenzi/ui/stats_panel.py
+++ b/src/wenzi/ui/stats_panel.py
@@ -207,7 +207,7 @@ class StatsChartPanel:
         # WKWebView fills content area
         from wenzi.ui.web_utils import lightweight_webview_config
 
-        config = lightweight_webview_config()
+        config = lightweight_webview_config(shared=False)
         webview = WKWebView.alloc().initWithFrame_configuration_(
             NSMakeRect(0, 0, self._WIDTH, self._HEIGHT),
             config,

--- a/src/wenzi/ui/vocab_manager_window.py
+++ b/src/wenzi/ui/vocab_manager_window.py
@@ -337,7 +337,7 @@ class VocabManagerPanel:
 
         from wenzi.ui.web_utils import lightweight_webview_config
 
-        config = lightweight_webview_config()
+        config = lightweight_webview_config(shared=False)
         content_controller = WKUserContentController.alloc().init()
 
         handler_cls = _get_message_handler_class()

--- a/src/wenzi/ui/web_utils.py
+++ b/src/wenzi/ui/web_utils.py
@@ -101,7 +101,9 @@ def _shared_nonpersistent_store():
     return _nonpersistent_store
 
 
-def lightweight_webview_config(*, network: bool = False):  # -> WKWebViewConfiguration
+def lightweight_webview_config(
+    *, network: bool = False, shared: bool = True
+):  # -> WKWebViewConfiguration
     """Return a WKWebViewConfiguration optimised for low memory usage.
 
     WebViews sharing the same ``WKWebsiteDataStore`` instance share a
@@ -111,15 +113,29 @@ def lightweight_webview_config(*, network: bool = False):  # -> WKWebViewConfigu
 
     *network* — keep the default persistent data store (needed when the
     WebView loads real URLs, e.g. Google Translate).  When ``False`` a
-    shared non-persistent ``WKWebsiteDataStore`` is used, which avoids
+    non-persistent ``WKWebsiteDataStore`` is used, which avoids
     persistent cookie/cache storage and reduces Networking process
     overhead.
+
+    *shared* — when ``True`` (default), all WebViews use a single shared
+    non-persistent data store and therefore share one Web Content process.
+    When ``False``, a dedicated non-persistent data store is created so
+    the WebView gets its own Web Content process that exits automatically
+    when the WebView is deallocated.  Use ``False`` for rarely-opened
+    panels to avoid long-lived memory retention in the shared process.
     """
     from WebKit import WKWebViewConfiguration
 
     config = WKWebViewConfiguration.alloc().init()
 
     if not network:
-        config.setWebsiteDataStore_(_shared_nonpersistent_store())
+        if shared:
+            config.setWebsiteDataStore_(_shared_nonpersistent_store())
+        else:
+            from WebKit import WKWebsiteDataStore
+
+            config.setWebsiteDataStore_(
+                WKWebsiteDataStore.nonPersistentDataStore()
+            )
 
     return config


### PR DESCRIPTION
## Summary
- Add `shared` parameter to `lightweight_webview_config()` in `web_utils.py`
- Rarely-opened panels (Settings, History Browser, Stats, Vocab Manager, plugin WebViewPanel) now use `shared=False` to get a dedicated Web Content process
- Dedicated process exits automatically when the webview is deallocated — no manual empty HTML cleanup needed
- Frequently-used panels (Chooser, Result Preview, Streaming Overlay) remain on the shared data store

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3759 passed
- [ ] Open/close Settings, History Browser, Stats, Vocab Manager — verify Web Content process count drops back after close (Activity Monitor)
- [ ] Verify Chooser, Result Preview, Streaming Overlay still share one Web Content process

🤖 Generated with [Claude Code](https://claude.com/claude-code)