### PR TITLE
fix: release all retained references in WebViewPanel.close()

### DIFF
--- a/src/wenzi/scripting/ui/webview_panel.py
+++ b/src/wenzi/scripting/ui/webview_panel.py
@@ -439,6 +439,13 @@ class WebViewPanel:
             NSApp.setActivationPolicy_(1)  # Accessory (statusbar-only)
 
         self._webview = None
+        self._panel = None
+        self._file_handler = None
+        self._message_handler_obj = None
+        self._close_delegate = None
+        self._on_close_callbacks = []
+        self._event_handlers = {}
+        self._call_handlers = {}
 
     def set_html(self, html: str) -> None:
         """Update the HTML content."""


### PR DESCRIPTION
## Summary
- Clear `_panel`, `_file_handler`, `_message_handler_obj`, `_close_delegate`, `_on_close_callbacks`, `_event_handlers`, and `_call_handlers` in `WebViewPanel.close()`
- Previously only `_webview` was niled — NSPanel, scheme handler, and closure chains survived until GC cycle collection
- Fixes memory growth after repeated screenshot/annotation cycles

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/scripting/test_webview_panel.py -v` — 45 passed
- [ ] Take 5+ screenshots, verify WenZi Lite process memory returns to baseline after closing each editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)