### PR TITLE
fix(ui): show panels in fullscreen Spaces

### DIFF
--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -364,8 +364,7 @@ class RecordingIndicatorPanel:
             panel.setIgnoresMouseEvents_(True)
             panel.setHasShadow_(True)
             panel.setHidesOnDeactivate_(False)
-            # canJoinAllSpaces (1<<4) + stationary (1<<4 is same, use just canJoinAllSpaces)
-            panel.setCollectionBehavior_(1 << 4)
+            panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
             # Position at center of main screen
             screen = NSScreen.mainScreen()

--- a/src/wenzi/scripting/api/alert.py
+++ b/src/wenzi/scripting/api/alert.py
@@ -98,7 +98,7 @@ def _show_alert(text: str, duration: float) -> None:
     panel.setIgnoresMouseEvents_(True)
     panel.setMovableByWindowBackground_(False)
     panel.setHidesOnDeactivate_(False)
-    panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+    panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
     # Vibrancy background (macOS frosted glass)
     vibrancy = NSVisualEffectView.alloc().initWithFrame_(

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -1761,7 +1761,7 @@ class ChooserPanel:
         panel.setFloatingPanel_(True)
         panel.setHidesOnDeactivate_(False)
         panel.setMovableByWindowBackground_(False)
-        panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+        panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
         # Transparent background — the HTML provides its own
         from AppKit import NSColor

--- a/src/wenzi/scripting/ui/leader_alert.py
+++ b/src/wenzi/scripting/ui/leader_alert.py
@@ -94,7 +94,7 @@ class LeaderAlertPanel:
         panel.setIgnoresMouseEvents_(True)
         panel.setMovableByWindowBackground_(False)
         panel.setHidesOnDeactivate_(False)
-        panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+        panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
         # --- Vibrancy background ---
         vibrancy = NSVisualEffectView.alloc().initWithFrame_(

--- a/src/wenzi/scripting/ui/quicklook_panel.py
+++ b/src/wenzi/scripting/ui/quicklook_panel.py
@@ -140,7 +140,7 @@ class QuickLookPanel:
             panel.setLevel_(NSStatusWindowLevel + 1)
             panel.setHidesOnDeactivate_(False)
             panel.setFloatingPanel_(True)
-            panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+            panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
             self._native_panel = panel
             self._data_source = data_source

--- a/src/wenzi/ui/hud.py
+++ b/src/wenzi/ui/hud.py
@@ -79,7 +79,7 @@ def show_hud(message: str) -> None:
     panel.setIgnoresMouseEvents_(True)
     panel.setFloatingPanel_(True)
     panel.setHidesOnDeactivate_(False)
-    panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+    panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
     panel.setBackgroundColor_(NSColor.clearColor())
 
     # Rounded semi-transparent background

--- a/src/wenzi/ui/live_transcription_overlay.py
+++ b/src/wenzi/ui/live_transcription_overlay.py
@@ -128,7 +128,7 @@ class LiveTranscriptionOverlay:
             panel.setIgnoresMouseEvents_(True)
             panel.setHasShadow_(True)
             panel.setHidesOnDeactivate_(False)
-            panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+            panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
             # Content view with drawRect_-based rounded background
             content = _LiveBgView.alloc().initWithFrame_(

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -163,7 +163,7 @@ class StreamingOverlayPanel:
             panel.setBackgroundColor_(NSColor.clearColor())
             panel.setHasShadow_(True)
             panel.setHidesOnDeactivate_(False)
-            panel.setCollectionBehavior_(1 << 4)  # canJoinAllSpaces
+            panel.setCollectionBehavior_((1 << 4) | (1 << 8))  # stationary | fullScreenAuxiliary
 
             # WKWebView
             from wenzi.ui.web_utils import lightweight_webview_config


### PR DESCRIPTION
## Summary
- Add `NSWindowCollectionBehaviorFullScreenAuxiliary` (`1 << 8`) to all 8 overlay panels so they appear in macOS Spaces with fullscreen apps
- Fix incorrect comments — `1 << 4` is `Stationary`, not `canJoinAllSpaces` (which is `1 << 0`)

## Affected panels
- Chooser (launcher), HUD, recording indicator, streaming overlay, live transcription overlay, quicklook, script alert, leader alert

## Test plan
- [x] `ruff check` passes
- [x] All 3780 tests pass
- [ ] Manual: open a fullscreen app, trigger the chooser panel — it should appear over the fullscreen app
- [ ] Manual: verify panels still dismiss correctly when clicking back into the fullscreen app

🤖 Generated with [Claude Code](https://claude.com/claude-code)