### PR TITLE
fix(ssl): bundle system CA certs into .app

### DIFF
--- a/WenZi-Lite.spec
+++ b/WenZi-Lite.spec
@@ -27,6 +27,7 @@ a = Analysis(
         (os.path.join(_spec_dir, 'src/wenzi/ui/vendor'), 'wenzi/ui/vendor'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/templates'), 'wenzi/ui/templates'),
         (os.path.join(_spec_dir, 'src/wenzi/screenshot/templates'), 'wenzi/screenshot/templates'),
+        ('/etc/ssl/cert.pem', '.'),
     ],
     hiddenimports=[
         # wenzi core

--- a/WenZi.spec
+++ b/WenZi.spec
@@ -34,6 +34,7 @@ a = Analysis(
         (os.path.join(_spec_dir, 'src/wenzi/ui/vendor'), 'wenzi/ui/vendor'),
         (os.path.join(_spec_dir, 'src/wenzi/ui/templates'), 'wenzi/ui/templates'),
         (os.path.join(_spec_dir, 'src/wenzi/screenshot/templates'), 'wenzi/screenshot/templates'),
+        ('/etc/ssl/cert.pem', '.'),
     ],
     hiddenimports=mlx_hiddenimports + mlx_whisper_hiddenimports + sherpa_hiddenimports + librosa_hiddenimports + [
         # wenzi core

--- a/src/wenzi/__main__.py
+++ b/src/wenzi/__main__.py
@@ -6,9 +6,11 @@ import sys
 # Ensure urllib/ssl can find CA certificates in PyInstaller bundles.
 # Without this, urllib.request fails with SSL: CERTIFICATE_VERIFY_FAILED
 # because the bundled Python cannot locate the system CA store.
-_cert = "/etc/ssl/cert.pem"
-if os.path.isfile(_cert):
-    os.environ.setdefault("SSL_CERT_FILE", _cert)
+_bundled_cert = os.path.join(getattr(sys, '_MEIPASS', ''), 'cert.pem')
+if os.path.isfile(_bundled_cert):
+    os.environ.setdefault("SSL_CERT_FILE", _bundled_cert)
+elif os.path.isfile("/etc/ssl/cert.pem"):
+    os.environ.setdefault("SSL_CERT_FILE", "/etc/ssl/cert.pem")
 
 
 def main():


### PR DESCRIPTION
## Summary
- Bundle `/etc/ssl/cert.pem` into the PyInstaller app package (both full and Lite specs)
- Prefer the bundled cert via `sys._MEIPASS` at startup, falling back to the system path
- Fixes `SSL: CERTIFICATE_VERIFY_FAILED` error on the Plugins settings page when fetching remote plugin registries

## Test plan
- [ ] Build .app with `pyinstaller WenZi.spec`, verify `cert.pem` exists inside the bundle
- [ ] Open Settings → Plugins, confirm no SSL error when loading plugin registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)