### PR TITLE
fix: release WKWebView GPU-cached bitmaps to prevent graphics memory growth

### DIFF
--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -700,6 +700,7 @@ class ChooserPanel:
         # cycle once the panel is already hidden).
         if self._webview is not None and self._page_loaded:
             self._webview.evaluateJavaScript_completionHandler_(
+                "_releasePreviewImages();"
                 "setResults([]);setInputValue('');"
                 "setPreviewVisible(false);setCompact(false);"
                 "setModifierHints({},null);setCreateButton(false);"

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -516,6 +516,10 @@ function _renderVisibleRows() {
     var endIdx = Math.min(items.length,
         Math.ceil((scrollTop + viewportHeight) / h) + BUFFER_COUNT);
 
+    // Release GPU-cached decoded bitmaps before replacing DOM nodes
+    var oldImgs = _spacer.querySelectorAll('img.icon');
+    for (var j = 0; j < oldImgs.length; j++) oldImgs[j].src = '';
+
     var htmlParts = [];
     for (var i = startIdx; i < endIdx; i++) {
         htmlParts.push(_buildRowHtml(items[i], i));
@@ -607,7 +611,13 @@ function updatePreview() {
     }
 }
 
+function _releasePreviewImages() {
+    var imgs = previewPanel.querySelectorAll('img');
+    for (var i = 0; i < imgs.length; i++) imgs[i].src = '';
+}
+
 function setPreview(data) {
+    _releasePreviewImages();
     if (!data) {
         previewPanel.className = 'preview-panel empty';
         previewPanel.textContent = i18n('preview.select_item');


### PR DESCRIPTION
## Summary
- Null `img.src` before removing DOM nodes to signal WebKit to release decoded IOSurface bitmaps from GPU memory
- Add `_releasePreviewImages()` helper to clear preview images before replacement
- Null icon `img.src` in `_renderVisibleRows()` before `innerHTML` rebuild
- Call `_releasePreviewImages()` in `close()` before blanking the page

Without this, the Web Content process accumulates GPU memory as users navigate through image previews and scroll through icon-heavy result lists.

## Test plan
- [ ] Open chooser, navigate through 20+ clipboard image previews, verify Web Content process memory stays flat in Activity Monitor
- [ ] Scroll through large result lists with icons, verify no GPU memory growth
- [ ] Open/close chooser repeatedly, verify memory is reclaimed

🤖 Generated with [Claude Code](https://claude.com/claude-code)