### PR TITLE
docs: update CGEventTap section to reflect ctypes approach

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,27 +133,38 @@ All `chat.completions.create` calls **must** include `max_tokens` to prevent run
 
 When adding a new LLM call, always set `max_tokens` to a reasonable upper bound for the expected output.
 
-## CGEventTap Autorelease Pool
+## CGEventTap — Use ctypes, Not PyObjC
 
-CGEventTap callbacks run on background threads via `CFRunLoopRun()`. PyObjC creates autoreleased Objective-C wrapper objects (HIDEvent, CGEvent, CGSEventAppendix) for each event that passes through the callback. Without explicit pool management, these objects accumulate indefinitely on the thread.
+CGEventTap callbacks **must** use the ctypes bindings in `wenzi/_cgeventtap.py`, NOT PyObjC's `Quartz.CGEventTapCreate`. PyObjC's callback bridge internally retains `CGEventRef` wrappers (CF types freed by `CFRelease`, not autorelease), accumulating ~42 MB over 7 hours. The ctypes path bypasses the bridge entirely — callbacks receive raw `c_void_p` pointers with no `CFRetain`.
 
-**Rule:** Always wrap CGEventTap `_callback` methods AND `_run` thread entry points with `objc.autorelease_pool()`:
+**Rule:** When adding a new CGEventTap:
 
 ```python
-import objc
+from wenzi import _cgeventtap as cg
 
 def _callback(self, proxy, event_type, event, refcon):
-    with objc.autorelease_pool():
-        # ... process event ...
-        return event
+    # event is a raw c_void_p integer — no PyObjC wrapper
+    keycode = cg.CGEventGetIntegerValueField(event, cg.kCGKeyboardEventKeycode)
+    flags = cg.CGEventGetFlags(event)
+    # ... process ...
+    return event  # pass through (active tap) or None/0 (swallow / listen-only)
 
-def _run():
-    with objc.autorelease_pool():
-        # ... create tap, run loop ...
-        CFRunLoopRun()
+def start(self):
+    def _raw_cb(proxy, event_type, event, refcon):
+        return self._callback(proxy, event_type, event, refcon) or 0
+    self._ctypes_cb = cg.CGEventTapCallBack(_raw_cb)  # MUST store to prevent GC!
+    self._tap = cg.CGEventTapCreate(
+        cg.kCGSessionEventTap, cg.kCGHeadInsertEventTap,
+        cg.kCGEventTapOptionListenOnly, mask, self._ctypes_cb, None,
+    )
+    # ... CFRunLoop setup via cg.CFMachPortCreateRunLoopSource, etc.
 ```
 
-The per-callback pool is what prevents the leak. The `_run` pool is a defensive measure for the thread's top-level scope.
+**Key rules:**
+- Store `self._ctypes_cb` — if the ctypes callback is garbage collected, the tap segfaults
+- Synthetic events from `cg.CGEventCreateKeyboardEvent` must be `cg.CFRelease`'d after posting
+- The `_raw_cb` trampoline converts `None` returns to `0` (ctypes `c_void_p` cannot handle `None`)
+- Set `self._ctypes_cb = None` in `stop()` only after the tap is disabled and the run loop is stopped
 
 See `hotkey.py` (`_QuartzAllKeysListener`, `TapHotkeyListener`, `KeyRemapListener`) and `snippet_expander.py` (`SnippetExpander`) for reference implementations.
 


### PR DESCRIPTION
## Summary
- Replace outdated autorelease pool docs with current ctypes-based CGEventTap approach from PR #158
- Documents key rules: store ctypes callback ref, CFRelease synthetic events, trampoline for None returns

## Test plan
- [x] Documentation-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)