### PR TITLE
fix(app): ensure data and cache directories exist before use

### DIFF
--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -190,6 +190,8 @@ class WenZiApp(StatusBarApp):
         self._config_dir = resolve_config_dir(config_dir)
         self._data_dir = resolve_data_dir()
         self._cache_dir = resolve_cache_dir()
+        os.makedirs(self._data_dir, exist_ok=True)
+        os.makedirs(self._cache_dir, exist_ok=True)
         self._config_path = os.path.join(self._config_dir, "config.json")
         self._config, config_error = load_config(self._config_path)
         self._config_error = config_error


### PR DESCRIPTION
## Summary
- On fresh installs, `~/.local/share/WenZi/` may not exist, causing `VocabDB` sqlite3 to crash with "unable to open database file"
- Add `os.makedirs(exist_ok=True)` for both data and cache dirs at startup, right after resolving paths

## Test plan
- [x] Existing tests pass (3798 passed)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)