### PR TITLE
fix(memory): drain autorelease pools in background threads

### DIFF
--- a/src/wenzi/input.py
+++ b/src/wenzi/input.py
@@ -7,6 +7,7 @@ import subprocess
 import threading
 import time
 
+import objc
 from AppKit import NSPasteboard, NSPasteboardTypeString, NSString
 
 logger = logging.getLogger(__name__)
@@ -262,16 +263,17 @@ def _set_pasteboard_concealed(text: str) -> bool:
     ``org.nspasteboard.ConcealedType`` and ``com.nspasteboard.TransientType``
     and will skip entries that carry these types.
     """
-    pb = NSPasteboard.generalPasteboard()
-    pb.clearContents()
-    ns_str = NSString.stringWithString_(text)
-    ok = pb.setString_forType_(ns_str, NSPasteboardTypeString)
-    if not ok:
-        return False
-    # Marker types – the value is irrelevant; their presence is the signal.
-    pb.setString_forType_("", "org.nspasteboard.ConcealedType")
-    pb.setString_forType_("", "com.nspasteboard.TransientType")
-    return True
+    with objc.autorelease_pool():
+        pb = NSPasteboard.generalPasteboard()
+        pb.clearContents()
+        ns_str = NSString.stringWithString_(text)
+        ok = pb.setString_forType_(ns_str, NSPasteboardTypeString)
+        if not ok:
+            return False
+        # Marker types – the value is irrelevant; their presence is the signal.
+        pb.setString_forType_("", "org.nspasteboard.ConcealedType")
+        pb.setString_forType_("", "com.nspasteboard.TransientType")
+        return True
 
 
 def _set_pasteboard_string(text: str) -> None:

--- a/src/wenzi/scripting/clipboard_monitor.py
+++ b/src/wenzi/scripting/clipboard_monitor.py
@@ -20,6 +20,8 @@ import time
 from dataclasses import dataclass, field
 from typing import List, Optional
 
+import objc
+
 from wenzi.config import DEFAULT_CLIPBOARD_IMAGES_DIR, DEFAULT_ICON_CACHE_DIR
 
 logger = logging.getLogger(__name__)
@@ -78,53 +80,54 @@ def _get_app_icon_png(bundle_id: str) -> Optional[bytes]:
 
     Returns None if the app is not found or icon extraction fails.
     """
-    try:
-        from AppKit import (
-            NSBitmapImageRep,
-            NSCalibratedRGBColorSpace,
-            NSCompositingOperationSourceOver,
-            NSGraphicsContext,
-            NSPNGFileType,
-            NSWorkspace,
-        )
-        from Foundation import NSMakeRect, NSZeroRect
-
-        ws = NSWorkspace.sharedWorkspace()
-        url = ws.URLForApplicationWithBundleIdentifier_(bundle_id)
-        if url is None:
-            return None
-        icon = ws.iconForFile_(url.path())
-        if icon is None:
-            return None
-
-        # Draw into a new bitmap at the exact pixel size we want.
-        sz = _ICON_SIZE
-        new_rep = NSBitmapImageRep.alloc() \
-            .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
-                None, sz, sz, 8, 4, True, False,
-                NSCalibratedRGBColorSpace, 0, 0,
+    with objc.autorelease_pool():
+        try:
+            from AppKit import (
+                NSBitmapImageRep,
+                NSCalibratedRGBColorSpace,
+                NSCompositingOperationSourceOver,
+                NSGraphicsContext,
+                NSPNGFileType,
+                NSWorkspace,
             )
-        if new_rep is None:
+            from Foundation import NSMakeRect, NSZeroRect
+
+            ws = NSWorkspace.sharedWorkspace()
+            url = ws.URLForApplicationWithBundleIdentifier_(bundle_id)
+            if url is None:
+                return None
+            icon = ws.iconForFile_(url.path())
+            if icon is None:
+                return None
+
+            # Draw into a new bitmap at the exact pixel size we want.
+            sz = _ICON_SIZE
+            new_rep = NSBitmapImageRep.alloc() \
+                .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
+                    None, sz, sz, 8, 4, True, False,
+                    NSCalibratedRGBColorSpace, 0, 0,
+                )
+            if new_rep is None:
+                return None
+
+            ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(new_rep)
+            if ctx is None:
+                return None
+
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.setCurrentContext_(ctx)
+            ctx.setImageInterpolation_(3)  # NSImageInterpolationHigh
+            icon.drawInRect_fromRect_operation_fraction_(
+                NSMakeRect(0, 0, sz, sz), NSZeroRect,
+                NSCompositingOperationSourceOver, 1.0,
+            )
+            NSGraphicsContext.restoreGraphicsState()
+
+            png = new_rep.representationUsingType_properties_(NSPNGFileType, {})
+            return bytes(png) if png else None
+        except Exception:
+            logger.debug("Failed to extract icon for %s", bundle_id, exc_info=True)
             return None
-
-        ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(new_rep)
-        if ctx is None:
-            return None
-
-        NSGraphicsContext.saveGraphicsState()
-        NSGraphicsContext.setCurrentContext_(ctx)
-        ctx.setImageInterpolation_(3)  # NSImageInterpolationHigh
-        icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, sz, sz), NSZeroRect,
-            NSCompositingOperationSourceOver, 1.0,
-        )
-        NSGraphicsContext.restoreGraphicsState()
-
-        png = new_rep.representationUsingType_properties_(NSPNGFileType, {})
-        return bytes(png) if png else None
-    except Exception:
-        logger.debug("Failed to extract icon for %s", bundle_id, exc_info=True)
-        return None
 
 
 @dataclass
@@ -564,10 +567,11 @@ class ClipboardMonitor:
     def _poll_loop(self) -> None:
         """Main polling loop running in a background thread."""
         while not self._stop_event.is_set():
-            try:
-                self._check_clipboard()
-            except Exception:
-                logger.debug("Clipboard poll error", exc_info=True)
+            with objc.autorelease_pool():
+                try:
+                    self._check_clipboard()
+                except Exception:
+                    logger.debug("Clipboard poll error", exc_info=True)
             self._stop_event.wait(self._poll_interval)
 
     def _check_clipboard(self) -> None:

--- a/src/wenzi/scripting/sources/app_source.py
+++ b/src/wenzi/scripting/sources/app_source.py
@@ -15,6 +15,8 @@ import threading
 import time
 from typing import List, Optional
 
+import objc
+
 from wenzi.config import DEFAULT_ICON_CACHE_DIR as _CFG_ICON_CACHE_DIR
 from wenzi.scripting.sources import (
     ChooserItem,
@@ -57,65 +59,67 @@ _CORE_SERVICES_APPS = [
 
 def _get_display_name(path: str, fallback: str) -> str:
     """Return the localized display name for an app bundle path."""
-    try:
-        from Foundation import NSFileManager
+    with objc.autorelease_pool():
+        try:
+            from Foundation import NSFileManager
 
-        fm = NSFileManager.defaultManager()
-        display = fm.displayNameAtPath_(path)
-        if display:
-            name = str(display)
-            # displayNameAtPath_ may include ".app" for non-localized names
-            if name.endswith(".app"):
-                name = name[:-4]
-            return name
-    except Exception:
-        pass
-    return fallback
+            fm = NSFileManager.defaultManager()
+            display = fm.displayNameAtPath_(path)
+            if display:
+                name = str(display)
+                # displayNameAtPath_ may include ".app" for non-localized names
+                if name.endswith(".app"):
+                    name = name[:-4]
+                return name
+        except Exception:
+            pass
+        return fallback
 
 
 def _get_app_icon_png(path: str) -> Optional[bytes]:
     """Return raw PNG bytes for the app icon, or None on failure."""
-    try:
-        from AppKit import (
-            NSBitmapImageRep,
-            NSCompositingOperationCopy,
-            NSDeviceRGBColorSpace,
-            NSGraphicsContext,
-            NSPNGFileType,
-            NSWorkspace,
-        )
-        from Foundation import NSMakeRect, NSZeroRect
-
-        ws = NSWorkspace.sharedWorkspace()
-        icon = ws.iconForFile_(path)
-        if icon is None:
-            return None
-
-        # Render into a bitmap rep (thread-safe, no deprecated lockFocus)
-        sz = _ICON_SIZE
-        rep = NSBitmapImageRep.alloc() \
-            .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
-                None, sz, sz, 8, 4, True, False,
-                NSDeviceRGBColorSpace, 0, 0,
+    with objc.autorelease_pool():
+        try:
+            from AppKit import (
+                NSBitmapImageRep,
+                NSCompositingOperationCopy,
+                NSDeviceRGBColorSpace,
+                NSGraphicsContext,
+                NSPNGFileType,
+                NSWorkspace,
             )
-        if rep is None:
-            return None
-        ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
-        if ctx is None:
-            return None
-        NSGraphicsContext.saveGraphicsState()
-        NSGraphicsContext.setCurrentContext_(ctx)
-        icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, sz, sz), NSZeroRect,
-            NSCompositingOperationCopy, 1.0,
-        )
-        NSGraphicsContext.restoreGraphicsState()
+            from Foundation import NSMakeRect, NSZeroRect
 
-        png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
-        return bytes(png_data) if png_data else None
-    except Exception:
-        logger.debug("Failed to get icon for %s", path, exc_info=True)
-        return None
+            ws = NSWorkspace.sharedWorkspace()
+            icon = ws.iconForFile_(path)
+            if icon is None:
+                return None
+
+            # Render into a bitmap rep (thread-safe, no deprecated lockFocus)
+            sz = _ICON_SIZE
+            rep = NSBitmapImageRep.alloc() \
+                .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
+                    None, sz, sz, 8, 4, True, False,
+                    NSDeviceRGBColorSpace, 0, 0,
+                )
+            if rep is None:
+                return None
+            ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
+            if ctx is None:
+                return None
+            NSGraphicsContext.saveGraphicsState()
+            NSGraphicsContext.setCurrentContext_(ctx)
+            icon.drawInRect_fromRect_operation_fraction_(
+                NSMakeRect(0, 0, sz, sz), NSZeroRect,
+                NSCompositingOperationCopy, 1.0,
+            )
+            NSGraphicsContext.restoreGraphicsState()
+
+            png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
+            return bytes(png_data) if png_data else None
+        except Exception:
+            logger.debug("Failed to get icon for %s", path, exc_info=True)
+            return None
 
 
 def _cache_key(path: str) -> str:

--- a/src/wenzi/scripting/sources/file_source.py
+++ b/src/wenzi/scripting/sources/file_source.py
@@ -13,6 +13,8 @@ import subprocess
 import threading
 from typing import List, Optional, Set
 
+import objc
+
 from wenzi.config import DEFAULT_ICON_CACHE_DIR as _CFG_ICON_CACHE_DIR
 from wenzi.scripting.sources import ChooserItem, ChooserSource
 from wenzi.scripting.sources._mdquery import mdquery_search
@@ -52,39 +54,40 @@ def _resize_icon_to_png(icon, png_path: str, icon_cache_dir: str) -> None:
     *icon* is an ``NSImage`` obtained from NSWorkspace.  The caller is
     responsible for checking the disk cache beforehand.
     """
-    from AppKit import (
-        NSBitmapImageRep,
-        NSCompositingOperationCopy,
-        NSDeviceRGBColorSpace,
-        NSGraphicsContext,
-        NSPNGFileType,
-    )
-    from Foundation import NSMakeRect, NSZeroRect
-
-    sz = _ICON_SIZE
-    rep = NSBitmapImageRep.alloc() \
-        .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
-            None, sz, sz, 8, 4, True, False,
-            NSDeviceRGBColorSpace, 0, 0,
+    with objc.autorelease_pool():
+        from AppKit import (
+            NSBitmapImageRep,
+            NSCompositingOperationCopy,
+            NSDeviceRGBColorSpace,
+            NSGraphicsContext,
+            NSPNGFileType,
         )
-    if rep is None:
-        return
-    ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
-    if ctx is None:
-        return
-    NSGraphicsContext.saveGraphicsState()
-    NSGraphicsContext.setCurrentContext_(ctx)
-    icon.drawInRect_fromRect_operation_fraction_(
-        NSMakeRect(0, 0, sz, sz), NSZeroRect,
-        NSCompositingOperationCopy, 1.0,
-    )
-    NSGraphicsContext.restoreGraphicsState()
+        from Foundation import NSMakeRect, NSZeroRect
 
-    png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
-    if png_data:
-        os.makedirs(icon_cache_dir, exist_ok=True)
-        with open(png_path, "wb") as f:
-            f.write(bytes(png_data))
+        sz = _ICON_SIZE
+        rep = NSBitmapImageRep.alloc() \
+            .initWithBitmapDataPlanes_pixelsWide_pixelsHigh_bitsPerSample_samplesPerPixel_hasAlpha_isPlanar_colorSpaceName_bytesPerRow_bitsPerPixel_(  # noqa: E501
+                None, sz, sz, 8, 4, True, False,
+                NSDeviceRGBColorSpace, 0, 0,
+            )
+        if rep is None:
+            return
+        ctx = NSGraphicsContext.graphicsContextWithBitmapImageRep_(rep)
+        if ctx is None:
+            return
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.setCurrentContext_(ctx)
+        icon.drawInRect_fromRect_operation_fraction_(
+            NSMakeRect(0, 0, sz, sz), NSZeroRect,
+            NSCompositingOperationCopy, 1.0,
+        )
+        NSGraphicsContext.restoreGraphicsState()
+
+        png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
+        if png_data:
+            os.makedirs(icon_cache_dir, exist_ok=True)
+            with open(png_path, "wb") as f:
+                f.write(bytes(png_data))
 
 
 def _extract_filetype_icon(ext: str, icon_cache_dir: str) -> None:

--- a/src/wenzi/scripting/sources/system_settings_source.py
+++ b/src/wenzi/scripting/sources/system_settings_source.py
@@ -9,6 +9,8 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
+import objc
+
 from wenzi.config import DEFAULT_ICON_CACHE_DIR as _CFG_ICON_CACHE_DIR
 
 if TYPE_CHECKING:
@@ -275,38 +277,39 @@ def get_static_entries() -> list[SettingsEntry]:
 
 def _get_icon_png(appex_path: str) -> Optional[bytes]:
     """Return 32x32 PNG bytes for an .appex icon via NSWorkspace, or None."""
-    try:
-        from AppKit import (
-            NSBitmapImageRep,
-            NSCompositingOperationCopy,
-            NSImage,
-            NSPNGFileType,
-            NSWorkspace,
-        )
-        from Foundation import NSMakeRect, NSSize
+    with objc.autorelease_pool():
+        try:
+            from AppKit import (
+                NSBitmapImageRep,
+                NSCompositingOperationCopy,
+                NSImage,
+                NSPNGFileType,
+                NSWorkspace,
+            )
+            from Foundation import NSMakeRect, NSSize
 
-        ws = NSWorkspace.sharedWorkspace()
-        icon = ws.iconForFile_(appex_path)
-        if icon is None:
+            ws = NSWorkspace.sharedWorkspace()
+            icon = ws.iconForFile_(appex_path)
+            if icon is None:
+                return None
+
+            size = NSSize(_ICON_SIZE, _ICON_SIZE)
+            target = NSImage.alloc().initWithSize_(size)
+            target.lockFocus()
+            icon.drawInRect_fromRect_operation_fraction_(
+                NSMakeRect(0, 0, _ICON_SIZE, _ICON_SIZE),
+                NSMakeRect(0, 0, icon.size().width, icon.size().height),
+                NSCompositingOperationCopy,
+                1.0,
+            )
+            target.unlockFocus()
+
+            rep = NSBitmapImageRep.imageRepWithData_(target.TIFFRepresentation())
+            png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
+            return bytes(png_data) if png_data else None
+        except Exception:
+            logger.debug("Failed to get icon for %s", appex_path, exc_info=True)
             return None
-
-        size = NSSize(_ICON_SIZE, _ICON_SIZE)
-        target = NSImage.alloc().initWithSize_(size)
-        target.lockFocus()
-        icon.drawInRect_fromRect_operation_fraction_(
-            NSMakeRect(0, 0, _ICON_SIZE, _ICON_SIZE),
-            NSMakeRect(0, 0, icon.size().width, icon.size().height),
-            NSCompositingOperationCopy,
-            1.0,
-        )
-        target.unlockFocus()
-
-        rep = NSBitmapImageRep.imageRepWithData_(target.TIFFRepresentation())
-        png_data = rep.representationUsingType_properties_(NSPNGFileType, None)
-        return bytes(png_data) if png_data else None
-    except Exception:
-        logger.debug("Failed to get icon for %s", appex_path, exc_info=True)
-        return None
 
 
 def _cache_key(appex_name: str) -> str:


### PR DESCRIPTION
Background threads that call AppKit/Foundation APIs (NSPasteboard, NSWorkspace, NSImage, NSBitmapImageRep, NSGraphicsContext, Vision) accumulate autoreleased ObjC objects indefinitely because non-main threads lack an automatic autorelease pool.

Add objc.autorelease_pool() to:
- clipboard_monitor: _poll_loop (every 0.5s), _get_app_icon_png
- app_source: _get_app_icon_png, _get_display_name
- file_source: _resize_icon_to_png (shared by filetype/folder icon extraction)
- system_settings_source: _get_icon_png
- input: _set_pasteboard_concealed (called from daemon restore threads)
- ocr: recognize_text (already had it on this branch)