### PR TITLE
fix: join CGEventTap threads before releasing ctypes callbacks on reload

### DIFF
--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -364,6 +364,9 @@ class _QuartzAllKeysListener:
             cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
         self._ctypes_cb = None
         logger.info("Quartz all-keys listener stopped")
 
@@ -468,6 +471,9 @@ class TapHotkeyListener:
             cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
         self._ctypes_cb = None
         logger.info("TapHotkeyListener stopped")
 
@@ -600,6 +606,9 @@ class KeyRemapListener:
             cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
         self._ctypes_cb = None
         logger.info("KeyRemapListener stopped")
 

--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -148,10 +148,10 @@ class SnippetExpander:
             cg.CFRunLoopStop(self._loop)
             self._loop = None
         self._tap = None
-        self._ctypes_cb = None
         if self._thread is not None:
             self._thread.join(timeout=2.0)
             self._thread = None
+        self._ctypes_cb = None
         with self._lock:
             self._buffer = ""
         logger.info("SnippetExpander stopped")


### PR DESCRIPTION
## Summary
- During script reload, `stop()` methods cleared `_ctypes_cb` (allowing GC of the ctypes callback) before the run loop thread had fully exited
- A pending CGEventTap event arriving at the freed callback caused SIGSEGV (3 identical crashes observed today, all in `closure_fcn` on thread 9)
- Now all `stop()` methods in `hotkey.py` and `snippet_expander.py` join the thread (2s timeout) before releasing the callback reference

## Test plan
- [x] `uv run ruff check` — 0 errors
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3759 passed
- [ ] Manual: reload scripts via chooser command and verify no crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)