### PR TITLE
Recording flow, chooser UX, memory management, and threading improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,22 @@ self._panel = None
 
 When re-showing, re-activate the effect view (`setState_(1)`) **just before** `orderFront_`/`makeKeyAndOrderFront_`, so the IOSurface is only allocated while the panel is visible.
 
+**Note:** The chooser panel (`ChooserPanel`) does **not** use `NSVisualEffectView`. It uses CSS `backdrop-filter` for frosted glass — see "CSS backdrop-filter in Transparent WKWebView" below.
+
+## CSS backdrop-filter in Transparent WKWebView
+
+The chooser panel uses CSS `backdrop-filter: blur() saturate()` instead of `NSVisualEffectView` for frosted glass. This is inherently fragile in transparent WKWebViews ([WebKit #275919](https://bugs.webkit.org/show_bug.cgi?id=275919)). System events (audio playback, compositing changes) can invalidate the backdrop-filter texture, causing the panel to appear transparent.
+
+**Required architecture** (see `chooser.html`):
+
+1. **Separate compositing layer** — `backdrop-filter` must be on `body::before` (pseudo-element), NOT on `body` itself. DOM changes in the content layer must not invalidate the blur layer.
+2. **Keepalive animation** — A perpetual micro-animation (`opacity: 0.999→1`) on `body::before` forces WebKit to re-composite every frame, preventing texture reclamation.
+3. **GPU hint** — `-webkit-backface-visibility: hidden` on `body::before` to force a separate compositing layer.
+4. **Matching border-radius** — `body` must have the same `border-radius` and `overflow: hidden` as the native panel's corner radius to prevent edge artifacts.
+5. **Transparent html** — `html { background: transparent }`, only `body::before` carries the `--bg` tinted overlay.
+
+**When adding a new panel with frosted glass**, prefer `NSVisualEffectView` (stable, native). Only use CSS `backdrop-filter` if you need fine-grained control over blur radius/saturation and can tolerate the fragility.
+
 ## LLM max_tokens Guard
 
 All `chat.completions.create` calls **must** include `max_tokens` to prevent runaway repetition (models sometimes loop the same tokens indefinitely). Current call sites and their limits:
@@ -156,11 +172,13 @@ When adding a new LLM call, always set `max_tokens` to a reasonable upper bound 
 
 ## Audio in WebViews — Use `wz.playAudio()`, Not `new Audio()`
 
-Playing audio via HTML5 `new Audio(url).play()` in WKWebView triggers macOS Now Playing, showing an unwanted playback icon in the menu bar. Use the built-in `wz.playAudio(url)` JS bridge method instead — it routes audio through native `NSSound`, which does not register with `MPNowPlayingInfoCenter`.
+Playing audio via HTML5 `new Audio(url).play()` in WKWebView triggers macOS Now Playing, showing an unwanted playback icon in the menu bar. Use the built-in `wz.playAudio(url)` JS bridge method instead — it routes audio through native playback, which does not register with `MPNowPlayingInfoCenter`.
 
 - **WebView panels** (`wz.ui.webview_panel`): use `wz.playAudio(url)` in JavaScript
 - **Chooser preview HTML** (no `wz` bridge): use `webkit.messageHandlers.chooser.postMessage({type: 'playAudio', url: url})`
 - The built-in handler is registered in `WebViewPanel._builtin_play_audio` and `ChooserPanel._play_audio_url`
+
+**ChooserPanel uses `AVAudioPlayer`** (AVFoundation) instead of `NSSound` (AppKit). `NSSound` operations interfere with AppKit window server compositing, which breaks CSS `backdrop-filter` in the chooser's transparent WKWebView. Download happens on a background thread; `play()` is dispatched to the main thread via `AppHelper.callAfter`.
 
 ## CGEventTap — Use ctypes, Not PyObjC
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,26 @@ All UI must support macOS dark mode. Follow these rules when writing UI code:
 - **Avoid deprecated `colorWithCalibratedRed_green_blue_alpha_`** — use `colorWithSRGBRed_green_blue_alpha_` or system semantic colors.
 - See `ui/result_window_web.py` for a good reference implementation of dark mode support.
 
+## NSVisualEffectView Memory Management
+
+`NSVisualEffectView` with `NSVisualEffectBlendingModeBehindWindow` causes macOS to allocate a **full-screen IOSurface** (~72 MB at retina) for desktop content capture used by the blur effect. This memory is **not released** by `orderOut_` alone.
+
+When hiding or closing any panel that contains an `NSVisualEffectView`, call the shared helper **before or after** `orderOut_`:
+
+```python
+from wenzi.ui_helpers import release_panel_surfaces
+
+release_panel_surfaces(self._panel)   # deactivate VFX + shrink to 1×1
+self._panel.orderOut_(None)
+self._panel = None
+```
+
+`release_panel_surfaces(panel)` handles both steps automatically:
+1. Walks the content view and its direct subviews, deactivates any `NSVisualEffectView` (`setState_(0)`)
+2. Shrinks the panel to 1×1 to force Core Animation to release the backing store
+
+When re-showing, re-activate the effect view (`setState_(1)`) **just before** `orderFront_`/`makeKeyAndOrderFront_`, so the IOSurface is only allocated while the panel is visible.
+
 ## LLM max_tokens Guard
 
 All `chat.completions.create` calls **must** include `max_tokens` to prevent runaway repetition (models sometimes loop the same tokens indefinitely). Current call sites and their limits:

--- a/dev/recording-shortcuts.md
+++ b/dev/recording-shortcuts.md
@@ -1,0 +1,49 @@
+# Recording Session Keyboard Shortcuts
+
+Keyboard shortcuts available during voice recording and streaming enhancement.
+
+## Recording Phase (Indicator Visible)
+
+All shortcuts require **holding the trigger hotkey** (default: `fn`) while pressing the action key.
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| Release trigger | Stop recording | Ends audio capture, transitions to transcription/enhancement |
+| Space | Cancel | Discard recording, return to idle |
+| Cmd | Restart | Discard current recording, start a new one immediately |
+| Z | Preview history | Stop recording, open history preview panel |
+| Left / Up arrow | Previous mode | Switch to the previous AI enhancement mode |
+| Right / Down arrow | Next mode | Switch to the next AI enhancement mode |
+
+> **Note:** When `fn` is the trigger hotkey, macOS converts fn+Arrow into Home/End/PageUp/PageDown. These keys are also recognized as mode navigation shortcuts, so fn+Arrow works as expected.
+
+### Configuration
+
+The cancel, restart, and history keys are configurable in `config.json` under `feedback`:
+
+```json
+{
+  "feedback": {
+    "cancel_key": "space",
+    "restart_key": "cmd",
+    "preview_history_key": "z"
+  }
+}
+```
+
+## Streaming Overlay Phase (Enhancement in Progress)
+
+These keys are captured by the overlay's own CGEventTap and **swallowed** (not passed to the focused application).
+
+| Key | Action | Description |
+|-----|--------|-------------|
+| ESC | Cancel enhancement | Stop the AI enhancement, close overlay, return to idle |
+| Enter | Confirm ASR | Skip enhancement, output the raw transcription text directly (only active in direct mode with background STT) |
+| Left / Up arrow | Previous mode | Switch to the previous AI enhancement mode (handled by main hotkey listener) |
+| Right / Down arrow | Next mode | Switch to the next AI enhancement mode (handled by main hotkey listener) |
+
+## Implementation References
+
+- Trigger hotkey listener: `src/wenzi/hotkey.py` (`MultiHotkeyListener`)
+- Action dispatch: `src/wenzi/controllers/recording_flow.py` (`Action` enum, `_handle_inline_action`)
+- Streaming overlay key tap: `src/wenzi/ui/streaming_overlay.py` (`_key_tap_callback`)

--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -1198,6 +1198,12 @@ class WenZiApp(StatusBarApp):
             shutdown_vault()
         except Exception:
             logger.debug("Vault shutdown failed", exc_info=True)
+        # Shut down the hotkey dispatch executor
+        try:
+            from wenzi.hotkey import shutdown_hotkey_executor
+            shutdown_hotkey_executor()
+        except Exception:
+            logger.debug("Hotkey executor shutdown failed", exc_info=True)
         # Close AI provider clients and shut down the shared asyncio loop
         if self._enhancer:
             try:

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -1,4 +1,4 @@
-"""Floating recording indicator panel with audio level visualization."""
+"""Floating recording indicator panel with audio waveform visualization."""
 
 from __future__ import annotations
 
@@ -8,35 +8,42 @@ import time
 
 logger = logging.getLogger(__name__)
 
-# EMA smoothing factor for audio level updates
-_EMA_ALPHA = 0.3
+# Asymmetric EMA smoothing: fast attack, slower release
+_EMA_ATTACK = 0.6
+_EMA_RELEASE = 0.25
 
 # Panel dimensions
-_PANEL_WIDTH = 120
-_PANEL_WIDTH_WITH_MODE = 220
-_PANEL_HEIGHT = 50
-_PANEL_HEIGHT_WITH_LABEL = 68
+_PANEL_WIDTH = 188
+_PANEL_HEIGHT = 30
+_LABEL_HEIGHT = 14  # height added for subtitle row
 
 # Animation refresh interval in seconds (~20Hz)
 _REFRESH_INTERVAL = 0.05
 
-# Number of audio level bars
-_NUM_BARS = 5
-
-# Bar visual parameters
-_BAR_WIDTH = 6
-_BAR_GAP = 4
-_BAR_MAX_HEIGHT = 30
-_BAR_MIN_HEIGHT = 3
-_BAR_CORNER_RADIUS = 2
+# Waveform visual parameters
+_WAVE_POINTS = 50       # sample points for smooth curve
+_WAVE_WIDTH = 120.0     # horizontal extent
+_WAVE_MAX_AMP = 8.0     # max amplitude from centre line
+_WAVE_LINE_W = 2.0      # primary wave stroke width
+_WAVE_LINE_W2 = 1.5     # secondary wave stroke width
 
 # Pulse dot parameters
-_DOT_BASE_RADIUS = 5.0
-_DOT_PULSE_AMPLITUDE = 1.5
-_DOT_PULSE_SPEED = 3.0
+_DOT_BASE_RADIUS = 3.5
+_DOT_PULSE_AMPLITUDE = 1.2
+_DOT_PULSE_SPEED = 5.0
+_DOT_ALPHA_MIN = 0.65
+_DOT_ALPHA_MAX = 1.0
+
+# Font
+_FONT_WEIGHT_MEDIUM = 0.23  # NSFontWeightMedium
 
 # Background
-_BG_CORNER_RADIUS = 12
+_BG_CORNER_RADIUS = 10
+
+# NSVisualEffectView constants (avoid AppKit import at module level)
+_VFX_MATERIAL_HUD = 13       # NSVisualEffectMaterialHUDWindow
+_VFX_BLENDING_BEHIND = 0     # NSVisualEffectBlendingModeBehindWindow
+_VFX_STATE_ACTIVE = 1        # NSVisualEffectStateActive
 
 
 class RecordingIndicatorView:
@@ -44,28 +51,22 @@ class RecordingIndicatorView:
 
     _view: object = None
 
-    def __init__(self, device_name: str | None = None) -> None:
+    def __init__(self) -> None:
         self._level: float = 0.0
         self._start_time: float = 0.0
         self._view = None
-        self._device_name: str | None = device_name
-        self._label_attrs: dict | None = None  # cached for draw loop
+        self._subtitle_attrs: dict | None = None  # cached for draw loop
+        self._subtitle_ns_str = None  # cached NSString for subtitle
         # Whether the recorder is actually capturing audio
         self._recording_active: bool = False
         # Cached dynamic colors (created once, adapt to light/dark automatically)
-        self._bg_color = None
         self._dot_color = None
         self._dot_color_inactive = None
-        self._bar_color = None
-        self._bar_color_inactive = None
-        # Mode display fields
-        self._mode_name: str | None = None
-        self._mode_nav: tuple = (False, False)  # (can_prev, can_next)
-        self._mode_attrs: dict | None = None  # cached for draw loop
-        self._arrow_attrs: dict | None = None  # cached for draw loop
-        self._mode_ns_str = None  # cached NSString for mode name
-        self._left_arrow_ns_str = None  # cached NSString for ◁
-        self._right_arrow_ns_str = None  # cached NSString for ▷
+        self._wave_color = None
+        self._wave_color_inactive = None
+        self._wave_strokes: dict = {}  # (active, wave_idx) -> cached NSColor
+        # Subtitle text (combined mode + device, built by panel)
+        self._subtitle: str | None = None
 
     def create_view(self, width: int, height: int) -> object:
         """Create and return the NSView instance."""
@@ -73,11 +74,11 @@ class RecordingIndicatorView:
 
         rect = NSMakeRect(0, 0, width, height)
 
-        # Use a block-based approach with a wrapper view
         view = _IndicatorNSView.alloc().initWithFrame_(rect)
         view._indicator = self
         self._view = view
-        self._start_time = time.monotonic()
+        if self._start_time == 0.0:
+            self._start_time = time.monotonic()
         return view
 
     def set_level(self, level: float) -> None:
@@ -98,9 +99,14 @@ class RecordingIndicatorView:
         return NSColor.colorWithName_dynamicProvider_(None, _provider)
 
     def draw(self, rect: object) -> None:
-        """Draw the indicator contents."""
+        """Draw the indicator contents.
+
+        Background is provided by NSVisualEffectView — this method only draws
+        the pulsing dot, waveform, and optional subtitle label.
+        """
         from AppKit import (
             NSBezierPath,
+            NSColor,
             NSFont,
             NSFontAttributeName,
             NSForegroundColorAttributeName,
@@ -111,38 +117,24 @@ class RecordingIndicatorView:
 
         width = rect.size.width
 
-        # When a device label is shown, the animation area is the top
-        # portion and the label sits at the bottom.
-        label_height = (_PANEL_HEIGHT_WITH_LABEL - _PANEL_HEIGHT) if self._device_name else 0
-        anim_center_y = label_height + _PANEL_HEIGHT / 2.0
-
-        # Semi-transparent rounded background (adapts to light/dark mode)
-        if self._bg_color is None:
-            self._bg_color = self._dynamic_color(
-                light_rgba=(0.95, 0.95, 0.95, 0.85),
-                dark_rgba=(0.15, 0.15, 0.15, 0.85),
-            )
-        self._bg_color.setFill()
-        bg_path = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
-            rect, _BG_CORNER_RADIUS, _BG_CORNER_RADIUS
-        )
-        bg_path.fill()
+        # Subtitle sits at the bottom; animation area is above it.
+        sub_height = _LABEL_HEIGHT if self._subtitle else 0
+        anim_center_y = sub_height + _PANEL_HEIGHT / 2.0
 
         elapsed = time.monotonic() - self._start_time
 
-        # Pulsing dot on the left (gray when waiting, red when recording)
-        dot_x = 18.0
+        # ── Pulsing dot (left) ──────────────────────────────────────────
+        dot_x = 15.0
         dot_y = anim_center_y
-        pulse = math.sin(elapsed * _DOT_PULSE_SPEED) * _DOT_PULSE_AMPLITUDE
-        dot_radius = _DOT_BASE_RADIUS + pulse
+        sin_pulse = math.sin(elapsed * _DOT_PULSE_SPEED)
+        dot_radius = _DOT_BASE_RADIUS + sin_pulse * _DOT_PULSE_AMPLITUDE
+        alpha_t = (sin_pulse + 1.0) / 2.0
+        alpha_pulse = _DOT_ALPHA_MIN + (_DOT_ALPHA_MAX - _DOT_ALPHA_MIN) * alpha_t
 
         if self._recording_active:
             if self._dot_color is None:
-                self._dot_color = self._dynamic_color(
-                    light_rgba=(0.85, 0.15, 0.15, 1.0),
-                    dark_rgba=(0.95, 0.25, 0.25, 1.0),
-                )
-            self._dot_color.setFill()
+                self._dot_color = NSColor.systemRedColor()
+            self._dot_color.colorWithAlphaComponent_(alpha_pulse).setFill()
         else:
             if self._dot_color_inactive is None:
                 self._dot_color_inactive = self._dynamic_color(
@@ -150,130 +142,88 @@ class RecordingIndicatorView:
                     dark_rgba=(0.55, 0.55, 0.55, 1.0),
                 )
             self._dot_color_inactive.setFill()
+
         dot_rect = NSMakeRect(
             dot_x - dot_radius, dot_y - dot_radius,
             dot_radius * 2, dot_radius * 2,
         )
-        dot_path = NSBezierPath.bezierPathWithOvalInRect_(dot_rect)
-        dot_path.fill()
+        NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
 
-        # Audio level bars on the right
-        bars_start_x = 38.0
-        bar_y_base = anim_center_y - _BAR_MAX_HEIGHT / 2.0
-
-        if self._recording_active:
-            if self._bar_color is None:
-                self._bar_color = self._dynamic_color(
-                    light_rgba=(0.2, 0.65, 0.2, 0.9),
-                    dark_rgba=(0.4, 0.9, 0.4, 0.9),
-                )
-            self._bar_color.setFill()
-        else:
-            if self._bar_color_inactive is None:
-                self._bar_color_inactive = self._dynamic_color(
-                    light_rgba=(0.55, 0.55, 0.55, 0.9),
-                    dark_rgba=(0.5, 0.5, 0.5, 0.9),
-                )
-            self._bar_color_inactive.setFill()
-
+        # ── Audio waveform (centre-right) ───────────────────────────────
+        wave_cx = 98.0
+        half_w = _WAVE_WIDTH / 2.0
         level = self._level
-        for i in range(_NUM_BARS):
-            # Each bar has a slightly different phase for visual variety
-            phase = i * 0.6
-            wave = (math.sin(elapsed * 5.0 + phase) + 1.0) / 2.0
-            # Base idle animation + level-driven height
-            idle = wave * 0.15
-            bar_factor = idle + level * (0.85 + wave * 0.15)
-            bar_height = max(_BAR_MIN_HEIGHT, bar_factor * _BAR_MAX_HEIGHT)
 
-            bar_x = bars_start_x + i * (_BAR_WIDTH + _BAR_GAP)
-            bar_y = bar_y_base + (_BAR_MAX_HEIGHT - bar_height) / 2.0
+        for wave_idx in range(2):
+            freq = 2.5 + wave_idx * 1.2
+            phase = elapsed * 8.0 + wave_idx * 2.0
 
-            bar_rect = NSMakeRect(bar_x, bar_y, _BAR_WIDTH, bar_height)
-            bar_path = NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
-                bar_rect, _BAR_CORNER_RADIUS, _BAR_CORNER_RADIUS
-            )
-            bar_path.fill()
+            if self._recording_active:
+                level_amp = level * _WAVE_MAX_AMP * (1.0 - wave_idx * 0.3)
+                idle_amp = 1.0 * (1.0 - wave_idx * 0.5)
+            else:
+                level_amp = 0.0
+                idle_amp = 2.0 * (1.0 - wave_idx * 0.5)
 
-        # Device name label at the bottom (single line, truncate tail)
-        if self._device_name:
-            if self._label_attrs is None:
-                label_color = self._dynamic_color(
-                    light_rgba=(0.3, 0.3, 0.3, 0.8),
-                    dark_rgba=(0.7, 0.7, 0.7, 0.8),
-                )
+            breath = 0.5 + 0.5 * math.sin(elapsed * 3.0 + wave_idx)
+            total_amp = level_amp + idle_amp * breath
+
+            path = NSBezierPath.alloc().init()
+            path.setLineWidth_(_WAVE_LINE_W if wave_idx == 0 else _WAVE_LINE_W2)
+            path.setLineCapStyle_(1)   # NSLineCapStyleRound
+            path.setLineJoinStyle_(1)  # NSLineJoinStyleRound
+
+            for i in range(_WAVE_POINTS + 1):
+                t = i / _WAVE_POINTS
+                x = wave_cx - half_w + t * _WAVE_WIDTH
+                envelope = math.sin(t * math.pi)  # taper at edges
+                y = anim_center_y + math.sin(t * freq * math.pi * 2 + phase) * total_amp * envelope
+                if i == 0:
+                    path.moveToPoint_((x, y))
+                else:
+                    path.lineToPoint_((x, y))
+
+            stroke_key = (self._recording_active, wave_idx)
+            stroke = self._wave_strokes.get(stroke_key)
+            if stroke is None:
+                if self._recording_active:
+                    if self._wave_color is None:
+                        self._wave_color = self._dynamic_color(
+                            light_rgba=(0.15, 0.55, 0.95, 1.0),
+                            dark_rgba=(0.35, 0.7, 1.0, 1.0),
+                        )
+                    w_alpha = 0.9 if wave_idx == 0 else 0.35
+                    stroke = self._wave_color.colorWithAlphaComponent_(w_alpha)
+                else:
+                    if self._wave_color_inactive is None:
+                        self._wave_color_inactive = self._dynamic_color(
+                            light_rgba=(0.55, 0.55, 0.55, 0.9),
+                            dark_rgba=(0.5, 0.5, 0.5, 0.9),
+                        )
+                    w_alpha = 0.7 if wave_idx == 0 else 0.25
+                    stroke = self._wave_color_inactive.colorWithAlphaComponent_(w_alpha)
+                self._wave_strokes[stroke_key] = stroke
+            stroke.setStroke()
+
+            path.stroke()
+
+        # ── Subtitle label (bottom) ─────────────────────────────────────
+        if self._subtitle:
+            if self._subtitle_attrs is None:
                 para = NSMutableParagraphStyle.alloc().init()
                 para.setAlignment_(1)  # NSTextAlignmentCenter
                 para.setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
-                self._label_attrs = {
+                self._subtitle_attrs = {
                     NSFontAttributeName: NSFont.systemFontOfSize_(9),
-                    NSForegroundColorAttributeName: label_color,
+                    NSForegroundColorAttributeName: NSColor.secondaryLabelColor(),
                     NSParagraphStyleAttributeName: para,
                 }
-                self._label_ns_str = NSString.stringWithString_(self._device_name)
-            label_rect = NSMakeRect(4, 4, width - 8, label_height)
-            self._label_ns_str.drawInRect_withAttributes_(
-                label_rect, self._label_attrs,
+            if self._subtitle_ns_str is None:
+                self._subtitle_ns_str = NSString.stringWithString_(self._subtitle)
+            label_rect = NSMakeRect(6, 5, width - 12, _LABEL_HEIGHT)
+            self._subtitle_ns_str.drawInRect_withAttributes_(
+                label_rect, self._subtitle_attrs,
             )
-
-        # Mode name with navigation arrows (right of audio bars)
-        if self._mode_name:
-            if self._mode_attrs is None:
-                mode_color = self._dynamic_color(
-                    light_rgba=(0.1, 0.1, 0.1, 0.9),
-                    dark_rgba=(0.9, 0.9, 0.9, 0.9),
-                )
-                mode_para = NSMutableParagraphStyle.alloc().init()
-                mode_para.setAlignment_(1)  # NSTextAlignmentCenter
-                mode_para.setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
-                self._mode_attrs = {
-                    NSFontAttributeName: NSFont.systemFontOfSize_(12),
-                    NSForegroundColorAttributeName: mode_color,
-                    NSParagraphStyleAttributeName: mode_para,
-                }
-                arrow_color = self._dynamic_color(
-                    light_rgba=(0.4, 0.4, 0.4, 0.7),
-                    dark_rgba=(0.6, 0.6, 0.6, 0.7),
-                )
-                arrow_para = NSMutableParagraphStyle.alloc().init()
-                arrow_para.setAlignment_(1)
-                self._arrow_attrs = {
-                    NSFontAttributeName: NSFont.systemFontOfSize_(11),
-                    NSForegroundColorAttributeName: arrow_color,
-                    NSParagraphStyleAttributeName: arrow_para,
-                }
-
-            can_prev, can_next = self._mode_nav
-            mode_x = bars_start_x + _NUM_BARS * (_BAR_WIDTH + _BAR_GAP) + 4
-            mode_area_w = width - mode_x - 6
-
-            # Draw left arrow
-            if can_prev:
-                if self._left_arrow_ns_str is None:
-                    self._left_arrow_ns_str = NSString.stringWithString_("\u25C1")
-                arrow_rect = NSMakeRect(mode_x, anim_center_y - 8, 14, 16)
-                self._left_arrow_ns_str.drawInRect_withAttributes_(
-                    arrow_rect, self._arrow_attrs
-                )
-
-            # Draw mode name (centered in the remaining space)
-            name_x = mode_x + (16 if can_prev else 2)
-            name_w = mode_area_w - (16 if can_prev else 2) - (16 if can_next else 2)
-            if self._mode_ns_str is None:
-                self._mode_ns_str = NSString.stringWithString_(self._mode_name)
-            name_rect = NSMakeRect(name_x, anim_center_y - 9, name_w, 18)
-            self._mode_ns_str.drawInRect_withAttributes_(name_rect, self._mode_attrs)
-
-            # Draw right arrow
-            if can_next:
-                if self._right_arrow_ns_str is None:
-                    self._right_arrow_ns_str = NSString.stringWithString_("\u25B7")
-                arrow_rect = NSMakeRect(
-                    mode_x + mode_area_w - 14, anim_center_y - 8, 14, 16
-                )
-                self._right_arrow_ns_str.drawInRect_withAttributes_(
-                    arrow_rect, self._arrow_attrs
-                )
 
 
 # PyObjC subclass for custom drawing
@@ -299,6 +249,13 @@ except Exception:
     _IndicatorNSView = None
 
 
+def _build_subtitle(mode_name: str | None, device_name: str | None) -> str | None:
+    """Combine mode and device into a single subtitle string."""
+    if mode_name and device_name:
+        return f"{mode_name} · {device_name}"
+    return mode_name or device_name
+
+
 class RecordingIndicatorPanel:
     """Manages a floating panel that shows recording status with audio visualization."""
 
@@ -309,6 +266,9 @@ class RecordingIndicatorPanel:
         self._smoothed_level: float = 0.0
         self._enabled: bool = True
         self._show_device_name: bool = False
+        # Stored values for subtitle rebuilding
+        self._mode_name: str | None = None
+        self._device_name: str | None = None
 
     @property
     def enabled(self) -> bool:
@@ -328,6 +288,28 @@ class RecordingIndicatorPanel:
     def show_device_name(self, value: bool) -> None:
         self._show_device_name = value
 
+    @staticmethod
+    def _make_vfx_view(width: int, height: int):
+        """Create an NSVisualEffectView with frosted-glass HUD appearance."""
+        from AppKit import NSVisualEffectView
+        from Foundation import NSMakeRect
+
+        vfx = NSVisualEffectView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, width, height)
+        )
+        vfx.setMaterial_(_VFX_MATERIAL_HUD)
+        vfx.setBlendingMode_(_VFX_BLENDING_BEHIND)
+        vfx.setState_(_VFX_STATE_ACTIVE)
+        vfx.setWantsLayer_(True)
+        vfx.layer().setCornerRadius_(_BG_CORNER_RADIUS)
+        vfx.layer().setMasksToBounds_(True)
+        return vfx
+
+    def _panel_height(self) -> int:
+        """Compute current panel height based on whether a subtitle is shown."""
+        has_sub = _build_subtitle(self._mode_name, self._device_name) is not None
+        return _PANEL_HEIGHT + (_LABEL_HEIGHT if has_sub else 0)
+
     def show(self, device_name: str | None = None) -> None:
         """Create and show the floating indicator panel."""
         if not self._enabled:
@@ -346,9 +328,12 @@ class RecordingIndicatorPanel:
                 self.hide()
 
             self._smoothed_level = 0.0
-            self._indicator_view = RecordingIndicatorView(device_name=device_name)
+            self._mode_name = None
+            self._device_name = device_name
+            self._indicator_view = RecordingIndicatorView()
+            self._update_subtitle()
 
-            panel_height = _PANEL_HEIGHT_WITH_LABEL if device_name else _PANEL_HEIGHT
+            panel_height = self._panel_height()
 
             # Create borderless panel
             panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
@@ -365,25 +350,28 @@ class RecordingIndicatorPanel:
             panel.setHidesOnDeactivate_(False)
             panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
 
-            # Position at center of main screen
-            screen = NSScreen.mainScreen()
-            if screen:
-                screen_frame = screen.visibleFrame()
-                x = screen_frame.origin.x + (screen_frame.size.width - _PANEL_WIDTH) / 2
-                y = screen_frame.origin.y + (screen_frame.size.height - panel_height) / 2
-                panel.setFrameOrigin_((x, y))
-
-            # Set content view
-            content_view = self._indicator_view.create_view(_PANEL_WIDTH, panel_height)
-            panel.setContentView_(content_view)
-
-            panel.orderFront_(None)
             self._panel = panel
 
-            # Start refresh timer
+            # Position at centre of main screen
+            screen = NSScreen.mainScreen()
+            if screen:
+                sf = screen.visibleFrame()
+                x = sf.origin.x + (sf.size.width - _PANEL_WIDTH) / 2.0
+                y = sf.origin.y + (sf.size.height - panel_height) / 2.0
+                panel.setFrameOrigin_((x, y))
+
+            # Frosted-glass background + indicator drawing view
+            vfx = self._make_vfx_view(_PANEL_WIDTH, panel_height)
+            indicator = self._indicator_view.create_view(_PANEL_WIDTH, panel_height)
+            vfx.addSubview_(indicator)
+            panel.setContentView_(vfx)
+
+            panel.orderFront_(None)
+
+            # Start refresh timer targeting the indicator subview
             self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
                 _REFRESH_INTERVAL,
-                content_view,
+                indicator,
                 b"refresh:",
                 None,
                 True,
@@ -428,101 +416,112 @@ class RecordingIndicatorPanel:
 
             self._indicator_view = None
             self._smoothed_level = 0.0
+            self._mode_name = None
+            self._device_name = None
             logger.debug("Recording indicator hidden")
         except Exception as e:
             logger.warning("Failed to hide recording indicator: %s", e)
 
-    def _rebuild_content_view(self, new_width: int, new_height: int) -> None:
-        """Resize the panel, recreate the content view, re-center, and restart the timer.
+    def _update_subtitle(self) -> None:
+        """Rebuild subtitle text on the indicator view from mode + device."""
+        if self._indicator_view is None:
+            return
+        new_sub = _build_subtitle(self._mode_name, self._device_name)
+        if self._indicator_view._subtitle == new_sub:
+            return
+        self._indicator_view._subtitle = new_sub
+        self._indicator_view._subtitle_ns_str = None
+        self._indicator_view._subtitle_attrs = None
 
-        Shared helper for update_mode() and update_device_name().
-        """
-        from AppKit import NSScreen
+    def _rebuild_panel(self) -> None:
+        """Resize the panel, recreate content views, reposition, and restart timer."""
+        if self._panel is None or self._indicator_view is None:
+            return
+
         from Foundation import NSTimer
 
         self._clear_view_backref()
-        content_view = self._indicator_view.create_view(new_width, new_height)
-        self._panel.setContentSize_((float(new_width), float(new_height)))
-        self._panel.setContentView_(content_view)
 
-        # Re-center on screen
+        new_height = self._panel_height()
+        vfx = self._make_vfx_view(_PANEL_WIDTH, new_height)
+        indicator = self._indicator_view.create_view(_PANEL_WIDTH, new_height)
+        vfx.addSubview_(indicator)
+
+        self._panel.setContentSize_((float(_PANEL_WIDTH), float(new_height)))
+        self._panel.setContentView_(vfx)
+
+        # Re-centre on screen
+        from AppKit import NSScreen
+
         screen = NSScreen.mainScreen()
         if screen:
             sf = screen.visibleFrame()
-            x = sf.origin.x + (sf.size.width - new_width) / 2
-            y = sf.origin.y + (sf.size.height - new_height) / 2
+            x = sf.origin.x + (sf.size.width - _PANEL_WIDTH) / 2.0
+            y = sf.origin.y + (sf.size.height - new_height) / 2.0
             self._panel.setFrameOrigin_((x, y))
 
-        # Restart refresh timer with new content view
+        # Restart refresh timer with new indicator view
         if self._timer is not None:
             self._timer.invalidate()
         self._timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
             _REFRESH_INTERVAL,
-            content_view,
+            indicator,
             b"refresh:",
             None,
             True,
         )
 
-    def update_mode(self, name: str, can_prev: bool, can_next: bool) -> None:
-        """Update the mode label and nav arrow state on the indicator.
-
-        Widens the panel to _PANEL_WIDTH_WITH_MODE if not already wide.
-        """
+    def update_mode(self, name: str) -> None:
+        """Update the mode label shown in the subtitle."""
         if self._indicator_view is None:
             return
+        if self._mode_name == name:
+            return
 
-        view = self._indicator_view
-        nav = (can_prev, can_next)
-        if view._mode_name == name and view._mode_nav == nav:
-            return  # nothing changed
+        self._mode_name = name
+        old_sub = self._indicator_view._subtitle
+        self._update_subtitle()
+        new_sub = self._indicator_view._subtitle
 
-        # Invalidate cached NSString when mode name changes
-        if view._mode_name != name:
-            view._mode_ns_str = None
-        view._mode_name = name
-        view._mode_nav = nav
-
-        if self._panel is not None:
+        # Resize panel if subtitle appeared/disappeared
+        if (old_sub is None) != (new_sub is None) and self._panel is not None:
             try:
-                current_width = self._panel.frame().size.width
-                if current_width < _PANEL_WIDTH_WITH_MODE:
-                    current_height = int(self._panel.frame().size.height)
-                    self._rebuild_content_view(
-                        _PANEL_WIDTH_WITH_MODE, current_height
-                    )
+                self._rebuild_panel()
             except Exception:
-                logger.debug("Failed to resize panel for mode display", exc_info=True)
+                logger.debug("Failed to resize panel for subtitle", exc_info=True)
 
     def clear_mode(self) -> None:
-        """Remove the mode label and shrink back to default width."""
+        """Remove the mode label from the subtitle."""
+        if self._mode_name is None:
+            return
+        self._mode_name = None
         if self._indicator_view is not None:
-            self._indicator_view._mode_name = None
-            self._indicator_view._mode_nav = (False, False)
-            self._indicator_view._mode_ns_str = None
+            old_sub = self._indicator_view._subtitle
+            self._update_subtitle()
+            new_sub = self._indicator_view._subtitle
+            if (old_sub is None) != (new_sub is None) and self._panel is not None:
+                try:
+                    self._rebuild_panel()
+                except Exception:
+                    logger.debug("Failed to resize panel after clear_mode", exc_info=True)
 
     def update_device_name(self, device_name: str) -> None:
-        """Update the device name label after the panel is already shown.
-
-        Resizes the panel from _PANEL_HEIGHT to _PANEL_HEIGHT_WITH_LABEL
-        and recreates the content view so the label area is included.
-        """
+        """Update the device name shown in the subtitle."""
         if self._panel is None or self._indicator_view is None:
             return
-        if self._indicator_view._device_name == device_name:
+        if self._device_name == device_name:
             return
 
-        try:
-            self._indicator_view._device_name = device_name
-            # Reset cached label attrs so they are rebuilt on next draw
-            self._indicator_view._label_attrs = None
+        self._device_name = device_name
+        old_sub = self._indicator_view._subtitle
+        self._update_subtitle()
+        new_sub = self._indicator_view._subtitle
 
-            current_width = int(self._panel.frame().size.width)
-            self._rebuild_content_view(current_width, _PANEL_HEIGHT_WITH_LABEL)
-
-            logger.debug("Recording indicator updated with device: %s", device_name)
-        except Exception:
-            logger.debug("Failed to update recording indicator device name", exc_info=True)
+        if (old_sub is None) != (new_sub is None):
+            try:
+                self._rebuild_panel()
+            except Exception:
+                logger.debug("Failed to resize panel for subtitle", exc_info=True)
 
     @property
     def current_frame(self) -> object | None:
@@ -558,6 +557,8 @@ class RecordingIndicatorPanel:
                 self._panel = None
                 self._indicator_view = None
                 self._smoothed_level = 0.0
+                self._mode_name = None
+                self._device_name = None
                 logger.debug("Recording indicator animated out")
                 if completion:
                     completion()
@@ -575,9 +576,14 @@ class RecordingIndicatorPanel:
                 completion()
 
     def update_level(self, level: float) -> None:
-        """Update the displayed audio level with EMA smoothing."""
+        """Update the displayed audio level with asymmetric EMA smoothing.
+
+        Uses a faster attack (rising) and slower release (falling) for snappy
+        response without jitter.
+        """
+        alpha = _EMA_ATTACK if level > self._smoothed_level else _EMA_RELEASE
         self._smoothed_level = (
-            _EMA_ALPHA * level + (1 - _EMA_ALPHA) * self._smoothed_level
+            alpha * level + (1 - alpha) * self._smoothed_level
         )
         if self._indicator_view is not None:
             self._indicator_view.set_level(self._smoothed_level)

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -22,7 +22,7 @@ _REFRESH_INTERVAL = 0.05
 
 # Waveform visual parameters
 _WAVE_POINTS = 50       # sample points for smooth curve
-_WAVE_WIDTH = 120.0     # horizontal extent
+_WAVE_WIDTH = 150.0     # horizontal extent
 _WAVE_MAX_AMP = 8.0     # max amplitude from centre line
 _WAVE_LINE_W = 2.0      # primary wave stroke width
 _WAVE_LINE_W2 = 1.5     # secondary wave stroke width
@@ -150,7 +150,7 @@ class RecordingIndicatorView:
         NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
 
         # ── Audio waveform (centre-right) ───────────────────────────────
-        wave_cx = 98.0
+        wave_cx = 103.0
         half_w = _WAVE_WIDTH / 2.0
         level = self._level
 
@@ -214,13 +214,13 @@ class RecordingIndicatorView:
                 para.setAlignment_(1)  # NSTextAlignmentCenter
                 para.setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
                 self._subtitle_attrs = {
-                    NSFontAttributeName: NSFont.systemFontOfSize_(9),
-                    NSForegroundColorAttributeName: NSColor.secondaryLabelColor(),
+                    NSFontAttributeName: NSFont.systemFontOfSize_weight_(9, _FONT_WEIGHT_MEDIUM),
+                    NSForegroundColorAttributeName: NSColor.labelColor(),
                     NSParagraphStyleAttributeName: para,
                 }
             if self._subtitle_ns_str is None:
                 self._subtitle_ns_str = NSString.stringWithString_(self._subtitle)
-            label_rect = NSMakeRect(6, 5, width - 12, _LABEL_HEIGHT)
+            label_rect = NSMakeRect(28, 5, 150, _LABEL_HEIGHT)
             self._subtitle_ns_str.drawInRect_withAttributes_(
                 label_rect, self._subtitle_attrs,
             )

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -27,12 +27,8 @@ _WAVE_MAX_AMP = 8.0     # max amplitude from centre line
 _WAVE_LINE_W = 2.0      # primary wave stroke width
 _WAVE_LINE_W2 = 1.5     # secondary wave stroke width
 
-# Pulse dot parameters
-_DOT_BASE_RADIUS = 3.5
-_DOT_PULSE_AMPLITUDE = 1.2
-_DOT_PULSE_SPEED = 5.0
-_DOT_ALPHA_MIN = 0.65
-_DOT_ALPHA_MAX = 1.0
+# Status dot parameters
+_DOT_RADIUS = 4.5
 
 # Font
 _FONT_WEIGHT_MEDIUM = 0.23  # NSFontWeightMedium
@@ -115,26 +111,20 @@ class RecordingIndicatorView:
         )
         from Foundation import NSMakeRect, NSString
 
-        width = rect.size.width
-
         # Subtitle sits at the bottom; animation area is above it.
         sub_height = _LABEL_HEIGHT if self._subtitle else 0
         anim_center_y = sub_height + _PANEL_HEIGHT / 2.0
 
         elapsed = time.monotonic() - self._start_time
 
-        # ── Pulsing dot (left) ──────────────────────────────────────────
+        # ── Status dot (left) — red when recording, grey when waiting ───
         dot_x = 15.0
         dot_y = anim_center_y
-        sin_pulse = math.sin(elapsed * _DOT_PULSE_SPEED)
-        dot_radius = _DOT_BASE_RADIUS + sin_pulse * _DOT_PULSE_AMPLITUDE
-        alpha_t = (sin_pulse + 1.0) / 2.0
-        alpha_pulse = _DOT_ALPHA_MIN + (_DOT_ALPHA_MAX - _DOT_ALPHA_MIN) * alpha_t
 
         if self._recording_active:
             if self._dot_color is None:
                 self._dot_color = NSColor.systemRedColor()
-            self._dot_color.colorWithAlphaComponent_(alpha_pulse).setFill()
+            self._dot_color.setFill()
         else:
             if self._dot_color_inactive is None:
                 self._dot_color_inactive = self._dynamic_color(
@@ -144,8 +134,8 @@ class RecordingIndicatorView:
             self._dot_color_inactive.setFill()
 
         dot_rect = NSMakeRect(
-            dot_x - dot_radius, dot_y - dot_radius,
-            dot_radius * 2, dot_radius * 2,
+            dot_x - _DOT_RADIUS, dot_y - _DOT_RADIUS,
+            _DOT_RADIUS * 2, _DOT_RADIUS * 2,
         )
         NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
 
@@ -404,6 +394,8 @@ class RecordingIndicatorPanel:
     def hide(self) -> None:
         """Hide and clean up the indicator panel."""
         try:
+            from wenzi.ui_helpers import release_panel_surfaces
+
             if self._timer is not None:
                 self._timer.invalidate()
                 self._timer = None
@@ -411,6 +403,7 @@ class RecordingIndicatorPanel:
             self._clear_view_backref()
 
             if self._panel is not None:
+                release_panel_surfaces(self._panel)
                 self._panel.orderOut_(None)
                 self._panel = None
 
@@ -552,6 +545,9 @@ class RecordingIndicatorPanel:
             panel = self._panel
 
             def _on_complete():
+                from wenzi.ui_helpers import release_panel_surfaces
+
+                release_panel_surfaces(panel)
                 panel.orderOut_(None)
                 self._clear_view_backref()
                 self._panel = None

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -13,28 +13,28 @@ _EMA_ATTACK = 0.6
 _EMA_RELEASE = 0.25
 
 # Panel dimensions
-_PANEL_WIDTH = 188
-_PANEL_HEIGHT = 30
-_LABEL_HEIGHT = 14  # height added for subtitle row
+_PANEL_WIDTH = 226
+_PANEL_HEIGHT = 36
+_LABEL_HEIGHT = 17  # height added for subtitle row
 
 # Animation refresh interval in seconds (~20Hz)
 _REFRESH_INTERVAL = 0.05
 
 # Waveform visual parameters
 _WAVE_POINTS = 50       # sample points for smooth curve
-_WAVE_WIDTH = 150.0     # horizontal extent
-_WAVE_MAX_AMP = 8.0     # max amplitude from centre line
-_WAVE_LINE_W = 2.0      # primary wave stroke width
-_WAVE_LINE_W2 = 1.5     # secondary wave stroke width
+_WAVE_WIDTH = 180.0     # horizontal extent
+_WAVE_MAX_AMP = 9.6     # max amplitude from centre line
+_WAVE_LINE_W = 2.4      # primary wave stroke width
+_WAVE_LINE_W2 = 1.8     # secondary wave stroke width
 
 # Status dot parameters
-_DOT_RADIUS = 4.5
+_DOT_RADIUS = 5.4
 
 # Font
 _FONT_WEIGHT_MEDIUM = 0.23  # NSFontWeightMedium
 
 # Background
-_BG_CORNER_RADIUS = 10
+_BG_CORNER_RADIUS = 12
 
 # NSVisualEffectView constants (avoid AppKit import at module level)
 _VFX_MATERIAL_HUD = 13       # NSVisualEffectMaterialHUDWindow
@@ -118,7 +118,7 @@ class RecordingIndicatorView:
         elapsed = time.monotonic() - self._start_time
 
         # ── Status dot (left) — red when recording, grey when waiting ───
-        dot_x = 15.0
+        dot_x = 18.0
         dot_y = anim_center_y
 
         if self._recording_active:
@@ -140,7 +140,7 @@ class RecordingIndicatorView:
         NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
 
         # ── Audio waveform (centre-right) ───────────────────────────────
-        wave_cx = 103.0
+        wave_cx = 123.6
         half_w = _WAVE_WIDTH / 2.0
         level = self._level
 
@@ -204,13 +204,13 @@ class RecordingIndicatorView:
                 para.setAlignment_(1)  # NSTextAlignmentCenter
                 para.setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
                 self._subtitle_attrs = {
-                    NSFontAttributeName: NSFont.systemFontOfSize_weight_(9, _FONT_WEIGHT_MEDIUM),
+                    NSFontAttributeName: NSFont.systemFontOfSize_weight_(10.8, _FONT_WEIGHT_MEDIUM),
                     NSForegroundColorAttributeName: NSColor.labelColor(),
                     NSParagraphStyleAttributeName: para,
                 }
             if self._subtitle_ns_str is None:
                 self._subtitle_ns_str = NSString.stringWithString_(self._subtitle)
-            label_rect = NSMakeRect(28, 5, 150, _LABEL_HEIGHT)
+            label_rect = NSMakeRect(33.6, 6, 180, _LABEL_HEIGHT)
             self._subtitle_ns_str.drawInRect_withAttributes_(
                 label_rect, self._subtitle_attrs,
             )

--- a/src/wenzi/config.py
+++ b/src/wenzi/config.py
@@ -301,7 +301,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
             },
         },
         "thinking": False,
-        "timeout": 30,
+        "timeout": 10,
         "connection_timeout": 10,
         "max_retries": 2,
         "vocabulary": {

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -22,6 +22,7 @@ from wenzi.config import save_config
 from wenzi.controllers import fire_scripting_event
 from wenzi.input import type_text
 from wenzi.input_context import capture_input_context
+from wenzi.ui_helpers import get_frontmost_app, reactivate_app
 
 if TYPE_CHECKING:
     from wenzi.app import WenZiApp
@@ -87,6 +88,7 @@ class RecordingFlow:
         self._saved_mode: tuple | None = None
         self._no_preview_override = False
         self._input_context = None
+        self._target_app = None  # NSRunningApplication to reactivate before typing
         # Sub-tasks managed within a session
         self._level_task: asyncio.Task | None = None
         self._live_overlay = None
@@ -170,14 +172,19 @@ class RecordingFlow:
             AppHelper.callAfter(self._try_enable_voice_input)
             return
 
-        # Capture input context while the user's target app is still frontmost
+        # Capture the frontmost app before any potentially slow AX context
+        # lookup so we can reactivate the original target window later.
         ic_level = (
             app._enhancer.input_context_level
             if app._enhancer
             else app._config.get("ai_enhance", {}).get("input_context", "basic")
         )
-        self._input_context = await self._loop.run_in_executor(
-            None, lambda: capture_input_context(ic_level)
+        self._target_app, self._input_context = await self._loop.run_in_executor(
+            None,
+            lambda: (
+                get_frontmost_app(),
+                capture_input_context(ic_level),
+            ),
         )
 
         # Restore previous override before applying a new one
@@ -753,6 +760,12 @@ class RecordingFlow:
             "output_text", final_text=text
         )
 
+        # Reactivate the app that was frontmost when the hotkey was pressed,
+        # in case the user switched windows during AI enhancement.
+        if self._target_app is not None:
+            AppHelper.callAfter(reactivate_app, self._target_app)
+            await asyncio.sleep(0.15)
+
         AppHelper.callAfter(
             type_text,
             text,
@@ -769,6 +782,8 @@ class RecordingFlow:
             app._usage_stats.record_output_method(copy_to_clipboard=False)
         except Exception as e:
             logger.error("Failed to record output method: %s", e)
+
+        self._target_app = None
 
         try:
             app._conversation_history.log(
@@ -813,6 +828,33 @@ class RecordingFlow:
                 lambda: self.send_action(Action.CONFIRM_ASR)
             ) if with_confirm_asr else None,
         )
+
+    @staticmethod
+    def _show_error_alert(message: str, duration: float = 3.0) -> None:
+        """Show a lightweight floating alert for errors."""
+        try:
+            from wenzi.scripting.api.alert import alert
+            alert(message, duration=duration)
+        except Exception:
+            logger.debug("Error alert failed", exc_info=True)
+
+    def _apply_timeout_fallback(
+        self, app, chunk: str, step_idx: int = 0, total_steps: int = 0,
+    ) -> tuple[list[str], int]:
+        """Update overlay with fallback text on AI timeout."""
+        completion_tokens = len(chunk)
+        app._streaming_overlay.clear_text()
+        app._streaming_overlay.append_text(chunk, completion_tokens=completion_tokens)
+        if total_steps > 0:
+            msg = (
+                f"\u26a0\ufe0f Step {step_idx}/{total_steps}: "
+                "AI timed out, using original text"
+            )
+        else:
+            msg = "\u26a0\ufe0f AI timed out, using original text"
+        app._streaming_overlay.set_status(msg)
+        self._show_error_alert("AI enhancement timed out")
+        return [chunk], completion_tokens
 
     # ------------------------------------------------------------------
     # Background STT for direct flow
@@ -913,6 +955,12 @@ class RecordingFlow:
                 app._streaming_overlay.append_thinking_text(chunk)
                 label = chunk.strip().strip("()\n")
                 app._streaming_overlay.set_status(f"\u23f3 {label}")
+            elif is_thinking == "timeout" and chunk:
+                had_thinking = False
+                collected, completion_tokens = self._apply_timeout_fallback(
+                    app, chunk,
+                )
+                break
             elif is_thinking and chunk:
                 had_thinking = True
                 thinking_tokens += len(chunk)
@@ -966,6 +1014,7 @@ class RecordingFlow:
                 app._streaming_overlay.set_status(
                     f"\u23f3 Step {step_idx}/{total_steps}: {step_label}"
                 )
+                app._streaming_overlay.set_progress(step_idx, total_steps)
 
                 if step_idx > 1:
                     app._streaming_overlay.clear_text()
@@ -989,6 +1038,11 @@ class RecordingFlow:
                         app._streaming_overlay.set_status(
                             f"\u23f3 Step {step_idx}/{total_steps}: {label}"
                         )
+                    elif is_thinking == "timeout" and chunk:
+                        collected, completion_tokens = self._apply_timeout_fallback(
+                            app, chunk, step_idx, total_steps,
+                        )
+                        break
                     elif is_thinking and chunk:
                         thinking_tokens += len(chunk)
                         app._streaming_overlay.append_thinking_text(
@@ -1134,6 +1188,7 @@ class RecordingFlow:
     def _reset_to_idle(self) -> None:
         """Common cleanup: hide overlays/indicator and restore idle status."""
         self._app._busy = False
+        self._target_app = None
         self._hide_live_overlay()
         self._cancel_level_task()
         self._app._recording_indicator.hide()

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -1246,11 +1246,9 @@ class RecordingFlow:
             self._switch_active_mode(new_mode)
 
         label = modes[new_idx][1]
-        can_prev = new_idx > 0
-        can_next = new_idx < len(modes) - 1
         AppHelper.callAfter(
             self._app._recording_indicator.update_mode,
-            label, can_prev, can_next,
+            label,
         )
         logger.info(
             "Mode nav %s → %s", "prev" if delta < 0 else "next", new_mode
@@ -1271,11 +1269,9 @@ class RecordingFlow:
         if idx < 0:
             return
         label = modes[idx][1]
-        can_prev = idx > 0
-        can_next = idx < len(modes) - 1
         AppHelper.callAfter(
             self._app._recording_indicator.update_mode,
-            label, can_prev, can_next,
+            label,
         )
 
     # ------------------------------------------------------------------

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -801,9 +801,11 @@ class RecordingFlow:
         Must be called on the main thread (via AppHelper.callAfter).
         """
         app = self._app
+        indicator_frame = app._recording_indicator.current_frame
         app._recording_indicator.hide()
         app._streaming_overlay.show(
             asr_text=asr_text,
+            animate_from_frame=indicator_frame,
             stt_info=stt_info,
             llm_info=llm_info,
             on_cancel=lambda: self.send_action(Action.CANCEL),

--- a/src/wenzi/controllers/update_controller.py
+++ b/src/wenzi/controllers/update_controller.py
@@ -7,7 +7,6 @@ import json
 import logging
 import os
 import sys
-import threading
 import urllib.request
 import webbrowser
 from typing import TYPE_CHECKING, Any
@@ -16,7 +15,7 @@ if TYPE_CHECKING:
     from wenzi.app import WenZiApp
     from wenzi.updater import AppUpdater
 
-from wenzi import get_version
+from wenzi import async_loop, get_version
 from wenzi.i18n import t
 from wenzi.statusbar import StatusMenuItem
 
@@ -116,8 +115,7 @@ class UpdateController:
         self._enabled = cfg.get("enabled", True)
         interval_hours = cfg.get("interval_hours", self._DEFAULT_INTERVAL_HOURS)
         self._interval = max(interval_hours, 1) * 3600
-        self._timer: threading.Timer | None = None
-        self._lock = threading.Lock()
+        self._timer: async_loop.TimerHandle | None = None
         self._update_menu_item: StatusMenuItem | None = None
         self._latest_version: str | None = None
         self._release_url: str | None = None
@@ -136,7 +134,7 @@ class UpdateController:
         if _is_frozen():
             if self._try_apply_staged_update():
                 return  # app is quitting to apply the update
-        threading.Thread(target=self._check_update, daemon=True).start()
+        async_loop.get_loop().run_in_executor(None, self._check_update)
 
     def _try_apply_staged_update(self) -> bool:
         """Check for a staged update and apply it if valid.
@@ -200,24 +198,30 @@ class UpdateController:
 
     def stop(self) -> None:
         """Cancel any pending timer and running updater."""
-        with self._lock:
-            if self._timer is not None:
-                self._timer.cancel()
-                self._timer = None
+        if self._timer is not None:
+            self._timer.cancel()
+            self._timer = None
         if self._updater is not None:
             self._updater.cancel()
 
     def _schedule_next_check(self) -> None:
         """Schedule the next update check after the configured interval."""
-        with self._lock:
-            if self._timer is not None:
-                self._timer.cancel()
-            self._timer = threading.Timer(self._interval, self._check_update)
-            self._timer.daemon = True
-            self._timer.start()
+        if self._timer is not None:
+            self._timer.cancel()
+        self._timer = async_loop.call_later(
+            self._interval, self._dispatch_check,
+        )
+
+    def _dispatch_check(self) -> None:
+        """Submit the blocking update check to the asyncio default executor.
+
+        Called on the asyncio event loop by ``call_later``; the actual
+        HTTP request runs in the thread-pool executor to avoid blocking.
+        """
+        async_loop.get_loop().run_in_executor(None, self._check_update)
 
     def _check_update(self) -> None:
-        """Perform the update check (runs in a background thread)."""
+        """Perform the update check (runs in the asyncio thread-pool executor)."""
         try:
             current = get_version()
             if current == "dev":

--- a/src/wenzi/enhance/enhancer.py
+++ b/src/wenzi/enhance/enhancer.py
@@ -216,8 +216,8 @@ class TextEnhancer:
         manual_vocab_store: ManualVocabularyStore | None = None,
     ) -> None:
         self._enabled = config.get("enabled", False)
-        self._timeout = config.get("timeout", 30)
-        self._connection_timeout = config.get("connection_timeout", 30)
+        self._timeout = config.get("timeout", 10)
+        self._connection_timeout = config.get("connection_timeout", 10)
         self._max_retries = config.get("max_retries", 2)
         self._max_output_tokens = config.get("max_output_tokens", 4096)
         self._thinking = config.get("thinking", False)
@@ -1021,7 +1021,7 @@ class TextEnhancer:
 
     async def enhance_stream(
         self, text: str, input_context: InputContext | None = None,
-    ) -> AsyncIterator[tuple[str, dict[str, int] | None, bool]]:
+    ) -> AsyncIterator[tuple[str, dict[str, int] | None, bool | str]]:
         """Stream-enhance text using LLM.
 
         Yields (chunk, None, is_thinking) for each text delta, then a final
@@ -1102,6 +1102,7 @@ class TextEnhancer:
                             None,
                             "retry",
                         )
+                        yield text, None, "timeout"
                         return
 
             collected = []
@@ -1181,7 +1182,7 @@ class TextEnhancer:
         except TimeoutError:
             self._pool_monitor.log_stats("stream:timeout", self._active_provider)
             logger.error("AI stream enhancement timed out after %ds", self._timeout)
-            yield text, None, False
+            yield text, None, "timeout"
         except Exception as e:
             if isinstance(e, RateLimitError):
                 self._pool_monitor.log_stats("stream:rate_limited", self._active_provider)

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -11,10 +11,33 @@ from __future__ import annotations
 import logging
 import threading
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 
 from wenzi.async_loop import TimerHandle, call_later
 
 logger = logging.getLogger(__name__)
+
+# Shared single-thread executor for dispatching hotkey callbacks off the
+# CGEventTap thread.  Reuses one thread instead of spawning a new one per
+# keypress.  max_workers=1 is safe because the callbacks are lightweight
+# async dispatchers (submit to asyncio loop / put_nowait to queue).
+_hotkey_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="hotkey")
+
+
+def shutdown_hotkey_executor() -> None:
+    """Shut down the shared hotkey executor (call during app quit)."""
+    _hotkey_executor.shutdown(wait=False)
+
+
+def _submit_callback(fn: Callable, *args) -> None:
+    """Submit a callback to the shared hotkey executor with error logging."""
+    def _safe():
+        try:
+            fn(*args)
+        except Exception as e:
+            logger.error("Hotkey callback error (%s): %s", fn.__name__, e)
+    _hotkey_executor.submit(_safe)
+
 
 # --- Virtual keycode mappings ---
 
@@ -327,12 +350,6 @@ class TapHotkeyListener:
         self._mod_flags, self._keycode = _parse_hotkey_for_quartz(hotkey_str)
         self._runner = None  # CGEventTapRunner | None
 
-    def _run_activate(self):
-        try:
-            self._on_activate()
-        except Exception as e:
-            logger.error("on_activate callback error: %s", e)
-
     def _callback(self, proxy, event_type, event, refcon):
         from wenzi import _cgeventtap as cg
 
@@ -353,9 +370,7 @@ class TapHotkeyListener:
 
             if keycode == self._keycode and flags == self._mod_flags:
                 logger.debug("TapHotkeyListener matched: %s", self._hotkey_str)
-                threading.Thread(
-                    target=self._run_activate, daemon=True,
-                ).start()
+                _submit_callback(self._on_activate)
                 return None  # Swallow the event
 
             return event
@@ -769,15 +784,10 @@ class MultiHotkeyListener:
                     return False
 
             if action == "press":
-                # Dispatch to a background thread so heavy work
-                # (e.g. Recorder.start with PortAudio re-init) cannot
-                # block the CGEventTap callback and cause a timeout.
-                def _run_press(n=name):
-                    try:
-                        self._on_press(n)
-                    except Exception as e:
-                        logger.error("on_press callback error: %s", e)
-                threading.Thread(target=_run_press, daemon=True).start()
+                # Dispatch off the CGEventTap thread to avoid a tap
+                # timeout (macOS disables the tap if the callback blocks
+                # for too long).
+                _submit_callback(self._on_press, name)
                 # Swallow non-modifier trigger keys to prevent input
                 # reaching the focused app (e.g. numpad keys).
                 if self._has_non_modifier_trigger:
@@ -785,55 +795,25 @@ class MultiHotkeyListener:
                     if not _is_modifier_like_vk(vk):
                         return True
             elif action == "restart":
-                # Dispatch to background thread (same rationale as press)
-                def _run_restart():
-                    try:
-                        self._on_restart()
-                    except Exception as e:
-                        logger.error("on_restart callback error: %s", e)
-                threading.Thread(target=_run_restart, daemon=True).start()
+                _submit_callback(self._on_restart)
                 return True  # swallow the restart key event
             elif action == "cancel":
                 self._cancel_requested = True
-                threading.Thread(
-                    target=self._run_cancel, daemon=True
-                ).start()
+                _submit_callback(self._on_cancel)
                 return True  # swallow the cancel key event
             elif action == "preview_history":
                 self._cancel_requested = True
-                threading.Thread(
-                    target=self._run_preview_history, daemon=True
-                ).start()
+                _submit_callback(self._on_preview_history)
                 return True  # swallow the key event
             elif action == "mode_prev":
-                try:
-                    self._on_mode_prev()
-                except Exception as e:
-                    logger.error("on_mode_prev callback error: %s", e)
+                _submit_callback(self._on_mode_prev)
                 return True  # swallow the arrow key event
             elif action == "mode_next":
-                try:
-                    self._on_mode_next()
-                except Exception as e:
-                    logger.error("on_mode_next callback error: %s", e)
+                _submit_callback(self._on_mode_next)
                 return True  # swallow the arrow key event
         except Exception:
             logger.warning("_handle_press exception", exc_info=True)
         return False
-
-    def _run_cancel(self) -> None:
-        """Run on_cancel callback in a background thread."""
-        try:
-            self._on_cancel()
-        except Exception as e:
-            logger.error("on_cancel callback error: %s", e)
-
-    def _run_preview_history(self) -> None:
-        """Run on_preview_history callback in a background thread."""
-        try:
-            self._on_preview_history()
-        except Exception as e:
-            logger.error("on_preview_history callback error: %s", e)
 
     def _handle_release(self, name: str) -> None:
         try:

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -36,6 +36,7 @@ _SPECIAL_VK = {
     "fn": 63, "esc": 53, "space": 49,
     "return": 36, "delete": 51, "tab": 48,
     "up": 126, "down": 125, "left": 123, "right": 124,
+    "home": 115, "end": 119, "pageup": 116, "pagedown": 121,
     "printscreen": 105,  # PC keyboards map PrintScreen to F13
     # Keypad (kp = keypad, distinguishes from main keyboard keys)
     "kp0": 82, "kp1": 83, "kp2": 84, "kp3": 85,
@@ -755,13 +756,13 @@ class MultiHotkeyListener:
                 elif (
                     self._on_mode_prev
                     and self._held
-                    and name in ("left", "up")
+                    and name in ("left", "up", "home", "pageup")
                 ):
                     action = "mode_prev"
                 elif (
                     self._on_mode_next
                     and self._held
-                    and name in ("right", "down")
+                    and name in ("right", "down", "end", "pagedown")
                 ):
                     action = "mode_next"
                 else:

--- a/src/wenzi/input.py
+++ b/src/wenzi/input.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import logging
 import subprocess
-import threading
 import time
 
 import objc
 from AppKit import NSPasteboard, NSPasteboardTypeString, NSString
+
+from wenzi import async_loop
 
 logger = logging.getLogger(__name__)
 
@@ -169,15 +170,9 @@ def _get_text_via_cmd_c() -> str | None:
     if new_clip == old_clip:
         return None  # Cmd+C didn't change clipboard — no selection
 
-    # Restore original clipboard in background
+    # Restore original clipboard after a short delay
     if old_clip is not None:
-        def _restore():
-            time.sleep(0.5)
-            try:
-                _set_pasteboard_concealed(old_clip)
-            except Exception:
-                pass
-        threading.Thread(target=_restore, daemon=True).start()
+        async_loop.call_later(0.5, _restore_clipboard_safe, old_clip)
 
     return new_clip
 
@@ -278,6 +273,14 @@ def _set_pasteboard_concealed(text: str) -> bool:
         return True
 
 
+def _restore_clipboard_safe(text: str) -> None:
+    """Restore clipboard content, silently ignoring errors."""
+    try:
+        _set_pasteboard_concealed(text)
+    except Exception:
+        pass
+
+
 def _set_pasteboard_string(text: str) -> None:
     """Write *text* to the pasteboard without concealed markers (for restore)."""
     pb = NSPasteboard.generalPasteboard()
@@ -315,15 +318,9 @@ def _type_via_clipboard(payload: str) -> bool:
         return False
     finally:
         if old_clip is not None:
-            def _restore():
-                time.sleep(1.0)
-                try:
-                    # Use concealed markers so clipboard monitors skip
-                    # this restore and don't record a ghost entry.
-                    _set_pasteboard_concealed(old_clip)
-                except Exception:
-                    pass
-            threading.Thread(target=_restore, daemon=True).start()
+            # Restore original clipboard after a delay; concealed markers
+            # ensure clipboard monitors skip this restore.
+            async_loop.call_later(1.0, _restore_clipboard_safe, old_clip)
 
 
 def _type_via_applescript(payload: str) -> bool:

--- a/src/wenzi/scripting/api/alert.py
+++ b/src/wenzi/scripting/api/alert.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 
 from wenzi.async_loop import call_later
+from wenzi.ui_helpers import release_panel_surfaces
 
 logger = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ def _show_alert(text: str, duration: float) -> None:
 
     # Close existing alert immediately (no fade)
     if _current_panel is not None:
+        release_panel_surfaces(_current_panel)
         _current_panel.orderOut_(None)
         _current_panel = None
     if _current_close_timer is not None:
@@ -161,6 +163,7 @@ def _dismiss_alert(panel) -> None:
 
     if _current_panel is not panel:
         # A newer alert has replaced this one; just remove quietly
+        release_panel_surfaces(panel)
         try:
             panel.orderOut_(None)
         except Exception:
@@ -169,6 +172,7 @@ def _dismiss_alert(panel) -> None:
 
     def _on_fade_complete():
         global _current_panel, _current_close_timer
+        release_panel_surfaces(panel)
         try:
             panel.orderOut_(None)
         except Exception:

--- a/src/wenzi/scripting/api/timer.py
+++ b/src/wenzi/scripting/api/timer.py
@@ -1,11 +1,17 @@
-"""vt.timer — delayed and repeating execution API."""
+"""wz.timer — delayed and repeating execution API.
+
+Scheduling uses :func:`async_loop.call_later` (single shared asyncio
+event-loop timer) instead of ``threading.Timer`` to avoid spawning a
+new thread for every timer tick.  User callbacks are offloaded to the
+asyncio default thread-pool executor so they cannot block the loop.
+"""
 
 from __future__ import annotations
 
 import logging
-import threading
 from collections.abc import Callable
 
+from wenzi import async_loop
 from wenzi.scripting.api._async_util import wrap_async
 from wenzi.scripting.registry import ScriptingRegistry
 
@@ -26,10 +32,9 @@ class TimerAPI:
         entry = self._registry.register_timer(
             seconds, wrap_async(callback), repeating=False,
         )
-        t = threading.Timer(seconds, self._fire_once, args=(entry.timer_id,))
-        t.daemon = True
-        entry._timer = t
-        t.start()
+        entry._timer = async_loop.call_later(
+            seconds, self._fire_once, entry.timer_id,
+        )
         return entry.timer_id
 
     def every(self, seconds: float, callback: Callable) -> str:
@@ -52,29 +57,38 @@ class TimerAPI:
         entry = self._registry.pop_timer(timer_id)
         if entry is None:
             return
-        try:
-            entry.callback()
-        except Exception as exc:
-            logger.error("Timer callback error: %s", exc)
+        # Offload to executor so sync user callbacks don't block the loop.
+        async_loop.get_loop().run_in_executor(
+            None, self._safe_callback, entry.callback,
+        )
 
     def _schedule_repeat(self, timer_id: str) -> None:
         """Schedule the next tick of a repeating timer."""
         entry = self._registry.get_timer(timer_id)
         if entry is None:
             return
-        t = threading.Timer(entry.interval, self._fire_repeat, args=(timer_id,))
-        t.daemon = True
-        entry._timer = t
-        t.start()
+        entry._timer = async_loop.call_later(
+            entry.interval, self._fire_repeat, timer_id,
+        )
 
     def _fire_repeat(self, timer_id: str) -> None:
         """Fire a repeating timer and reschedule."""
         entry = self._registry.get_timer(timer_id)
         if entry is None:
             return
+        cb = entry.callback
+
+        def _run() -> None:
+            self._safe_callback(cb)
+            # call_later uses call_soon_threadsafe, safe from executor.
+            self._schedule_repeat(timer_id)
+
+        async_loop.get_loop().run_in_executor(None, _run)
+
+    @staticmethod
+    def _safe_callback(callback: Callable) -> None:
+        """Execute a user callback with error handling."""
         try:
-            entry.callback()
+            callback()
         except Exception as exc:
-            logger.error("Repeating timer callback error: %s", exc)
-        # Reschedule
-        self._schedule_repeat(timer_id)
+            logger.error("Timer callback error: %s", exc)

--- a/src/wenzi/scripting/registry.py
+++ b/src/wenzi/scripting/registry.py
@@ -62,7 +62,7 @@ class TimerEntry:
     interval: float
     callback: Callable
     repeating: bool
-    _timer: threading.Timer | None = field(default=None, repr=False)
+    _timer: Any = field(default=None, repr=False)  # async_loop.TimerHandle
 
 
 class ScriptingRegistry:

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -212,7 +212,6 @@ class ChooserPanel:
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
         self._webview = None
-        self._effect_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -256,6 +255,7 @@ class ChooserPanel:
         self._recycle_preloading: bool = False
         self._last_screen = None  # last screen the panel was positioned on
 
+    # ------------------------------------------------------------------
     # ------------------------------------------------------------------
     # Panel resize (driven by JS)
     # ------------------------------------------------------------------
@@ -359,12 +359,9 @@ class ChooserPanel:
         """Reset the webview UI state for a reused panel.
 
         Clears the previous search input, results, context block, and
-        preview/compact modes so the panel appears fresh.
-
-        The panel must be invisible (alpha=0) when this method is called.
-        After the JS reset completes, the panel is resized to the measured
-        collapsed height and revealed (alpha=1) so the user never sees
-        stale content or the wrong dimensions.
+        preview/compact modes so the panel appears fresh.  Results are
+        already cleared in close(), so the panel can be visible during
+        this call — only the collapsed height needs adjusting.
         """
         parts = [
             "setResults([])",
@@ -408,7 +405,6 @@ class ChooserPanel:
                 return
             h = int(result) if result else self._INITIAL_HEIGHT
             self._apply_frame(self._INITIAL_WIDTH, h)
-            self._panel.setAlphaValue_(1.0)
 
         self._webview.evaluateJavaScript_completionHandler_(
             js, _on_reset_done
@@ -751,13 +747,10 @@ class ChooserPanel:
         self._previous_app = get_frontmost_app()
 
         if self._panel is not None and self._page_loaded:
-            # Reuse hidden panel — reconnect refs and reset UI.
-            # Hide the panel visually while JS resets content and layout;
-            # _reset_panel_ui reveals it (alpha=1) once the measured
-            # collapsed height is applied so no stale frame flashes.
+            # Hot path — reuse hidden panel.  Results were already cleared
+            # in close(), so we can show immediately without alpha dance.
             self._reconnect_panel_refs()
             self._position_on_mouse_screen()
-            self._panel.setAlphaValue_(0.0)
             self._reset_panel_ui(initial_query, placeholder)
         elif self._panel is not None and self._webview is not None:
             # Warm path: panel + webview alive but page was unloaded
@@ -773,11 +766,6 @@ class ChooserPanel:
         else:
             # First show — build from scratch
             self._build_panel()
-
-        # Activate the blur backdrop just before showing the panel so macOS
-        # allocates the full-screen IOSurface only while visible.
-        if self._effect_view is not None:
-            self._effect_view.setState_(1)  # NSVisualEffectStateActive
 
         self._panel.makeKeyAndOrderFront_(None)
 
@@ -886,22 +874,9 @@ class ChooserPanel:
                 None,
             )
 
-        # Deactivate VFX + shrink to 1×1 to release the full-screen IOSurface
-        # (~72 MB at retina).  show() repositions and JS resizes back.
-        from wenzi.ui_helpers import release_panel_surfaces
-
         if self._panel is not None:
-            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
         self._last_screen = None
-
-        # Load empty HTML to release IOSurface compositing layer buffers.
-        # The WKWebView stays alive for fast re-show; only the rendered
-        # content is discarded.  _page_loaded is set to False so the next
-        # show() will reload the HTML from the cached temp file.
-        if self._webview is not None:
-            self._webview.loadHTMLString_baseURL_("", None)
-            self._page_loaded = False
 
         self._closing = False
 
@@ -959,7 +934,6 @@ class ChooserPanel:
             self._panel.orderOut_(None)
         self._panel = None
         self._webview = None
-        self._effect_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -2047,26 +2021,10 @@ class ChooserPanel:
         panel.setDelegate_(delegate)
         self._panel_delegate = delegate
 
-        # Round corners
+        # Round corners — frosted glass is handled by CSS backdrop-filter
         panel.contentView().setWantsLayer_(True)
-        panel.contentView().layer().setCornerRadius_(16.0)
+        panel.contentView().layer().setCornerRadius_(18.0)
         panel.contentView().layer().setMasksToBounds_(True)
-
-        # Glass blur background (NSVisualEffectView behind WKWebView)
-        from AppKit import NSVisualEffectView
-
-        effect_view = NSVisualEffectView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, initial_width, initial_height)
-        )
-        effect_view.setAutoresizingMask_(0x12)  # Width + Height sizable
-        effect_view.setBlendingMode_(0)  # NSVisualEffectBlendingModeBehindWindow
-        effect_view.setMaterial_(15)  # NSVisualEffectMaterialFullScreenUI
-        effect_view.setState_(0)  # NSVisualEffectStateInactive until show()
-        effect_view.setWantsLayer_(True)
-        effect_view.layer().setCornerRadius_(16.0)
-        effect_view.layer().setMasksToBounds_(True)
-        panel.contentView().addSubview_(effect_view)
-        self._effect_view = effect_view
 
         # Position: center-top of mouse screen (like Spotlight)
         self._panel = panel

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -256,7 +256,6 @@ class ChooserPanel:
         self._last_screen = None  # last screen the panel was positioned on
 
     # ------------------------------------------------------------------
-    # ------------------------------------------------------------------
     # Panel resize (driven by JS)
     # ------------------------------------------------------------------
 
@@ -405,6 +404,7 @@ class ChooserPanel:
                 return
             h = int(result) if result else self._INITIAL_HEIGHT
             self._apply_frame(self._INITIAL_WIDTH, h)
+            self._panel.setAlphaValue_(1.0)
 
         self._webview.evaluateJavaScript_completionHandler_(
             js, _on_reset_done
@@ -747,25 +747,26 @@ class ChooserPanel:
         self._previous_app = get_frontmost_app()
 
         if self._panel is not None and self._page_loaded:
-            # Hot path — reuse hidden panel.  Results were already cleared
-            # in close(), so we can show immediately without alpha dance.
+            # Hot path — reuse hidden panel.  Hide via alpha until
+            # _reset_panel_ui JS completes so stale results never flash.
             self._reconnect_panel_refs()
             self._position_on_mouse_screen()
+            self._panel.setAlphaValue_(0.0)
             self._reset_panel_ui(initial_query, placeholder)
         elif self._panel is not None and self._webview is not None:
-            # Warm path: panel + webview alive but page was unloaded
-            # (empty HTML) to reclaim IOSurface memory.  Reload the
-            # cached HTML — _on_page_loaded will handle pending query,
-            # placeholder, and context.  Hide the panel (alpha=0) until
-            # the page finishes loading to avoid a blank flash.
+            # Warm path: panel + webview alive but HTML not yet loaded
+            # (recycled in prebuild mode).  Load HTML — _on_page_loaded
+            # will handle pending query, placeholder, and context.
             self._reconnect_panel_refs()
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             if not self._recycle_preloading:
                 self._reload_chooser_html()
         else:
-            # First show — build from scratch
+            # First show — build from scratch.  Hide via alpha until
+            # _on_page_loaded reveals it after backdrop-filter is ready.
             self._build_panel()
+            self._panel.setAlphaValue_(0.0)
 
         self._panel.makeKeyAndOrderFront_(None)
 
@@ -859,18 +860,12 @@ class ChooserPanel:
         if self._panel_delegate is not None:
             self._panel_delegate._panel_ref = None
 
-        # Clear visible content while the webview is still on screen so
-        # that next show() won't flash stale results (evaluateJavaScript
-        # is async but executes before the next display
-        # cycle once the panel is already hidden).
+        # Release preview image blob URLs to free memory while hidden.
+        # UI state (results, input, etc.) is reset by _reset_panel_ui
+        # on the next show().
         if self._webview is not None and self._page_loaded:
             self._webview.evaluateJavaScript_completionHandler_(
-                "_releasePreviewImages();"
-                "setResults([]);setInputValue('');"
-                "setPreviewVisible(false);setCompact(false);"
-                "setModifierHints({},null);setCreateButton(false);"
-                "setLoading(false);"
-                "clearContext()",
+                "_releasePreviewImages()",
                 None,
             )
 
@@ -1555,17 +1550,34 @@ class ChooserPanel:
                     target=self._play_audio_url, args=(url,), daemon=True
                 ).start()
 
-    def _play_audio_url(self, url: str) -> None:
-        """Download and play an audio URL via NSSound (no Now Playing icon)."""
-        try:
-            from AppKit import NSSound
-            from Foundation import NSURL
+    _audio_player = None  # prevent GC during playback
 
-            sound = NSSound.alloc().initWithContentsOfURL_byReference_(
-                NSURL.URLWithString_(url), False
+    def _play_audio_url(self, url: str) -> None:
+        """Download and play an audio URL via AVAudioPlayer.
+
+        Uses AVFoundation instead of NSSound to avoid interfering with
+        AppKit window compositing (NSSound triggers window server
+        recomposition that breaks CSS backdrop-filter in WKWebView).
+        """
+        try:
+            from AVFoundation import AVAudioPlayer
+            from Foundation import NSURL, NSData
+
+            # Download on background thread
+            data = NSData.dataWithContentsOfURL_(NSURL.URLWithString_(url))
+            if not data:
+                return
+            player, error = AVAudioPlayer.alloc().initWithData_error_(
+                data, None
             )
-            if sound:
-                sound.play()
+            if player and not error:
+                from PyObjCTools import AppHelper
+
+                def _play():
+                    ChooserPanel._audio_player = player
+                    player.play()
+
+                AppHelper.callAfter(_play)
         except Exception:
             logger.debug("Failed to play audio: %s", url, exc_info=True)
 
@@ -1844,16 +1856,6 @@ class ChooserPanel:
 
     def _on_page_loaded(self) -> None:
         """Called when WKWebView finishes loading the HTML."""
-        # Guard against the blank-page navigation fired by close().
-        # If show() is called before the blank load completes,
-        # _reconnect_panel_refs restores the delegate ref and this
-        # callback would fire for the empty page.  Ignore it.
-        if self._webview is not None:
-            url = self._webview.URL()
-            url_str = str(url.absoluteString()) if url is not None else ""
-            if not url_str or url_str == "about:blank":
-                return
-
         # Inject i18n translations before flushing pending JS
         self._inject_i18n()
 

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -212,6 +212,7 @@ class ChooserPanel:
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
         self._webview = None
+        self._effect_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -773,6 +774,11 @@ class ChooserPanel:
             # First show — build from scratch
             self._build_panel()
 
+        # Activate the blur backdrop just before showing the panel so macOS
+        # allocates the full-screen IOSurface only while visible.
+        if self._effect_view is not None:
+            self._effect_view.setState_(1)  # NSVisualEffectStateActive
+
         self._panel.makeKeyAndOrderFront_(None)
 
         from AppKit import NSApp
@@ -879,6 +885,11 @@ class ChooserPanel:
                 "clearContext()",
                 None,
             )
+
+        # Deactivate the blur backdrop to release the full-screen IOSurface
+        # that macOS allocates for behindWindow blending (~72 MB at retina).
+        if self._effect_view is not None:
+            self._effect_view.setState_(0)  # NSVisualEffectStateInactive
 
         if self._panel is not None:
             self._panel.orderOut_(None)
@@ -1923,6 +1934,10 @@ class ChooserPanel:
                 self._panel.setFrame_display_(
                     NSMakeRect(f.origin.x, f.origin.y, 1, 1), False,
                 )
+                # Clear cached screen so next show() repositions correctly
+                # instead of skipping because the screen hasn't changed.
+                # The 1×1 origin is stale after the shrink.
+                self._last_screen = None
             else:
                 self._panel.setAlphaValue_(1.0)
 
@@ -2058,7 +2073,7 @@ class ChooserPanel:
         effect_view.setAutoresizingMask_(0x12)  # Width + Height sizable
         effect_view.setBlendingMode_(1)  # NSVisualEffectBlendingModeBehindWindow
         effect_view.setMaterial_(0)  # NSVisualEffectMaterialAppearanceBased — bright glass
-        effect_view.setState_(1)  # NSVisualEffectStateActive (always active)
+        effect_view.setState_(0)  # NSVisualEffectStateInactive until show()
         effect_view.setWantsLayer_(True)
         effect_view.layer().setCornerRadius_(16.0)
         effect_view.layer().setMasksToBounds_(True)

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -886,25 +886,13 @@ class ChooserPanel:
                 None,
             )
 
-        # Deactivate the blur backdrop to release the full-screen IOSurface
-        # that macOS allocates for behindWindow blending (~72 MB at retina).
-        if self._effect_view is not None:
-            self._effect_view.setState_(0)  # NSVisualEffectStateInactive
+        # Deactivate VFX + shrink to 1×1 to release the full-screen IOSurface
+        # (~72 MB at retina).  show() repositions and JS resizes back.
+        from wenzi.ui_helpers import release_panel_surfaces
 
         if self._panel is not None:
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
-
-            # Shrink to 1×1 to release the CA Whippet Drawable backing
-            # store.  macOS retains the full-size RGBA half-float
-            # IOSurface (~63 MB at retina) even after orderOut_;
-            # resizing forces CoreAnimation to reallocate a trivial
-            # buffer.  show() repositions and JS resizes back.
-            from Foundation import NSMakeRect
-
-            f = self._panel.frame()
-            self._panel.setFrame_display_(
-                NSMakeRect(f.origin.x, f.origin.y, 1, 1), False,
-            )
         self._last_screen = None
 
         # Load empty HTML to release IOSurface compositing layer buffers.
@@ -2071,8 +2059,8 @@ class ChooserPanel:
             NSMakeRect(0, 0, initial_width, initial_height)
         )
         effect_view.setAutoresizingMask_(0x12)  # Width + Height sizable
-        effect_view.setBlendingMode_(1)  # NSVisualEffectBlendingModeBehindWindow
-        effect_view.setMaterial_(0)  # NSVisualEffectMaterialAppearanceBased — bright glass
+        effect_view.setBlendingMode_(0)  # NSVisualEffectBlendingModeBehindWindow
+        effect_view.setMaterial_(15)  # NSVisualEffectMaterialFullScreenUI
         effect_view.setState_(0)  # NSVisualEffectStateInactive until show()
         effect_view.setWantsLayer_(True)
         effect_view.layer().setCornerRadius_(16.0)

--- a/src/wenzi/scripting/ui/leader_alert.py
+++ b/src/wenzi/scripting/ui/leader_alert.py
@@ -247,7 +247,10 @@ class LeaderAlertPanel:
 
         from AppKit import NSAnimationContext
 
+        from wenzi.ui_helpers import release_panel_surfaces
+
         def _on_fade_done():
+            release_panel_surfaces(panel)
             try:
                 panel.orderOut_(None)
             except Exception:

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -21,13 +21,20 @@ _PADDING_H = 14
 _PADDING_V = 10
 _SECTION_SPACING = 8
 _ASR_MAX_HEIGHT = 60  # max before ASR section scrolls
+_LABEL_HEIGHT = 14
+_HINT_GAP = 8
+_PROGRESS_HEIGHT = 3
+_PROGRESS_CORNER = 1.5
+
+# Font
+_FONT_SIZE = 13
 
 # Key codes
 _ESC_KEY_CODE = 53
 _RETURN_KEY_CODE = 36
 
 # Delayed close
-_CLOSE_DELAY = 1.0
+_CLOSE_DELAY = 3.0
 _HOVER_RECHECK_INTERVAL = 0.5
 _FADE_OUT_DURATION = 0.3
 
@@ -36,8 +43,8 @@ _VFX_MATERIAL_HUD = 13
 _VFX_BLENDING_BEHIND = 0
 _VFX_STATE_ACTIVE = 1
 
-# Height recalc debounce flag
-_RECALC_PENDING_KEY = "_recalc_pending"
+# Height recalc debounce
+_RECALC_DEBOUNCE = 0.05
 
 
 class StreamingOverlayPanel:
@@ -68,6 +75,10 @@ class StreamingOverlayPanel:
         self._close_timer: object = None
         self._has_thinking: bool = False
         self._transcribing: bool = False  # animate "Transcribing..." dots
+        self._recalc_timer: object = None
+        self._hint_label: object = None
+        self._complete: bool = False
+        self._progress_view: object = None
         # Screen centre anchor (for height growth animation)
         self._center_x: float = 0.0
         self._center_y: float = 0.0
@@ -100,7 +111,7 @@ class StreamingOverlayPanel:
         return label
 
     @staticmethod
-    def _make_text_view(width: float, font_size: float = 13.0):
+    def _make_text_view(width: float, font_size: float = _FONT_SIZE):
         """Create a scrollable NSTextView pair. Returns (scroll_view, text_view)."""
         from AppKit import (
             NSColor,
@@ -183,7 +194,7 @@ class StreamingOverlayPanel:
             content_w = _PANEL_WIDTH - _PADDING_H * 2
             self._asr_title_label = self._make_label(asr_title_text)
             self._asr_scroll, self._asr_text_view = self._make_text_view(
-                content_w, font_size=12,
+                content_w,
             )
             if asr_text:
                 self._set_text(self._asr_text_view, asr_text)
@@ -191,7 +202,7 @@ class StreamingOverlayPanel:
             else:
                 self._set_text(
                     self._asr_text_view, "Transcribing",
-                    secondary=True, italic=True,
+                    italic=True,
                 )
                 self._transcribing = True
 
@@ -208,8 +219,20 @@ class StreamingOverlayPanel:
 
             self._status_label = self._make_label(self._ai_label(""))
             self._stream_scroll, self._stream_text_view = self._make_text_view(
-                content_w, font_size=12,
+                content_w,
             )
+
+            hint_parts = ["ESC cancel"]
+            if on_confirm_asr:
+                hint_parts.append("\u23ce use original")
+            hint_parts.append("\u2318C copy")
+            self._hint_label = self._make_label("  \u00b7  ".join(hint_parts))
+
+            progress = _NSView.alloc().initWithFrame_(NSMakeRect(0, 0, 0, _PROGRESS_HEIGHT))
+            progress.setWantsLayer_(True)
+            progress.layer().setBackgroundColor_(NSColor.controlAccentColor().CGColor())
+            progress.layer().setCornerRadius_(_PROGRESS_CORNER)
+            self._progress_view = progress
 
             # -- Panel --
             init_h = self._compute_height()
@@ -243,6 +266,17 @@ class StreamingOverlayPanel:
 
             self._panel = panel
 
+            # -- Add subviews once (repositioned by _layout_subviews) --
+            vfx.addSubview_(self._asr_title_label)
+            vfx.addSubview_(self._asr_scroll)
+            vfx.addSubview_(self._separator)
+            vfx.addSubview_(self._status_label)
+            vfx.addSubview_(self._stream_scroll)
+            if self._hint_label is not None:
+                vfx.addSubview_(self._hint_label)
+            if self._progress_view is not None:
+                vfx.addSubview_(self._progress_view)
+
             # -- Position at screen centre --
             screen = NSScreen.mainScreen()
             if screen:
@@ -251,21 +285,30 @@ class StreamingOverlayPanel:
                 self._center_y = sf.origin.y + sf.size.height / 2.0
 
             # Layout subviews, position, and show
-            self._layout_subviews(init_h)
             target_frame = self._frame_for_height(init_h)
-            print(f"[SO] init_h={init_h}, center=({self._center_x},{self._center_y}), target={target_frame}")
-            panel.setFrame_display_(target_frame, True)
-            panel.orderFront_(None)
-            print(f"[SO] panel.frame()={panel.frame()}, alpha={panel.alphaValue()}, visible={panel.isVisible()}")
-            print(f"[SO] vfx subviews={self._vfx_view.subviews().count() if self._vfx_view else 'None'}")
+
+            if animate_from_frame is not None:
+                # Start at recording indicator's position, animate to target
+                panel.setAlphaValue_(0.6)
+                panel.setFrame_display_(animate_from_frame, False)
+                panel.orderFront_(None)
+                self._layout_subviews(init_h)  # layout for target size
+                from AppKit import NSAnimationContext
+                NSAnimationContext.beginGrouping()
+                ctx = NSAnimationContext.currentContext()
+                ctx.setDuration_(0.25)
+                panel.animator().setFrame_display_(target_frame, True)
+                panel.animator().setAlphaValue_(1.0)
+                NSAnimationContext.endGrouping()
+            else:
+                self._layout_subviews(init_h)
+                panel.setFrame_display_(target_frame, True)
+                panel.orderFront_(None)
 
             self._register_key_tap()
             self._start_loading_timer()
             logger.debug("Streaming overlay shown")
-        except Exception as exc:
-            import traceback
-            print(f"[SO] EXCEPTION in show(): {exc}")
-            traceback.print_exc()
+        except Exception:
             logger.error("Failed to show streaming overlay", exc_info=True)
 
     def _frame_for_height(self, h: float):
@@ -277,53 +320,55 @@ class StreamingOverlayPanel:
         return NSMakeRect(x, y, _PANEL_WIDTH, h)
 
     def _layout_subviews(self, panel_h: float) -> None:
-        """Position all subviews within the VFX view for a given panel height."""
+        """Reposition subviews within the VFX view for a given panel height.
+
+        Subviews are added once in show(); this method only adjusts frames.
+        """
         from Foundation import NSMakeRect
 
         if self._vfx_view is None:
             return
 
-        # Remove existing subviews
-        for sv in list(self._vfx_view.subviews()):
-            sv.removeFromSuperview()
-
         cw = _PANEL_WIDTH - _PADDING_H * 2
         y = panel_h - _PADDING_V  # start from top
 
-        # ASR title
-        lh = 14
-        y -= lh
+        y -= _LABEL_HEIGHT
         self._asr_title_label.setFrame_(
-            NSMakeRect(_PADDING_H, y, cw, lh)
+            NSMakeRect(_PADDING_H, y, cw, _LABEL_HEIGHT)
         )
-        self._vfx_view.addSubview_(self._asr_title_label)
 
-        # ASR text
         y -= 2  # small gap
         asr_h = min(self._text_content_height(self._asr_text_view), _ASR_MAX_HEIGHT)
         asr_h = max(asr_h, 16)
         y -= asr_h
         self._asr_scroll.setFrame_(NSMakeRect(_PADDING_H, y, cw, asr_h))
-        self._vfx_view.addSubview_(self._asr_scroll)
 
-        # Separator
         y -= _SECTION_SPACING
         self._separator.setFrame_(NSMakeRect(_PADDING_H, y, cw, 1))
-        self._vfx_view.addSubview_(self._separator)
         y -= _SECTION_SPACING
 
-        # Status label
-        y -= lh
-        self._status_label.setFrame_(NSMakeRect(_PADDING_H, y, cw, lh))
-        self._vfx_view.addSubview_(self._status_label)
+        y -= _LABEL_HEIGHT
+        self._status_label.setFrame_(NSMakeRect(_PADDING_H, y, cw, _LABEL_HEIGHT))
 
-        # Stream text (fill remaining space)
+        if self._hint_label is not None:
+            hint_y = _PADDING_V
+            self._hint_label.setFrame_(NSMakeRect(_PADDING_H, hint_y, cw, _LABEL_HEIGHT))
+            bottom_for_stream = hint_y + _LABEL_HEIGHT + _HINT_GAP
+        else:
+            bottom_for_stream = _PADDING_V
+
+        # Stream text fills remaining space
         y -= 2
-        stream_h = max(y - _PADDING_V, 16)
+        stream_h = max(y - bottom_for_stream, 16)
         self._stream_scroll.setFrame_(
-            NSMakeRect(_PADDING_H, _PADDING_V, cw, stream_h)
+            NSMakeRect(_PADDING_H, bottom_for_stream, cw, stream_h)
         )
-        self._vfx_view.addSubview_(self._stream_scroll)
+
+        if self._progress_view is not None:
+            pw = self._progress_view.frame().size.width
+            self._progress_view.setFrame_(
+                NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, pw, _PROGRESS_HEIGHT)
+            )
 
     def _compute_height(self) -> float:
         """Compute ideal panel height from content."""
@@ -336,16 +381,34 @@ class StreamingOverlayPanel:
 
         total = (
             _PADDING_V
-            + 14  # asr title
-            + 2 + asr_h
-            + _SECTION_SPACING + 1 + _SECTION_SPACING  # separator
-            + 14  # status label
-            + 2 + stream_h
+            + _LABEL_HEIGHT + 2 + asr_h
+            + _SECTION_SPACING + 1 + _SECTION_SPACING
+            + _LABEL_HEIGHT + 2 + stream_h
+            + _LABEL_HEIGHT + _HINT_GAP
             + _PADDING_V
         )
         return max(_MIN_HEIGHT, min(total, _MAX_HEIGHT))
 
     def _recalculate_height(self) -> None:
+        """Schedule debounced height recalculation."""
+        if self._panel is None or self._recalc_timer is not None:
+            return
+        try:
+            from Foundation import NSTimer
+            self._recalc_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                _RECALC_DEBOUNCE, self, b"_doRecalcHeight:", None, False,
+            )
+        except Exception:
+            self._do_recalculate_height()
+
+    def _doRecalcHeight_(self, timer) -> None:
+        self._recalc_timer = None
+        try:
+            self._do_recalculate_height()
+        except Exception:
+            logger.error("Recalc height timer error", exc_info=True)
+
+    def _do_recalculate_height(self) -> None:
         """Recompute panel height and animate the change."""
         if self._panel is None:
             return
@@ -368,12 +431,15 @@ class StreamingOverlayPanel:
         ctx.setDuration_(0.12)
 
         def _after_resize():
-            self._layout_subviews(new_h)
-            self._vfx_view.setFrame_(
-                self._panel.contentView().bounds()
-                if self._panel
-                else self._vfx_view.frame()
-            )
+            try:
+                self._layout_subviews(new_h)
+                self._vfx_view.setFrame_(
+                    self._panel.contentView().bounds()
+                    if self._panel
+                    else self._vfx_view.frame()
+                )
+            except Exception:
+                logger.error("After-resize completion error", exc_info=True)
 
         ctx.setCompletionHandler_(_after_resize)
         self._panel.animator().setFrame_display_(target, True)
@@ -415,10 +481,10 @@ class StreamingOverlayPanel:
         attrs = NSMutableDictionary.dictionary()
         if italic:
             attrs["NSFont"] = NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
-                    NSFont.systemFontOfSize_(13), 1,  # NSItalicFontMask
+                    NSFont.systemFontOfSize_(_FONT_SIZE), 1,  # NSItalicFontMask
                 )
         else:
-            attrs["NSFont"] = NSFont.systemFontOfSize_(13)
+            attrs["NSFont"] = NSFont.systemFontOfSize_(_FONT_SIZE)
         if secondary:
             attrs["NSColor"] = NSColor.secondaryLabelColor()
         else:
@@ -484,6 +550,13 @@ class StreamingOverlayPanel:
                 logger.info("Streaming cancelled via ESC key")
                 return None
 
+            flags = cg.CGEventGetFlags(event)
+
+            if keycode == 8 and (flags & cg.kCGEventFlagMaskCommand):  # Cmd+C
+                from PyObjCTools import AppHelper
+                AppHelper.callAfter(self._copy_stream_text)
+                return None
+
             if keycode == _RETURN_KEY_CODE and self._on_confirm_asr is not None:
                 if self._tap_runner is not None and self._tap_runner.tap is not None:
                     cg.CGEventTapEnable(self._tap_runner.tap, False)
@@ -491,12 +564,31 @@ class StreamingOverlayPanel:
 
                 on_confirm = self._on_confirm_asr
                 AppHelper.callAfter(on_confirm)
+                AppHelper.callAfter(self._do_close)
                 logger.info("ASR confirmed via Enter key")
                 return None
+
+            if self._complete:
+                from PyObjCTools import AppHelper
+                AppHelper.callAfter(self._do_close)
+                return event  # close panel but let the key through
 
         except Exception:
             logger.warning("Key tap callback error", exc_info=True)
         return event
+
+    def _copy_stream_text(self) -> None:
+        """Copy stream text to clipboard with visual feedback."""
+        if self._stream_text_view is None:
+            return
+        text = self._stream_text_view.textStorage().string()
+        if not text.strip():
+            return
+        from wenzi.input import set_clipboard_text
+        set_clipboard_text(text)
+        if self._status_label is not None:
+            self._status_label.setStringValue_("\u2713 Copied to clipboard")
+        logger.debug("Stream text copied to clipboard")
 
     def _remove_key_tap(self) -> None:
         if self._tap_runner is not None:
@@ -531,23 +623,26 @@ class StreamingOverlayPanel:
             self._loading_timer = None
 
     def tickLoadingTimer_(self, timer) -> None:
-        self._tick_count += 1
+        try:
+            self._tick_count += 1
 
-        # Animate "Transcribing..." dots (cycles every 3 ticks)
-        if self._transcribing and self._asr_text_view is not None:
-            dots = "." * ((self._tick_count % 3) + 1)
-            self._set_text(
-                self._asr_text_view, f"Transcribing{dots}",
-                secondary=True, italic=True,
-            )
-
-        # Update AI status every second (every 2 ticks at 0.5s interval)
-        if self._tick_count % 2 == 0:
-            self._loading_seconds += 1
-            if self._status_label is not None:
-                self._status_label.setStringValue_(
-                    self._ai_label(f"\u23f3 {self._loading_seconds}s")
+            # Animate "Transcribing..." dots (cycles every 3 ticks)
+            if self._transcribing and self._asr_text_view is not None:
+                dots = "." * ((self._tick_count % 3) + 1)
+                self._set_text(
+                    self._asr_text_view, f"Transcribing{dots}",
+                    italic=True,
                 )
+
+            # Update AI status every second (every 2 ticks at 0.5s interval)
+            if self._tick_count % 2 == 0:
+                self._loading_seconds += 1
+                if self._status_label is not None:
+                    self._status_label.setStringValue_(
+                        self._ai_label(f"\u23f3 {self._loading_seconds}s")
+                    )
+        except Exception:
+            logger.error("Loading timer tick error", exc_info=True)
 
     # ------------------------------------------------------------------
     # Streaming text updates (all thread-safe via callAfter)
@@ -564,18 +659,21 @@ class StreamingOverlayPanel:
 
             from AppKit import NSColor, NSFont
 
-            # Clear thinking text if present
-            if self._has_thinking:
-                self._stream_text_view.textStorage().setAttributedString_(
-                    __import__("Foundation").NSAttributedString.alloc().init()
-                )
-                self._has_thinking = False
-
             attrs = {
-                "NSFont": NSFont.systemFontOfSize_(13),
+                "NSFont": NSFont.systemFontOfSize_(_FONT_SIZE),
                 "NSColor": NSColor.labelColor(),
             }
-            self._append_attributed(self._stream_text_view, chunk, attrs)
+
+            if self._has_thinking:
+                from Foundation import NSAttributedString, NSMakeRange
+                astr = NSAttributedString.alloc().initWithString_attributes_(chunk, attrs)
+                ts = self._stream_text_view.textStorage()
+                ts.replaceCharactersInRange_withAttributedString_(
+                    NSMakeRange(0, ts.length()), astr
+                )
+                self._has_thinking = False
+            else:
+                self._append_attributed(self._stream_text_view, chunk, attrs)
 
             if completion_tokens and self._status_label:
                 self._status_label.setStringValue_(
@@ -600,7 +698,7 @@ class StreamingOverlayPanel:
             self._has_thinking = True
             attrs = {
                 "NSFont": NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
-                    NSFont.systemFontOfSize_(13), 1,  # NSItalicFontMask
+                    NSFont.systemFontOfSize_(_FONT_SIZE), 1,  # NSItalicFontMask
                 ),
                 "NSColor": NSColor.tertiaryLabelColor(),
             }
@@ -655,6 +753,7 @@ class StreamingOverlayPanel:
 
         def _update():
             self._stop_loading_timer()
+            self._complete = True
             if self._status_label is None:
                 return
 
@@ -679,6 +778,30 @@ class StreamingOverlayPanel:
 
         AppHelper.callAfter(_update)
 
+    def set_progress(self, step: int, total: int) -> None:
+        """Update chain progress bar. Thread-safe."""
+        from PyObjCTools import AppHelper
+
+        def _update():
+            if self._progress_view is None or self._panel is None or total <= 0:
+                return
+            from Foundation import NSMakeRect
+            w = _PANEL_WIDTH * (step / total)
+            try:
+                panel_h = float(self._panel.frame().size.height)
+            except (TypeError, ValueError):
+                return
+            from AppKit import NSAnimationContext
+            NSAnimationContext.beginGrouping()
+            ctx = NSAnimationContext.currentContext()
+            ctx.setDuration_(0.2)
+            self._progress_view.animator().setFrame_(
+                NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, w, _PROGRESS_HEIGHT)
+            )
+            NSAnimationContext.endGrouping()
+
+        AppHelper.callAfter(_update)
+
     def clear_text(self) -> None:
         """Clear the streaming text view. Thread-safe."""
         from PyObjCTools import AppHelper
@@ -686,8 +809,10 @@ class StreamingOverlayPanel:
         def _clear():
             if self._stream_text_view is None:
                 return
+            from Foundation import NSAttributedString
+
             self._stream_text_view.textStorage().setAttributedString_(
-                __import__("Foundation").NSAttributedString.alloc().init()
+                NSAttributedString.alloc().init()
             )
             self._has_thinking = False
             self._recalculate_height()
@@ -718,24 +843,27 @@ class StreamingOverlayPanel:
         AppHelper.callAfter(_schedule)
 
     def _delayedCloseCheck_(self, timer) -> None:
-        self._close_timer = None
-        if self._panel is None:
-            return
+        try:
+            self._close_timer = None
+            if self._panel is None:
+                return
 
-        if self._is_mouse_over_panel():
-            try:
-                from Foundation import NSTimer
+            if self._is_mouse_over_panel():
+                try:
+                    from Foundation import NSTimer
 
-                self._close_timer = (
-                    NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                        _HOVER_RECHECK_INTERVAL,
-                        self, b"_delayedCloseCheck:", None, False,
+                    self._close_timer = (
+                        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                            _HOVER_RECHECK_INTERVAL,
+                            self, b"_delayedCloseCheck:", None, False,
+                        )
                     )
-                )
-            except Exception:
-                self._do_close()
-        else:
-            self._fade_out_and_close()
+                except Exception:
+                    self._do_close()
+            else:
+                self._fade_out_and_close()
+        except Exception:
+            logger.error("Delayed close check error", exc_info=True)
 
     def _is_mouse_over_panel(self) -> bool:
         try:
@@ -756,7 +884,12 @@ class StreamingOverlayPanel:
             NSAnimationContext.beginGrouping()
             ctx = NSAnimationContext.currentContext()
             ctx.setDuration_(_FADE_OUT_DURATION)
-            ctx.setCompletionHandler_(self._do_close)
+            def _safe_close():
+                try:
+                    self._do_close()
+                except Exception:
+                    logger.error("Fade-out close error", exc_info=True)
+            ctx.setCompletionHandler_(_safe_close)
             self._panel.animator().setAlphaValue_(0.0)
             NSAnimationContext.endGrouping()
         except Exception:
@@ -779,6 +912,14 @@ class StreamingOverlayPanel:
         self._on_confirm_asr = None
         self._has_thinking = False
         self._transcribing = False
+        self._complete = False
+
+        if self._recalc_timer:
+            try:
+                self._recalc_timer.invalidate()
+            except Exception:
+                pass
+            self._recalc_timer = None
 
         if self._panel is not None:
             from wenzi.ui_helpers import release_panel_surfaces
@@ -795,6 +936,8 @@ class StreamingOverlayPanel:
         self._status_label = None
         self._stream_text_view = None
         self._stream_scroll = None
+        self._hint_label = None
+        self._progress_view = None
         logger.debug("Streaming overlay closed")
 
     def close_now(self) -> None:

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -1,25 +1,26 @@
 """Floating overlay panel for Direct mode streaming AI enhancement output.
 
-Uses WKWebView for rendering with automatic dark mode support via CSS.
+Uses native AppKit views (NSVisualEffectView + NSTextView) for instant
+rendering, dynamic height, and seamless visual transition from the
+recording indicator.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 import threading
-
-from wenzi.ui.templates import load_template
 
 logger = logging.getLogger(__name__)
 
 # Panel dimensions
-_PANEL_WIDTH = 400
-_PANEL_HEIGHT = 200
-
-# Layout constants
+_PANEL_WIDTH = 420
+_MIN_HEIGHT = 80
+_MAX_HEIGHT = 360
 _CORNER_RADIUS = 10
-_SCREEN_MARGIN = 20
+_PADDING_H = 14
+_PADDING_V = 10
+_SECTION_SPACING = 8
+_ASR_MAX_HEIGHT = 60  # max before ASR section scrolls
 
 # Key codes
 _ESC_KEY_CODE = 53
@@ -30,49 +31,33 @@ _CLOSE_DELAY = 1.0
 _HOVER_RECHECK_INTERVAL = 0.5
 _FADE_OUT_DURATION = 0.3
 
-# ---------------------------------------------------------------------------
-# WKNavigationDelegate (lazy-created)
-# ---------------------------------------------------------------------------
-_OverlayNavDelegate = None
+# NSVisualEffectView constants
+_VFX_MATERIAL_HUD = 13
+_VFX_BLENDING_BEHIND = 0
+_VFX_STATE_ACTIVE = 1
 
-
-def _get_nav_delegate_class():
-    global _OverlayNavDelegate
-    if _OverlayNavDelegate is None:
-        import objc
-        import WebKit  # noqa: F401
-        from Foundation import NSObject
-
-        WKNavigationDelegate = objc.protocolNamed("WKNavigationDelegate")
-
-        class StreamingOverlayNavDelegate(
-            NSObject, protocols=[WKNavigationDelegate]
-        ):
-            _panel_ref = None
-
-            def webView_didFinishNavigation_(self, webview, navigation):
-                if self._panel_ref is not None:
-                    self._panel_ref._on_page_loaded()
-
-        _OverlayNavDelegate = StreamingOverlayNavDelegate
-    return _OverlayNavDelegate
-
-
-_MAX_PENDING_JS = 500  # cap queued JS calls while WKWebView page loads
+# Height recalc debounce flag
+_RECALC_PENDING_KEY = "_recalc_pending"
 
 
 class StreamingOverlayPanel:
     """Non-interactive floating overlay that displays streaming AI enhancement.
 
     Shows ASR original text at top, streaming enhanced text below.
-    Uses WKWebView for rendering with automatic dark mode support.
-    Does not steal focus or accept mouse events.
+    Uses native AppKit views with NSVisualEffectView for frosted-glass
+    appearance matching the recording indicator.
     """
 
     def __init__(self) -> None:
         self._panel: object = None
-        self._webview: object = None
-        self._nav_delegate: object = None
+        self._vfx_view: object = None
+        self._asr_title_label: object = None
+        self._asr_text_view: object = None
+        self._asr_scroll: object = None
+        self._separator: object = None
+        self._status_label: object = None
+        self._stream_text_view: object = None
+        self._stream_scroll: object = None
         self._tap_runner: object = None
         self._cancel_event: threading.Event | None = None
         self._on_cancel: object = None
@@ -81,34 +66,14 @@ class StreamingOverlayPanel:
         self._loading_seconds: int = 0
         self._llm_info: str = ""
         self._close_timer: object = None
-        self._page_loaded: bool = False
-        self._pending_js: list[str] = []
+        self._has_thinking: bool = False
+        self._transcribing: bool = False  # animate "Transcribing..." dots
+        # Screen centre anchor (for height growth animation)
+        self._center_x: float = 0.0
+        self._center_y: float = 0.0
 
     # ------------------------------------------------------------------
-    # JavaScript bridge
-    # ------------------------------------------------------------------
-
-    def _eval_js(self, js_code: str) -> None:
-        """Evaluate JS in the webview. Queues if page not loaded yet."""
-        if not self._page_loaded:
-            self._pending_js.append(js_code)
-            if len(self._pending_js) > _MAX_PENDING_JS:
-                self._pending_js = self._pending_js[-_MAX_PENDING_JS:]
-            return
-        if self._webview is not None:
-            self._webview.evaluateJavaScript_completionHandler_(js_code, None)
-
-    def _on_page_loaded(self) -> None:
-        """Called by navigation delegate when HTML finishes loading."""
-        pending = self._pending_js[:]
-        self._pending_js.clear()
-        self._page_loaded = True
-        if pending and self._webview is not None:
-            combined = ";".join(pending)
-            self._webview.evaluateJavaScript_completionHandler_(combined, None)
-
-    # ------------------------------------------------------------------
-    # Show / position
+    # Helpers
     # ------------------------------------------------------------------
 
     def _ai_label(self, suffix: str) -> str:
@@ -120,6 +85,65 @@ class StreamingOverlayPanel:
             return f"{base}  {suffix}"
         return base
 
+    @staticmethod
+    def _make_label(text: str):
+        """Create a small, muted section header label."""
+        from AppKit import NSColor, NSFont, NSTextField
+
+        label = NSTextField.labelWithString_(text)
+        label.setFont_(NSFont.systemFontOfSize_weight_(9.5, 0.23))
+        label.setTextColor_(NSColor.tertiaryLabelColor())
+        label.setSelectable_(False)
+        label.setDrawsBackground_(False)
+        label.setBezeled_(False)
+        label.setEditable_(False)
+        return label
+
+    @staticmethod
+    def _make_text_view(width: float, font_size: float = 13.0):
+        """Create a scrollable NSTextView pair. Returns (scroll_view, text_view)."""
+        from AppKit import (
+            NSColor,
+            NSFont,
+            NSScrollView,
+            NSTextView,
+        )
+        from Foundation import NSMakeRect
+
+        scroll = NSScrollView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, width, 20)
+        )
+        scroll.setHasVerticalScroller_(True)
+        scroll.setHasHorizontalScroller_(False)
+        scroll.setAutohidesScrollers_(True)
+        scroll.setDrawsBackground_(False)
+        scroll.setBorderType_(0)  # NSNoBorder
+
+        tv = NSTextView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, width, 20)
+        )
+        tv.setEditable_(False)
+        tv.setSelectable_(True)
+        tv.setDrawsBackground_(False)
+        tv.setRichText_(True)
+        tv.setFont_(NSFont.systemFontOfSize_(font_size))
+        tv.setTextColor_(NSColor.labelColor())
+        tv.setTextContainerInset_((0, 0))
+        # Allow unlimited height, fixed width
+        tv.textContainer().setWidthTracksTextView_(True)
+        tv.textContainer().setContainerSize_((width, 1e7))
+        tv.setHorizontallyResizable_(False)
+        tv.setVerticallyResizable_(True)
+        # Hide scrollbar visually but keep scrolling
+        scroll.setScrollerStyle_(1)  # NSScrollerStyleOverlay
+
+        scroll.setDocumentView_(tv)
+        return scroll, tv
+
+    # ------------------------------------------------------------------
+    # Show / position
+    # ------------------------------------------------------------------
+
     def show(
         self,
         asr_text: str = "",
@@ -130,17 +154,16 @@ class StreamingOverlayPanel:
         on_cancel: object = None,
         on_confirm_asr: object = None,
     ) -> None:
-        """Create and show the overlay panel. Must be called on main thread.
-
-        Args:
-            on_cancel: Optional callback invoked when ESC is pressed.
-            on_confirm_asr: Optional callback invoked when Enter is pressed
-                (skip enhancement, output ASR text directly).
-        """
+        """Create and show the overlay panel. Must be called on main thread."""
         try:
-            from AppKit import NSColor, NSPanel, NSScreen, NSStatusWindowLevel
-            from Foundation import NSURL, NSMakeRect
-            from WebKit import WKWebView
+            from AppKit import (
+                NSColor,
+                NSPanel,
+                NSScreen,
+                NSStatusWindowLevel,
+                NSVisualEffectView,
+            )
+            from Foundation import NSMakeRect
 
             if self._panel is not None:
                 self._do_close()
@@ -150,113 +173,279 @@ class StreamingOverlayPanel:
             self._on_confirm_asr = on_confirm_asr
             self._loading_seconds = 0
             self._llm_info = llm_info
-            self._page_loaded = False
-            self._pending_js.clear()
+            self._has_thinking = False
 
-            # Create borderless panel
+            # -- Build labels --
+            asr_title_text = "\U0001f3a4 ASR"
+            if stt_info:
+                asr_title_text += f"  ({stt_info})"
+
+            content_w = _PANEL_WIDTH - _PADDING_H * 2
+            self._asr_title_label = self._make_label(asr_title_text)
+            self._asr_scroll, self._asr_text_view = self._make_text_view(
+                content_w, font_size=12,
+            )
+            if asr_text:
+                self._set_text(self._asr_text_view, asr_text)
+                self._transcribing = False
+            else:
+                self._set_text(
+                    self._asr_text_view, "Transcribing",
+                    secondary=True, italic=True,
+                )
+                self._transcribing = True
+
+            # Soft separator (thin semi-transparent view)
+            from AppKit import NSView as _NSView
+
+            sep = _NSView.alloc().initWithFrame_(NSMakeRect(0, 0, content_w, 1))
+            sep.setWantsLayer_(True)
+            sep.layer().setBackgroundColor_(
+                NSColor.separatorColor().CGColor()
+            )
+            sep.layer().setOpacity_(0.4)
+            self._separator = sep
+
+            self._status_label = self._make_label(self._ai_label(""))
+            self._stream_scroll, self._stream_text_view = self._make_text_view(
+                content_w, font_size=12,
+            )
+
+            # -- Panel --
+            init_h = self._compute_height()
             panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
-                NSMakeRect(0, 0, _PANEL_WIDTH, _PANEL_HEIGHT),
-                0,  # NSBorderlessWindowMask
-                2,  # NSBackingStoreBuffered
-                False,
+                NSMakeRect(0, 0, _PANEL_WIDTH, init_h),
+                0, 2, False,
             )
             panel.setLevel_(NSStatusWindowLevel + 1)
             panel.setOpaque_(False)
             panel.setBackgroundColor_(NSColor.clearColor())
+            panel.setIgnoresMouseEvents_(False)
             panel.setHasShadow_(True)
             panel.setHidesOnDeactivate_(False)
-            panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
-
-            # WKWebView
-            from wenzi.ui.web_utils import lightweight_webview_config
-
-            config = lightweight_webview_config(shared=False)
-            webview = WKWebView.alloc().initWithFrame_configuration_(
-                NSMakeRect(0, 0, _PANEL_WIDTH, _PANEL_HEIGHT),
-                config,
+            panel.setCollectionBehavior_(
+                (1 << 0) | (1 << 4) | (1 << 8)
             )
-            webview.setAutoresizingMask_(0x12)
-            webview.setValue_forKey_(False, "drawsBackground")
-            panel.contentView().addSubview_(webview)
 
-            # Navigation delegate for page-load callback
-            nav_cls = _get_nav_delegate_class()
-            nav_delegate = nav_cls.alloc().init()
-            nav_delegate._panel_ref = self
-            webview.setNavigationDelegate_(nav_delegate)
+            # -- VFX background --
+            vfx = NSVisualEffectView.alloc().initWithFrame_(
+                NSMakeRect(0, 0, _PANEL_WIDTH, init_h)
+            )
+            vfx.setMaterial_(_VFX_MATERIAL_HUD)
+            vfx.setBlendingMode_(_VFX_BLENDING_BEHIND)
+            vfx.setState_(_VFX_STATE_ACTIVE)
+            vfx.setWantsLayer_(True)
+            vfx.layer().setCornerRadius_(_CORNER_RADIUS)
+            vfx.layer().setMasksToBounds_(True)
+            vfx.setAutoresizingMask_(0x12)  # flex W+H
+            panel.setContentView_(vfx)
+            self._vfx_view = vfx
 
             self._panel = panel
-            self._webview = webview
-            self._nav_delegate = nav_delegate
 
-            # Build config and load HTML
-            ai_base = "\u2728 AI"
-            if llm_info:
-                ai_base += f" ({llm_info})"
-
-            asr_title = "\U0001f3a4 ASR"
-            if stt_info:
-                asr_title += f"  ({stt_info})"
-
-            config_data = {
-                "asrTitle": asr_title,
-                "asrText": asr_text,
-                "statusText": ai_base,
-                "aiBase": ai_base,
-            }
-            html = load_template(
-                "streaming_overlay.html",
-                CONFIG=json.dumps(config_data, ensure_ascii=False),
-                RADIUS=str(_CORNER_RADIUS),
-            )
-            webview.loadHTMLString_baseURL_(
-                html, NSURL.fileURLWithPath_("/")
-            )
-
-            # Position at bottom-right
+            # -- Position at screen centre --
             screen = NSScreen.mainScreen()
-            target_x, target_y = 0, 0
             if screen:
                 sf = screen.visibleFrame()
-                target_x = sf.origin.x + sf.size.width - _PANEL_WIDTH - _SCREEN_MARGIN
-                target_y = sf.origin.y + _SCREEN_MARGIN
+                self._center_x = sf.origin.x + sf.size.width / 2.0
+                self._center_y = sf.origin.y + sf.size.height / 2.0
 
-            if animate_from_frame is not None:
-                from AppKit import NSAnimationContext
+            # Layout subviews, position, and show
+            self._layout_subviews(init_h)
+            target_frame = self._frame_for_height(init_h)
+            print(f"[SO] init_h={init_h}, center=({self._center_x},{self._center_y}), target={target_frame}")
+            panel.setFrame_display_(target_frame, True)
+            panel.orderFront_(None)
+            print(f"[SO] panel.frame()={panel.frame()}, alpha={panel.alphaValue()}, visible={panel.isVisible()}")
+            print(f"[SO] vfx subviews={self._vfx_view.subviews().count() if self._vfx_view else 'None'}")
 
-                panel.setFrame_display_(animate_from_frame, False)
-                panel.setAlphaValue_(0.0)
-                panel.orderFront_(None)
-
-                target_frame = NSMakeRect(
-                    target_x, target_y, _PANEL_WIDTH, _PANEL_HEIGHT
-                )
-                NSAnimationContext.beginGrouping()
-                ctx = NSAnimationContext.currentContext()
-                ctx.setDuration_(0.3)
-                panel.animator().setFrame_display_(target_frame, True)
-                panel.animator().setAlphaValue_(1.0)
-                NSAnimationContext.endGrouping()
-            else:
-                panel.setFrameOrigin_((target_x, target_y))
-                panel.orderFront_(None)
-
-            # Register global ESC key monitor
             self._register_key_tap()
-
-            # Start loading timer
             self._start_loading_timer()
-
             logger.debug("Streaming overlay shown")
-        except Exception:
+        except Exception as exc:
+            import traceback
+            print(f"[SO] EXCEPTION in show(): {exc}")
+            traceback.print_exc()
             logger.error("Failed to show streaming overlay", exc_info=True)
+
+    def _frame_for_height(self, h: float):
+        """Return an NSRect centred on screen with the given height."""
+        from Foundation import NSMakeRect
+
+        x = self._center_x - _PANEL_WIDTH / 2.0
+        y = self._center_y - h / 2.0
+        return NSMakeRect(x, y, _PANEL_WIDTH, h)
+
+    def _layout_subviews(self, panel_h: float) -> None:
+        """Position all subviews within the VFX view for a given panel height."""
+        from Foundation import NSMakeRect
+
+        if self._vfx_view is None:
+            return
+
+        # Remove existing subviews
+        for sv in list(self._vfx_view.subviews()):
+            sv.removeFromSuperview()
+
+        cw = _PANEL_WIDTH - _PADDING_H * 2
+        y = panel_h - _PADDING_V  # start from top
+
+        # ASR title
+        lh = 14
+        y -= lh
+        self._asr_title_label.setFrame_(
+            NSMakeRect(_PADDING_H, y, cw, lh)
+        )
+        self._vfx_view.addSubview_(self._asr_title_label)
+
+        # ASR text
+        y -= 2  # small gap
+        asr_h = min(self._text_content_height(self._asr_text_view), _ASR_MAX_HEIGHT)
+        asr_h = max(asr_h, 16)
+        y -= asr_h
+        self._asr_scroll.setFrame_(NSMakeRect(_PADDING_H, y, cw, asr_h))
+        self._vfx_view.addSubview_(self._asr_scroll)
+
+        # Separator
+        y -= _SECTION_SPACING
+        self._separator.setFrame_(NSMakeRect(_PADDING_H, y, cw, 1))
+        self._vfx_view.addSubview_(self._separator)
+        y -= _SECTION_SPACING
+
+        # Status label
+        y -= lh
+        self._status_label.setFrame_(NSMakeRect(_PADDING_H, y, cw, lh))
+        self._vfx_view.addSubview_(self._status_label)
+
+        # Stream text (fill remaining space)
+        y -= 2
+        stream_h = max(y - _PADDING_V, 16)
+        self._stream_scroll.setFrame_(
+            NSMakeRect(_PADDING_H, _PADDING_V, cw, stream_h)
+        )
+        self._vfx_view.addSubview_(self._stream_scroll)
+
+    def _compute_height(self) -> float:
+        """Compute ideal panel height from content."""
+        asr_h = min(
+            self._text_content_height(self._asr_text_view), _ASR_MAX_HEIGHT,
+        )
+        asr_h = max(asr_h, 16)
+        stream_h = self._text_content_height(self._stream_text_view)
+        stream_h = max(stream_h, 16)
+
+        total = (
+            _PADDING_V
+            + 14  # asr title
+            + 2 + asr_h
+            + _SECTION_SPACING + 1 + _SECTION_SPACING  # separator
+            + 14  # status label
+            + 2 + stream_h
+            + _PADDING_V
+        )
+        return max(_MIN_HEIGHT, min(total, _MAX_HEIGHT))
+
+    def _recalculate_height(self) -> None:
+        """Recompute panel height and animate the change."""
+        if self._panel is None:
+            return
+
+        new_h = self._compute_height()
+        try:
+            old_h = float(self._panel.frame().size.height)
+        except (TypeError, ValueError):
+            old_h = 0.0
+        if abs(new_h - old_h) < 2:
+            # Still relayout at current height (content may have changed)
+            self._layout_subviews(old_h)
+            return
+
+        from AppKit import NSAnimationContext
+
+        target = self._frame_for_height(new_h)
+        NSAnimationContext.beginGrouping()
+        ctx = NSAnimationContext.currentContext()
+        ctx.setDuration_(0.12)
+
+        def _after_resize():
+            self._layout_subviews(new_h)
+            self._vfx_view.setFrame_(
+                self._panel.contentView().bounds()
+                if self._panel
+                else self._vfx_view.frame()
+            )
+
+        ctx.setCompletionHandler_(_after_resize)
+        self._panel.animator().setFrame_display_(target, True)
+        NSAnimationContext.endGrouping()
+
+    @staticmethod
+    def _text_content_height(text_view) -> float:
+        """Measure the used height of an NSTextView's content."""
+        if text_view is None:
+            return 0
+        try:
+            lm = text_view.layoutManager()
+            tc = text_view.textContainer()
+            lm.ensureLayoutForTextContainer_(tc)
+            h = lm.usedRectForTextContainer_(tc).size.height
+            return float(h)
+        except (TypeError, ValueError, AttributeError):
+            return 0
+        except Exception:
+            return 0
+
+    # ------------------------------------------------------------------
+    # Text manipulation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _set_text(
+        text_view, text: str,
+        secondary: bool = False,
+        italic: bool = False,
+    ) -> None:
+        """Replace all text in an NSTextView."""
+        from AppKit import NSColor, NSFont, NSFontManager
+        from Foundation import (
+            NSAttributedString,
+            NSMutableDictionary,
+        )
+
+        attrs = NSMutableDictionary.dictionary()
+        if italic:
+            attrs["NSFont"] = NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
+                    NSFont.systemFontOfSize_(13), 1,  # NSItalicFontMask
+                )
+        else:
+            attrs["NSFont"] = NSFont.systemFontOfSize_(13)
+        if secondary:
+            attrs["NSColor"] = NSColor.secondaryLabelColor()
+        else:
+            attrs["NSColor"] = NSColor.labelColor()
+
+        astr = NSAttributedString.alloc().initWithString_attributes_(
+            text, attrs,
+        )
+        text_view.textStorage().setAttributedString_(astr)
+
+    @staticmethod
+    def _append_attributed(text_view, text: str, attrs: dict) -> None:
+        """Append attributed text and auto-scroll to bottom."""
+        from Foundation import NSAttributedString, NSMakeRange
+
+        astr = NSAttributedString.alloc().initWithString_attributes_(
+            text, attrs,
+        )
+        ts = text_view.textStorage()
+        ts.appendAttributedString_(astr)
+        text_view.scrollRangeToVisible_(NSMakeRange(ts.length(), 0))
 
     # ------------------------------------------------------------------
     # Key tap (ESC / Enter) — CGEventTap swallows the keys
     # ------------------------------------------------------------------
 
     def _register_key_tap(self) -> None:
-        """Create a CGEventTap that intercepts and swallows ESC / Enter."""
         if self._tap_runner is not None:
             return
         from wenzi import _cgeventtap as cg
@@ -266,7 +455,6 @@ class StreamingOverlayPanel:
         self._tap_runner.start(mask, self._key_tap_callback)
 
     def _key_tap_callback(self, proxy, event_type, event, refcon):
-        """CGEventTap callback — runs on the tap's background thread."""
         from wenzi import _cgeventtap as cg
 
         try:
@@ -283,24 +471,20 @@ class StreamingOverlayPanel:
             )
 
             if keycode == _ESC_KEY_CODE:
-                # Disable tap to prevent auto-repeat queueing
                 if self._tap_runner is not None and self._tap_runner.tap is not None:
                     cg.CGEventTapEnable(self._tap_runner.tap, False)
                 if self._cancel_event is not None:
                     self._cancel_event.set()
                 from PyObjCTools import AppHelper
 
-                # Marshal callbacks to the main thread — this callback
-                # runs on the CGEventTap background thread.
                 on_cancel = self._on_cancel
                 if on_cancel is not None:
                     AppHelper.callAfter(on_cancel)
                 AppHelper.callAfter(self._do_close)
                 logger.info("Streaming cancelled via ESC key")
-                return None  # swallow
+                return None
 
             if keycode == _RETURN_KEY_CODE and self._on_confirm_asr is not None:
-                # Disable tap to prevent auto-repeat queueing
                 if self._tap_runner is not None and self._tap_runner.tap is not None:
                     cg.CGEventTapEnable(self._tap_runner.tap, False)
                 from PyObjCTools import AppHelper
@@ -308,39 +492,37 @@ class StreamingOverlayPanel:
                 on_confirm = self._on_confirm_asr
                 AppHelper.callAfter(on_confirm)
                 logger.info("ASR confirmed via Enter key")
-                return None  # swallow
+                return None
 
         except Exception:
             logger.warning("Key tap callback error", exc_info=True)
         return event
 
     def _remove_key_tap(self) -> None:
-        """Disable and remove the CGEventTap."""
         if self._tap_runner is not None:
             self._tap_runner.stop()
             self._tap_runner = None
 
     # ------------------------------------------------------------------
-    # Loading timer (elapsed seconds while waiting for first chunk)
+    # Loading timer
     # ------------------------------------------------------------------
 
     def _start_loading_timer(self) -> None:
-        """Start a 1-second repeating timer that updates the status label."""
         self._stop_loading_timer()
         self._loading_seconds = 0
+        self._tick_count = 0
         try:
             from Foundation import NSTimer
 
             self._loading_timer = (
                 NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                    1.0, self, b"tickLoadingTimer:", None, True,
+                    0.5, self, b"tickLoadingTimer:", None, True,
                 )
             )
         except Exception:
             logger.error("Failed to start loading timer", exc_info=True)
 
     def _stop_loading_timer(self) -> None:
-        """Stop the loading timer if running."""
         if self._loading_timer is not None:
             try:
                 self._loading_timer.invalidate()
@@ -349,11 +531,23 @@ class StreamingOverlayPanel:
             self._loading_timer = None
 
     def tickLoadingTimer_(self, timer) -> None:
-        """NSTimer callback: update status label with elapsed seconds."""
-        self._loading_seconds += 1
-        self._eval_js(
-            f"setStatus({json.dumps(self._ai_label(f'⏳ {self._loading_seconds}s'))})"
-        )
+        self._tick_count += 1
+
+        # Animate "Transcribing..." dots (cycles every 3 ticks)
+        if self._transcribing and self._asr_text_view is not None:
+            dots = "." * ((self._tick_count % 3) + 1)
+            self._set_text(
+                self._asr_text_view, f"Transcribing{dots}",
+                secondary=True, italic=True,
+            )
+
+        # Update AI status every second (every 2 ticks at 0.5s interval)
+        if self._tick_count % 2 == 0:
+            self._loading_seconds += 1
+            if self._status_label is not None:
+                self._status_label.setStringValue_(
+                    self._ai_label(f"\u23f3 {self._loading_seconds}s")
+                )
 
     # ------------------------------------------------------------------
     # Streaming text updates (all thread-safe via callAfter)
@@ -365,25 +559,59 @@ class StreamingOverlayPanel:
 
         def _append():
             self._stop_loading_timer()
-            if self._webview is None:
+            if self._stream_text_view is None:
                 return
-            self._eval_js(
-                f"appendText({json.dumps(chunk)},{completion_tokens})"
-            )
+
+            from AppKit import NSColor, NSFont
+
+            # Clear thinking text if present
+            if self._has_thinking:
+                self._stream_text_view.textStorage().setAttributedString_(
+                    __import__("Foundation").NSAttributedString.alloc().init()
+                )
+                self._has_thinking = False
+
+            attrs = {
+                "NSFont": NSFont.systemFontOfSize_(13),
+                "NSColor": NSColor.labelColor(),
+            }
+            self._append_attributed(self._stream_text_view, chunk, attrs)
+
+            if completion_tokens and self._status_label:
+                self._status_label.setStringValue_(
+                    self._ai_label(f"Chars: \u2193{completion_tokens}")
+                )
+
+            self._recalculate_height()
 
         AppHelper.callAfter(_append)
 
     def append_thinking_text(self, chunk: str, thinking_tokens: int = 0) -> None:
-        """Append thinking/reasoning text in italic secondary color. Thread-safe."""
+        """Append thinking/reasoning text in italic. Thread-safe."""
         from PyObjCTools import AppHelper
 
         def _append():
             self._stop_loading_timer()
-            if self._webview is None:
+            if self._stream_text_view is None:
                 return
-            self._eval_js(
-                f"appendThinkingText({json.dumps(chunk)},{thinking_tokens})"
-            )
+
+            from AppKit import NSColor, NSFont, NSFontManager
+
+            self._has_thinking = True
+            attrs = {
+                "NSFont": NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
+                    NSFont.systemFontOfSize_(13), 1,  # NSItalicFontMask
+                ),
+                "NSColor": NSColor.tertiaryLabelColor(),
+            }
+            self._append_attributed(self._stream_text_view, chunk, attrs)
+
+            if thinking_tokens and self._status_label:
+                self._status_label.setStringValue_(
+                    self._ai_label(f"\u25b6 Thinking: {thinking_tokens} chars")
+                )
+
+            self._recalculate_height()
 
         AppHelper.callAfter(_append)
 
@@ -392,20 +620,21 @@ class StreamingOverlayPanel:
         from PyObjCTools import AppHelper
 
         def _update():
-            if self._webview is None:
-                return
-            self._eval_js(f"setStatus({json.dumps(text)})")
+            if self._status_label is not None:
+                self._status_label.setStringValue_(text)
 
         AppHelper.callAfter(_update)
 
     def set_asr_text(self, text: str) -> None:
-        """Update the ASR label text after transcription completes. Thread-safe."""
+        """Update the ASR text after transcription completes. Thread-safe."""
         from PyObjCTools import AppHelper
 
         def _update():
-            if self._webview is None:
+            if self._asr_text_view is None:
                 return
-            self._eval_js(f"setAsrText({json.dumps(text)})")
+            self._transcribing = False
+            self._set_text(self._asr_text_view, text)
+            self._recalculate_height()
 
         AppHelper.callAfter(_update)
 
@@ -426,11 +655,27 @@ class StreamingOverlayPanel:
 
         def _update():
             self._stop_loading_timer()
-            if self._webview is None:
+            if self._status_label is None:
                 return
-            self._eval_js(
-                f"setComplete({json.dumps(usage) if usage else 'null'})"
-            )
+
+            if usage and usage.get("total_tokens"):
+                prompt = usage.get("prompt_tokens", 0)
+                completion = usage.get("completion_tokens", 0)
+                total = usage["total_tokens"]
+                cached = usage.get("prompt_tokens_details", {}).get(
+                    "cached_tokens", 0
+                )
+                if cached:
+                    up = f"\u2191{cached}+{prompt - cached}"
+                else:
+                    up = f"\u2191{prompt}"
+                label = (
+                    f"{self._ai_label('')}  "
+                    f"Tokens: {total} ({up} \u2193{completion})"
+                )
+            else:
+                label = self._ai_label("")
+            self._status_label.setStringValue_(label)
 
         AppHelper.callAfter(_update)
 
@@ -439,9 +684,13 @@ class StreamingOverlayPanel:
         from PyObjCTools import AppHelper
 
         def _clear():
-            if self._webview is None:
+            if self._stream_text_view is None:
                 return
-            self._eval_js("clearText()")
+            self._stream_text_view.textStorage().setAttributedString_(
+                __import__("Foundation").NSAttributedString.alloc().init()
+            )
+            self._has_thinking = False
+            self._recalculate_height()
 
         AppHelper.callAfter(_clear)
 
@@ -450,11 +699,7 @@ class StreamingOverlayPanel:
     # ------------------------------------------------------------------
 
     def close_with_delay(self, delay: float = _CLOSE_DELAY) -> None:
-        """Close the overlay after *delay* seconds, with fade-out animation.
-
-        If the mouse cursor is hovering over the panel when the timer fires,
-        the close is postponed until the cursor leaves. Thread-safe.
-        """
+        """Close after *delay* seconds, postponed if mouse is hovering. Thread-safe."""
         from PyObjCTools import AppHelper
 
         def _schedule():
@@ -473,7 +718,6 @@ class StreamingOverlayPanel:
         AppHelper.callAfter(_schedule)
 
     def _delayedCloseCheck_(self, timer) -> None:
-        """NSTimer callback: fade out if mouse is not hovering, else recheck."""
         self._close_timer = None
         if self._panel is None:
             return
@@ -484,7 +728,8 @@ class StreamingOverlayPanel:
 
                 self._close_timer = (
                     NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                        _HOVER_RECHECK_INTERVAL, self, b"_delayedCloseCheck:", None, False,
+                        _HOVER_RECHECK_INTERVAL,
+                        self, b"_delayedCloseCheck:", None, False,
                     )
                 )
             except Exception:
@@ -493,7 +738,6 @@ class StreamingOverlayPanel:
             self._fade_out_and_close()
 
     def _is_mouse_over_panel(self) -> bool:
-        """Return True if the mouse cursor is inside the panel frame."""
         try:
             from AppKit import NSEvent
             from Foundation import NSPointInRect
@@ -504,7 +748,6 @@ class StreamingOverlayPanel:
             return False
 
     def _fade_out_and_close(self) -> None:
-        """Animate the panel to transparent, then clean up."""
         if self._panel is None:
             return
         try:
@@ -520,7 +763,6 @@ class StreamingOverlayPanel:
             self._do_close()
 
     def _stop_close_timer(self) -> None:
-        """Cancel any pending delayed-close timer."""
         if self._close_timer is not None:
             try:
                 self._close_timer.invalidate()
@@ -529,35 +771,38 @@ class StreamingOverlayPanel:
             self._close_timer = None
 
     def _do_close(self) -> None:
-        """Immediate cleanup — shared by close() and fade-out completion."""
         self._stop_loading_timer()
         self._stop_close_timer()
         self._remove_key_tap()
         self._cancel_event = None
         self._on_cancel = None
         self._on_confirm_asr = None
-        self._page_loaded = False
-        self._pending_js.clear()
+        self._has_thinking = False
+        self._transcribing = False
 
         if self._panel is not None:
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
 
-        from wenzi.ui.web_utils import cleanup_webview
-
-        cleanup_webview(self._webview, handler_name=None)
-        if self._nav_delegate is not None:
-            self._nav_delegate._panel_ref = None
-        self._webview = None
-        self._nav_delegate = None
+        self._vfx_view = None
+        self._asr_title_label = None
+        self._asr_text_view = None
+        self._asr_scroll = None
+        self._separator = None
+        self._status_label = None
+        self._stream_text_view = None
+        self._stream_scroll = None
         logger.debug("Streaming overlay closed")
 
     def close_now(self) -> None:
-        """Close and clean up the overlay panel. Must be on main thread."""
+        """Close and clean up immediately. Must be on main thread."""
         self._do_close()
 
     def close(self) -> None:
-        """Close and clean up the overlay panel immediately. Thread-safe."""
+        """Close and clean up immediately. Thread-safe."""
         from PyObjCTools import AppHelper
 
         AppHelper.callAfter(self._do_close)

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -13,21 +13,21 @@ import threading
 logger = logging.getLogger(__name__)
 
 # Panel dimensions
-_PANEL_WIDTH = 420
-_MIN_HEIGHT = 80
-_MAX_HEIGHT = 360
-_CORNER_RADIUS = 10
-_PADDING_H = 14
-_PADDING_V = 10
-_SECTION_SPACING = 8
-_ASR_MAX_HEIGHT = 60  # max before ASR section scrolls
-_LABEL_HEIGHT = 14
-_HINT_GAP = 8
-_PROGRESS_HEIGHT = 3
-_PROGRESS_CORNER = 1.5
+_PANEL_WIDTH = 504
+_MIN_HEIGHT = 96
+_MAX_HEIGHT = 432
+_CORNER_RADIUS = 12
+_PADDING_H = 17
+_PADDING_V = 12
+_SECTION_SPACING = 10
+_ASR_MAX_HEIGHT = 72  # max before ASR section scrolls
+_LABEL_HEIGHT = 17
+_HINT_GAP = 10
+_PROGRESS_HEIGHT = 3.6
+_PROGRESS_CORNER = 1.8
 
 # Font
-_FONT_SIZE = 13
+_FONT_SIZE = 15.6
 
 # Key codes
 _ESC_KEY_CODE = 53
@@ -102,7 +102,7 @@ class StreamingOverlayPanel:
         from AppKit import NSColor, NSFont, NSTextField
 
         label = NSTextField.labelWithString_(text)
-        label.setFont_(NSFont.systemFontOfSize_weight_(9.5, 0.23))
+        label.setFont_(NSFont.systemFontOfSize_weight_(11.4, 0.23))
         label.setTextColor_(NSColor.tertiaryLabelColor())
         label.setSelectable_(False)
         label.setDrawsBackground_(False)

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -5,28 +5,28 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 :root {
-    --bg: rgba(255, 255, 255, 0.20);
+    --bg: rgba(255, 255, 255, 0.65);
     --text: #1d1d1f;
     --secondary: #86868b;
     --border: rgba(0, 0, 0, 0.08);
     --accent: #007aff;
     --item-hover: rgba(0, 0, 0, 0.06);
-    --item-selected: rgba(0, 122, 255, 0.22);
+    --item-selected: rgba(0, 122, 255, 0.16);
     --item-selected-text: #003d99;
     --input-bg: transparent;
     --shadow: rgba(0, 0, 0, 0.06);
-    --specular: rgba(255, 255, 255, 0.7);
+    --specular: rgba(255, 255, 255, 0.85);
     --glass-badge: rgba(0, 0, 0, 0.06);
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --bg: rgba(40, 40, 42, 0.25);
+        --bg: rgba(50, 50, 55, 0.55);
         --text: #e5e5e7;
         --secondary: #98989d;
         --border: rgba(255, 255, 255, 0.10);
         --accent: #0a84ff;
         --item-hover: rgba(255, 255, 255, 0.08);
-        --item-selected: rgba(10, 132, 255, 0.32);
+        --item-selected: rgba(10, 132, 255, 0.25);
         --item-selected-text: #64d2ff;
         --input-bg: transparent;
         --shadow: rgba(0, 0, 0, 0.3);
@@ -38,22 +38,24 @@
 html, body {
     height: 100%; overflow: hidden;
     font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
-    background: var(--bg); color: var(--text);
+    color: var(--text);
     -webkit-user-select: none; user-select: none;
 }
+html { background: transparent; }
 body {
     display: flex; flex-direction: column;
-    /* Specular top-edge highlight — simulates light on glass */
-    border-top: 0.5px solid var(--specular);
-    border-radius: 16px 16px 0 0;
+    background: var(--bg);
+    -webkit-backdrop-filter: blur(40px) saturate(1.8);
+    backdrop-filter: blur(40px) saturate(1.8);
 }
 
 /* Main content: left panel + preview */
 .main-content {
     display: none; flex: 1; min-height: 0;
+    opacity: 0; transition: opacity 0.18s ease;
 }
 .main-content.visible {
-    display: flex;
+    display: flex; opacity: 1;
 }
 .left-panel {
     width: 440px; flex-shrink: 0;
@@ -113,7 +115,7 @@ body {
 /* Search bar */
 .search-bar {
     display: flex; align-items: center; gap: 10px;
-    padding: 14px 18px;
+    padding: 16px 20px;
     background: var(--input-bg);
     border-bottom: 0.5px solid var(--border);
     flex-shrink: 0;
@@ -122,12 +124,12 @@ body {
 /* Subtle bottom fade instead of hard line */
 .search-bar::after {
     content: ''; position: absolute;
-    left: 18px; right: 18px; bottom: -0.5px; height: 0.5px;
+    left: 20px; right: 20px; bottom: -0.5px; height: 0.5px;
     background: linear-gradient(90deg, transparent, var(--border), transparent);
     pointer-events: none;
 }
 .search-icon {
-    width: 22px; height: 22px; flex-shrink: 0;
+    width: 26px; height: 26px; flex-shrink: 0;
     color: var(--secondary);
     cursor: grab;
 }
@@ -137,7 +139,7 @@ body {
 }
 .search-input {
     flex: 1; border: none; outline: none;
-    font-size: 18px; font-family: inherit;
+    font-size: 22px; font-family: inherit;
     background: transparent; color: var(--text);
     caret-color: var(--accent);
 }
@@ -212,8 +214,8 @@ body {
 }
 .result-item {
     display: flex; align-items: center;
-    padding: 8px 12px; cursor: default;
-    transition: background 0.15s, box-shadow 0.15s;
+    padding: 10px 14px; cursor: default;
+    transition: background 0.2s ease;
     gap: 12px;
     box-sizing: border-box;
     overflow: hidden;
@@ -222,16 +224,16 @@ body {
 }
 .icon-wrap {
     position: relative; flex-shrink: 0;
-    width: 36px; height: 36px;
+    width: 40px; height: 40px;
 }
 .result-item .icon {
-    width: 36px; height: 36px; flex-shrink: 0;
-    border-radius: 8px;
+    width: 40px; height: 40px; flex-shrink: 0;
+    border-radius: 9px;
     image-rendering: -webkit-optimize-contrast;
 }
 .result-item .icon-placeholder {
     background-color: var(--secondary);
-    -webkit-mask-size: 22px 22px;
+    -webkit-mask-size: 24px 24px;
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-position: center;
     opacity: 0.35;
@@ -246,13 +248,8 @@ body {
     line-height: 1;
 }
 #placeholder-mask-style { display: none; }
-.result-item:hover:not(.selected) {
-    background: var(--item-hover);
-}
 .result-item.selected {
     background: var(--item-selected);
-    box-shadow: inset 0 0.5px 0 0 rgba(255, 255, 255, 0.25),
-                inset 0 0 0 0.5px rgba(0, 122, 255, 0.2);
 }
 .result-item .left {
     display: flex; flex-direction: column; gap: 2px;
@@ -287,7 +284,8 @@ body {
     border: none; border-radius: 9px;
     background: transparent; color: var(--secondary);
     font-size: 13px; line-height: 18px; text-align: center;
-    cursor: pointer; opacity: 0; transition: opacity 0.15s, background 0.15s, color 0.15s;
+    cursor: pointer; opacity: 0;
+    transition: opacity 0.2s ease, background 0.2s ease, color 0.2s ease, transform 0.2s ease;
     padding: 0;
 }
 .result-item.selected .delete-btn { opacity: 0.6; }
@@ -297,6 +295,7 @@ body {
 .result-item .delete-btn.confirm {
     opacity: 1; background: #ff3b30; color: #fff;
     font-size: 10px; padding: 0 6px; font-weight: 500;
+    transform: scale(1.05);
 }
 
 /* Empty state */
@@ -304,6 +303,7 @@ body {
     display: flex; align-items: center; justify-content: center;
     flex: 1; color: var(--secondary); font-size: 13px;
     padding: 20px;
+    transition: opacity 0.2s ease;
 }
 
 /* Loading spinner for async sources */
@@ -314,8 +314,9 @@ body {
     border-top-color: var(--accent);
     border-radius: 50%;
     animation: spin 0.6s linear infinite;
+    opacity: 0; transition: opacity 0.18s ease;
 }
-.search-spinner.visible { display: block; }
+.search-spinner.visible { display: block; opacity: 1; }
 @keyframes spin { to { transform: rotate(360deg); } }
 </style>
 </head>
@@ -378,7 +379,7 @@ var _settingHistoryValue = false;
 
 // --- Virtual scrolling ---
 var ITEM_HEIGHT = 0;  // measured from first rendered row
-var ITEM_HEIGHT_DEFAULT = 52;  // fallback before measurement
+var ITEM_HEIGHT_DEFAULT = 60;  // fallback before measurement
 var BUFFER_COUNT = 5;  // extra rows above/below viewport
 
 // --- DOM ---
@@ -592,6 +593,7 @@ function _renderVisibleRows() {
 }
 
 // --- Event delegation on resultList (replaces per-row listeners) ---
+var _mouseHoverTimer = null;
 resultList.addEventListener('mousemove', function(e) {
     if (e.clientX === _lastMouseX && e.clientY === _lastMouseY) return;
     _lastMouseX = e.clientX;
@@ -600,12 +602,23 @@ resultList.addEventListener('mousemove', function(e) {
     if (!row) return;
     var idx = parseInt(row.getAttribute('data-idx'), 10);
     if (isNaN(idx) || idx === selectedIndex) return;
-    // Swap selected class without full re-render
-    var prev = _spacer.querySelector('.result-item.selected');
-    if (prev) prev.className = 'result-item';
-    row.className = 'result-item selected';
-    selectedIndex = idx;
-    updatePreview();
+    // Debounce: wait for mouse to settle before switching selection
+    if (_mouseHoverTimer) clearTimeout(_mouseHoverTimer);
+    _mouseHoverTimer = setTimeout(function() {
+        _mouseHoverTimer = null;
+        // Re-check the element under cursor is still the same row
+        var el = document.elementFromPoint(e.clientX, e.clientY);
+        if (!el) return;
+        var curRow = el.closest('.result-item');
+        if (!curRow) return;
+        var curIdx = parseInt(curRow.getAttribute('data-idx'), 10);
+        if (isNaN(curIdx) || curIdx === selectedIndex) return;
+        var prev = _spacer.querySelector('.result-item.selected');
+        if (prev) prev.className = 'result-item';
+        curRow.className = 'result-item selected';
+        selectedIndex = curIdx;
+        updatePreview();
+    }, 180);
 }, false);
 
 resultList.addEventListener('click', function(e) {

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 :root {
-    --bg: rgba(255, 255, 255, 0.65);
+    --bg: rgba(255, 255, 255, 0.70);
     --text: #1d1d1f;
     --secondary: #86868b;
     --border: rgba(0, 0, 0, 0.08);
@@ -15,12 +15,11 @@
     --item-selected-text: #003d99;
     --input-bg: transparent;
     --shadow: rgba(0, 0, 0, 0.06);
-    --specular: rgba(255, 255, 255, 0.85);
     --glass-badge: rgba(0, 0, 0, 0.06);
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --bg: rgba(50, 50, 55, 0.55);
+        --bg: rgba(50, 50, 55, 0.70);
         --text: #e5e5e7;
         --secondary: #98989d;
         --border: rgba(255, 255, 255, 0.10);
@@ -30,7 +29,6 @@
         --item-selected-text: #64d2ff;
         --input-bg: transparent;
         --shadow: rgba(0, 0, 0, 0.3);
-        --specular: rgba(255, 255, 255, 0.12);
         --glass-badge: rgba(255, 255, 255, 0.10);
     }
 }
@@ -44,9 +42,29 @@ html, body {
 html { background: transparent; }
 body {
     display: flex; flex-direction: column;
+    position: relative;
+    background: transparent;
+    border-radius: 18px;
+    overflow: hidden;
+}
+body::before {
+    content: '';
+    position: fixed; inset: 0;
+    border-radius: 18px;
     background: var(--bg);
     -webkit-backdrop-filter: blur(40px) saturate(1.8);
     backdrop-filter: blur(40px) saturate(1.8);
+    -webkit-backface-visibility: hidden;
+    z-index: -1;
+    pointer-events: none;
+    /* Micro-animation keeps the compositing layer alive so the
+       window server doesn't reclaim the backdrop-filter texture
+       during audio playback or other system events (WebKit #275919). */
+    animation: keepCompositing 1s linear infinite;
+}
+@keyframes keepCompositing {
+    from { opacity: 0.999; }
+    to   { opacity: 1; }
 }
 
 /* Main content: left panel + preview */
@@ -606,17 +624,10 @@ resultList.addEventListener('mousemove', function(e) {
     if (_mouseHoverTimer) clearTimeout(_mouseHoverTimer);
     _mouseHoverTimer = setTimeout(function() {
         _mouseHoverTimer = null;
-        // Re-check the element under cursor is still the same row
-        var el = document.elementFromPoint(e.clientX, e.clientY);
-        if (!el) return;
-        var curRow = el.closest('.result-item');
-        if (!curRow) return;
-        var curIdx = parseInt(curRow.getAttribute('data-idx'), 10);
-        if (isNaN(curIdx) || curIdx === selectedIndex) return;
         var prev = _spacer.querySelector('.result-item.selected');
         if (prev) prev.className = 'result-item';
-        curRow.className = 'result-item selected';
-        selectedIndex = curIdx;
+        row.className = 'result-item selected';
+        selectedIndex = idx;
         updatePreview();
     }, 180);
 }, false);

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -5,33 +5,33 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 :root {
-    --bg: rgba(255, 255, 255, 0.45);
+    --bg: rgba(255, 255, 255, 0.20);
     --text: #1d1d1f;
     --secondary: #86868b;
-    --border: rgba(0, 0, 0, 0.06);
+    --border: rgba(0, 0, 0, 0.08);
     --accent: #007aff;
-    --item-hover: rgba(0, 0, 0, 0.04);
-    --item-selected: rgba(0, 122, 255, 0.18);
+    --item-hover: rgba(0, 0, 0, 0.06);
+    --item-selected: rgba(0, 122, 255, 0.22);
     --item-selected-text: #003d99;
     --input-bg: transparent;
     --shadow: rgba(0, 0, 0, 0.06);
     --specular: rgba(255, 255, 255, 0.7);
-    --glass-badge: rgba(0, 0, 0, 0.05);
+    --glass-badge: rgba(0, 0, 0, 0.06);
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --bg: rgba(40, 40, 42, 0.45);
+        --bg: rgba(40, 40, 42, 0.25);
         --text: #e5e5e7;
         --secondary: #98989d;
-        --border: rgba(255, 255, 255, 0.08);
+        --border: rgba(255, 255, 255, 0.10);
         --accent: #0a84ff;
-        --item-hover: rgba(255, 255, 255, 0.06);
-        --item-selected: rgba(10, 132, 255, 0.28);
+        --item-hover: rgba(255, 255, 255, 0.08);
+        --item-selected: rgba(10, 132, 255, 0.32);
         --item-selected-text: #64d2ff;
         --input-bg: transparent;
         --shadow: rgba(0, 0, 0, 0.3);
         --specular: rgba(255, 255, 255, 0.12);
-        --glass-badge: rgba(255, 255, 255, 0.08);
+        --glass-badge: rgba(255, 255, 255, 0.10);
     }
 }
 * { box-sizing: border-box; margin: 0; padding: 0; }
@@ -127,10 +127,11 @@ body {
     pointer-events: none;
 }
 .search-icon {
-    font-size: 18px; color: var(--secondary); flex-shrink: 0;
-    line-height: 1;
+    width: 22px; height: 22px; flex-shrink: 0;
+    color: var(--secondary);
     cursor: grab;
 }
+.search-icon svg { display: block; width: 100%; height: 100%; }
 .search-icon:active {
     cursor: grabbing;
 }
@@ -326,7 +327,7 @@ body {
 </div>
 
 <div class="search-bar">
-    <span class="search-icon" id="search-icon">&#128269;</span>
+    <span class="search-icon" id="search-icon"><svg viewBox="0 0 18 18" fill="none" stroke="currentColor" stroke-width="2.0" stroke-linecap="round" stroke-linejoin="round"><circle cx="7.5" cy="7.5" r="5.2"/><line x1="11.2" y1="11.2" x2="15.5" y2="15.5"/></svg></span>
     <input class="search-input" id="search-input"
            type="text" placeholder="" autocomplete="off"
            autocorrect="off" autocapitalize="off" spellcheck="false">

--- a/src/wenzi/ui_helpers.py
+++ b/src/wenzi/ui_helpers.py
@@ -14,6 +14,41 @@ from .statusbar import InputWindow
 logger = logging.getLogger(__name__)
 
 
+def release_panel_surfaces(panel) -> None:
+    """Deactivate NSVisualEffectView(s) and shrink panel to release IOSurface memory.
+
+    Call before or after ``orderOut_`` when hiding any panel that uses
+    ``NSVisualEffectView`` with behind-window blending.  See CLAUDE.md
+    "NSVisualEffectView Memory Management" for why this is needed.
+
+    Safe to call on any NSPanel/NSWindow — no-ops gracefully if no VFX view.
+    """
+    if panel is None:
+        return
+    # Deactivate all NSVisualEffectViews (content view itself or direct subviews)
+    try:
+        from AppKit import NSVisualEffectView
+
+        cv = panel.contentView()
+        if isinstance(cv, NSVisualEffectView):
+            cv.setState_(0)  # NSVisualEffectStateInactive
+        if cv is not None:
+            for sv in cv.subviews():
+                if isinstance(sv, NSVisualEffectView):
+                    sv.setState_(0)
+    except Exception:
+        pass
+    # Shrink to 1×1 to force Core Animation to release the CA Whippet
+    # Drawable backing store (RGBA half-float IOSurface ~72 MB at retina).
+    try:
+        from Foundation import NSMakeRect
+
+        f = panel.frame()
+        panel.setFrame_display_(NSMakeRect(f.origin.x, f.origin.y, 1, 1), False)
+    except Exception:
+        pass
+
+
 def activate_for_dialog() -> None:
     """Set activation policy so modal dialogs can show from non-bundled process.
 

--- a/tests/audio/test_recording_indicator.py
+++ b/tests/audio/test_recording_indicator.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import MagicMock, patch
 
-from wenzi.audio.recording_indicator import RecordingIndicatorPanel, RecordingIndicatorView
+from wenzi.audio.recording_indicator import (
+    RecordingIndicatorPanel,
+    RecordingIndicatorView,
+    _build_subtitle,
+)
 
 
 class TestRecordingIndicatorView:
@@ -26,20 +30,30 @@ class TestRecordingIndicatorViewRecordingActive:
         assert view._recording_active is True
 
 
-class TestRecordingIndicatorViewMode:
-    def test_initial_mode_fields(self):
+class TestRecordingIndicatorViewSubtitle:
+    def test_initial_subtitle_is_none(self):
         view = RecordingIndicatorView()
-        assert view._mode_name is None
-        assert view._mode_nav == (False, False)
-        assert view._mode_attrs is None
-        assert view._arrow_attrs is None
+        assert view._subtitle is None
+        assert view._subtitle_attrs is None
 
-    def test_set_mode_fields(self):
+    def test_set_subtitle(self):
         view = RecordingIndicatorView()
-        view._mode_name = "Proofread"
-        view._mode_nav = (True, True)
-        assert view._mode_name == "Proofread"
-        assert view._mode_nav == (True, True)
+        view._subtitle = "Proofread"
+        assert view._subtitle == "Proofread"
+
+
+class TestBuildSubtitle:
+    def test_both_none(self):
+        assert _build_subtitle(None, None) is None
+
+    def test_mode_only(self):
+        assert _build_subtitle("Proofread", None) == "Proofread"
+
+    def test_device_only(self):
+        assert _build_subtitle(None, "MacBook Mic") == "MacBook Mic"
+
+    def test_both(self):
+        assert _build_subtitle("Proofread", "MacBook Mic") == "Proofread · MacBook Mic"
 
 
 class TestRecordingIndicatorPanel:
@@ -65,28 +79,32 @@ class TestRecordingIndicatorPanel:
         panel.enabled = True
         assert panel.enabled is True
 
-    def test_update_level_ema_smoothing(self):
+    def test_update_level_asymmetric_ema(self):
         panel = RecordingIndicatorPanel()
         panel._indicator_view = RecordingIndicatorView()
 
-        # First update: smoothed = 0.3 * 1.0 + 0.7 * 0.0 = 0.3
+        # First update: level=1.0 > smoothed=0.0 → attack (alpha=0.6)
+        # smoothed = 0.6 * 1.0 + 0.4 * 0.0 = 0.6
         panel.update_level(1.0)
-        assert abs(panel._smoothed_level - 0.3) < 0.01
+        assert abs(panel._smoothed_level - 0.6) < 0.01
 
-        # Second update: smoothed = 0.3 * 1.0 + 0.7 * 0.3 = 0.51
+        # Second update: level=1.0 > smoothed=0.6 → attack
+        # smoothed = 0.6 * 1.0 + 0.4 * 0.6 = 0.84
         panel.update_level(1.0)
-        assert abs(panel._smoothed_level - 0.51) < 0.01
+        assert abs(panel._smoothed_level - 0.84) < 0.01
 
-        # Drop to zero: smoothed = 0.3 * 0.0 + 0.7 * 0.51 = 0.357
+        # Drop to zero: level=0.0 < smoothed=0.84 → release (alpha=0.25)
+        # smoothed = 0.25 * 0.0 + 0.75 * 0.84 = 0.63
         panel.update_level(0.0)
-        assert abs(panel._smoothed_level - 0.357) < 0.01
+        assert abs(panel._smoothed_level - 0.63) < 0.01
 
     def test_update_level_without_view(self):
         panel = RecordingIndicatorPanel()
         panel._indicator_view = None
-        # Should not raise
+        # Should not raise; level=0.5 > smoothed=0.0 → attack
+        # smoothed = 0.6 * 0.5 + 0.4 * 0.0 = 0.3
         panel.update_level(0.5)
-        assert abs(panel._smoothed_level - 0.15) < 0.01
+        assert abs(panel._smoothed_level - 0.3) < 0.01
 
     def test_hide_cleans_up(self):
         panel = RecordingIndicatorPanel()
@@ -96,6 +114,8 @@ class TestRecordingIndicatorPanel:
         panel._panel = mock_panel
         panel._indicator_view = RecordingIndicatorView()
         panel._smoothed_level = 0.5
+        panel._mode_name = "Proofread"
+        panel._device_name = "Mic"
 
         panel.hide()
 
@@ -105,6 +125,8 @@ class TestRecordingIndicatorPanel:
         assert panel._panel is None
         assert panel._indicator_view is None
         assert panel._smoothed_level == 0.0
+        assert panel._mode_name is None
+        assert panel._device_name is None
 
     def test_hide_noop_when_not_shown(self):
         panel = RecordingIndicatorPanel()
@@ -144,44 +166,6 @@ class TestRecordingIndicatorPanel:
         assert panel.current_frame is mock_frame
         mock_panel.frame.assert_called_once()
 
-    def test_update_device_name_noop_when_no_panel(self):
-        panel = RecordingIndicatorPanel()
-        # Should not raise when panel is not shown
-        panel.update_device_name("Test Mic")
-        assert panel._panel is None
-
-    def test_update_device_name_noop_when_same_name(self):
-        panel = RecordingIndicatorPanel()
-        panel._panel = MagicMock()
-        view = RecordingIndicatorView(device_name="Same Mic")
-        panel._indicator_view = view
-
-        panel.update_device_name("Same Mic")
-        # Panel should not be resized since name didn't change
-        panel._panel.setContentSize_.assert_not_called()
-
-    def test_update_device_name_updates_view_and_resets_attrs(self):
-        panel = RecordingIndicatorPanel()
-        view = RecordingIndicatorView(device_name=None)
-        # Pre-set label attrs to verify they get reset
-        view._label_attrs = {"some": "attrs"}
-        panel._indicator_view = view
-        mock_panel = MagicMock()
-        panel._panel = mock_panel
-        mock_timer = MagicMock()
-        panel._timer = mock_timer
-
-        # Patch the whole method's internals since it imports AppKit/Foundation
-        # Just verify the state changes by letting the exception path handle it
-        try:
-            panel.update_device_name("New Mic")
-        except Exception:
-            pass
-
-        # These are set before any AppKit calls
-        assert view._device_name == "New Mic"
-        assert view._label_attrs is None
-
     def test_animate_out_calls_completion_when_no_panel(self):
         panel = RecordingIndicatorPanel()
         callback = MagicMock()
@@ -193,47 +177,101 @@ class TestRecordingIndicatorPanel:
         # Should not raise
         panel.animate_out()
 
-    def test_update_mode_sets_view_fields(self):
+    def test_update_mode_sets_subtitle(self):
         panel = RecordingIndicatorPanel()
         view = RecordingIndicatorView()
         panel._indicator_view = view
-        panel._panel = None  # no real panel — just test view updates
+        panel._panel = None
 
-        panel.update_mode("Translate EN", True, False)
+        panel.update_mode("Translate EN")
 
-        assert view._mode_name == "Translate EN"
-        assert view._mode_nav == (True, False)
+        assert panel._mode_name == "Translate EN"
+        assert view._subtitle == "Translate EN"
 
-    def test_update_mode_noop_when_same_values(self):
+    def test_update_mode_merges_with_device(self):
         panel = RecordingIndicatorPanel()
         view = RecordingIndicatorView()
-        view._mode_name = "Proofread"
-        view._mode_nav = (True, True)
-        view._mode_ns_str = "cached"  # should not be reset
         panel._indicator_view = view
+        panel._panel = None
+        panel._device_name = "MacBook Mic"
 
-        panel.update_mode("Proofread", True, True)
+        panel.update_mode("Proofread")
 
-        # Cached NSString should be preserved (no invalidation)
-        assert view._mode_ns_str == "cached"
+        assert view._subtitle == "Proofread · MacBook Mic"
+
+    def test_update_mode_noop_when_same_name(self):
+        panel = RecordingIndicatorPanel()
+        view = RecordingIndicatorView()
+        view._subtitle = "Proofread"
+        view._subtitle_ns_str = "cached"
+        panel._indicator_view = view
+        panel._mode_name = "Proofread"
+
+        panel.update_mode("Proofread")
+
+        # Cached NSString should be preserved
+        assert view._subtitle_ns_str == "cached"
 
     def test_update_mode_noop_when_no_view(self):
         panel = RecordingIndicatorPanel()
         panel._indicator_view = None
         # Should not raise
-        panel.update_mode("Proofread", False, True)
+        panel.update_mode("Proofread")
 
-    def test_clear_mode_resets_fields(self):
+    def test_clear_mode_clears_subtitle(self):
         panel = RecordingIndicatorPanel()
         view = RecordingIndicatorView()
-        view._mode_name = "Proofread"
-        view._mode_nav = (True, True)
+        view._subtitle = "Proofread"
         panel._indicator_view = view
+        panel._mode_name = "Proofread"
 
         panel.clear_mode()
 
-        assert view._mode_name is None
-        assert view._mode_nav == (False, False)
+        assert panel._mode_name is None
+        assert view._subtitle is None
+
+    def test_clear_mode_preserves_device_in_subtitle(self):
+        panel = RecordingIndicatorPanel()
+        view = RecordingIndicatorView()
+        view._subtitle = "Proofread · MacBook Mic"
+        panel._indicator_view = view
+        panel._mode_name = "Proofread"
+        panel._device_name = "MacBook Mic"
+
+        panel.clear_mode()
+
+        assert view._subtitle == "MacBook Mic"
+
+    def test_update_device_name_noop_when_no_panel(self):
+        panel = RecordingIndicatorPanel()
+        panel.update_device_name("Test Mic")
+        assert panel._panel is None
+
+    def test_update_device_name_noop_when_same_name(self):
+        panel = RecordingIndicatorPanel()
+        panel._panel = MagicMock()
+        panel._indicator_view = RecordingIndicatorView()
+        panel._device_name = "Same Mic"
+
+        panel.update_device_name("Same Mic")
+        # Panel should not be resized since name didn't change
+        panel._panel.setContentSize_.assert_not_called()
+
+    def test_update_device_name_updates_subtitle(self):
+        panel = RecordingIndicatorPanel()
+        view = RecordingIndicatorView()
+        panel._indicator_view = view
+        panel._panel = MagicMock()
+        panel._device_name = None
+
+        # Will fail on AppKit calls but state should be set first
+        try:
+            panel.update_device_name("New Mic")
+        except Exception:
+            pass
+
+        assert panel._device_name == "New Mic"
+        assert view._subtitle == "New Mic"
 
     def test_set_recording_active_updates_view(self):
         panel = RecordingIndicatorPanel()
@@ -256,38 +294,15 @@ class TestRecordingIndicatorPanel:
         panel.enabled = False  # prevent actual AppKit panel creation
         panel.show()
         # Panel not created (disabled), but verify the contract:
-        # a fresh RecordingIndicatorView always starts inactive
         view = RecordingIndicatorView()
         assert view._recording_active is False
 
     def test_clear_mode_noop_when_no_view(self):
         panel = RecordingIndicatorPanel()
         panel._indicator_view = None
-        # Should not raise
+        panel._mode_name = "Proofread"
         panel.clear_mode()
-
-    def test_update_device_name_preserves_panel_width(self):
-        """update_device_name should use current panel width, not _PANEL_WIDTH."""
-        panel = RecordingIndicatorPanel()
-        view = RecordingIndicatorView(device_name=None)
-        panel._indicator_view = view
-        mock_panel = MagicMock()
-        # Simulate panel already widened to 220 by update_mode
-        mock_frame = MagicMock()
-        mock_frame.size.width = 220
-        mock_panel.frame.return_value = mock_frame
-        panel._panel = mock_panel
-        panel._timer = MagicMock()
-
-        try:
-            panel.update_device_name("New Mic")
-        except Exception:
-            pass
-
-        # Verify setContentSize_ was called with width 220 (not 120)
-        if mock_panel.setContentSize_.called:
-            args = mock_panel.setContentSize_.call_args[0][0]
-            assert args[0] == 220.0
+        assert panel._mode_name is None
 
     def test_animate_out_stops_timer(self):
         panel = RecordingIndicatorPanel()
@@ -296,7 +311,6 @@ class TestRecordingIndicatorPanel:
         panel._timer = mock_timer
         panel._panel = mock_panel
 
-        # animate_out will try to import NSAnimationContext; mock it
         mock_ctx = MagicMock()
         mock_animation_context = MagicMock()
         mock_animation_context.currentContext.return_value = mock_ctx
@@ -305,8 +319,6 @@ class TestRecordingIndicatorPanel:
             "wenzi.audio.recording_indicator.RecordingIndicatorPanel.animate_out",
             wraps=panel.animate_out,
         ):
-            # Just verify the timer gets invalidated
-            # We can't easily test the full animation, so test the fallback path
             with patch.dict(
                 "sys.modules",
                 {"AppKit": MagicMock(NSAnimationContext=mock_animation_context)},

--- a/tests/controllers/test_recording_flow.py
+++ b/tests/controllers/test_recording_flow.py
@@ -222,6 +222,38 @@ class TestSoundDelay:
         mock_app._recorder.start.assert_called()
 
 
+class TestPressContextCapture:
+    @patch("wenzi.controllers.recording_flow.capture_input_context")
+    @patch("wenzi.controllers.recording_flow.get_frontmost_app")
+    def test_frontmost_app_captured_before_input_context(
+        self, mock_get_frontmost_app, mock_capture_input_context, flow
+    ):
+        """The original target app must be saved before slow AX context lookup."""
+        call_order: list[str] = []
+        target_app = object()
+
+        mock_get_frontmost_app.side_effect = (
+            lambda: call_order.append("frontmost") or target_app
+        )
+        mock_capture_input_context.side_effect = (
+            lambda _level: call_order.append("context") or None
+        )
+
+        async def _noop_session(_key_name: str) -> None:
+            return None
+
+        flow._recording_session = _noop_session
+
+        async def _test():
+            await flow._handle_press("fn")
+            await flow._current_task
+
+        run(_test())
+
+        assert call_order == ["frontmost", "context"]
+        assert flow._target_app is target_app
+
+
 class TestRecordAndRelease:
     @patch("wenzi.controllers.recording_flow.capture_input_context", return_value=None)
     @patch("PyObjCTools.AppHelper")
@@ -504,6 +536,84 @@ class TestStartTimeout:
         mock_app._recording_indicator.hide.assert_called()
         assert not flow.is_busy
 
+
+class TestStreamingTimeoutFallback:
+    def test_single_stream_timeout_replaces_partial_output(
+        self, flow, mock_app
+    ):
+        """Timeout fallback must replace partial streamed output."""
+
+        async def _gen():
+            yield "partial", None, False
+            yield "original text", None, "timeout"
+
+        mock_app._enhancer.enhance_stream.return_value = _gen()
+        flow._show_error_alert = MagicMock()
+
+        result = run(
+            flow._run_direct_single_stream("original text", asyncio.Event())
+        )
+
+        assert result == "original text"
+        mock_app._streaming_overlay.clear_text.assert_called_once()
+        assert mock_app._streaming_overlay.append_text.call_args_list[-1].args == (
+            "original text",
+        )
+        assert (
+            mock_app._streaming_overlay.append_text.call_args_list[-1].kwargs
+            == {"completion_tokens": len("original text")}
+        )
+        mock_app._streaming_overlay.set_status.assert_called_with(
+            "\u26a0\ufe0f AI timed out, using original text"
+        )
+        flow._show_error_alert.assert_called_once_with("AI enhancement timed out")
+
+    def test_chain_stream_timeout_passes_original_text_to_next_step(
+        self, flow, mock_app
+    ):
+        """A timed-out step must not poison the next chain step input."""
+        step1_def = MagicMock()
+        step1_def.label = "Proofread"
+        step2_def = MagicMock()
+        step2_def.label = "Translate"
+        mock_app._enhancer.get_mode_definition.side_effect = (
+            lambda mode_id: {
+                "proofread": step1_def,
+                "translate": step2_def,
+            }.get(mode_id)
+        )
+
+        inputs: list[str] = []
+
+        def _make_stream(text: str, input_context=None):
+            inputs.append(text)
+
+            async def _gen():
+                if len(inputs) == 1:
+                    yield "partial", None, False
+                    yield "original text", None, "timeout"
+                else:
+                    yield "translated text", None, False
+
+            return _gen()
+
+        mock_app._enhancer.enhance_stream.side_effect = _make_stream
+        flow._show_error_alert = MagicMock()
+
+        result = run(
+            flow._run_direct_chain_stream(
+                "original text",
+                ["proofread", "translate"],
+                asyncio.Event(),
+            )
+        )
+
+        assert result == "translated text"
+        assert inputs == ["original text", "original text"]
+        flow._show_error_alert.assert_called_once_with("AI enhancement timed out")
+
+
+class TestOrphanedRecording:
     @patch("wenzi.controllers.recording_flow.capture_input_context", return_value=None)
     @patch("PyObjCTools.AppHelper")
     def test_orphaned_recording_cleaned_up(

--- a/tests/controllers/test_update_controller.py
+++ b/tests/controllers/test_update_controller.py
@@ -168,25 +168,25 @@ class TestUpdateControllerStart:
     def test_start_disabled_noop(self):
         app = _make_app({"enabled": False})
         ctrl = UpdateController(app)
-        with patch("threading.Thread") as mock_thread:
+        with patch("wenzi.controllers.update_controller.async_loop") as mock_loop:
             ctrl.start()
-            mock_thread.assert_not_called()
+            mock_loop.get_loop.assert_not_called()
 
-    def test_start_enabled_launches_thread(self):
+    def test_start_enabled_submits_check(self):
         app = _make_app()
         ctrl = UpdateController(app)
-        with patch("threading.Thread") as mock_thread:
-            mock_instance = MagicMock()
-            mock_thread.return_value = mock_instance
+        with patch("wenzi.controllers.update_controller.async_loop") as mock_loop:
             ctrl.start()
-            mock_thread.assert_called_once()
-            mock_instance.start.assert_called_once()
+            mock_loop.get_loop.assert_called_once()
+            mock_loop.get_loop().run_in_executor.assert_called_once_with(
+                None, ctrl._check_update,
+            )
 
 
 class TestUpdateControllerCheckUpdate:
     @patch("wenzi.controllers.update_controller._fetch_latest_release")
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_skip_dev_mode(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_skip_dev_mode(self, mock_async_loop, mock_fetch):
         app = _make_app()
         ctrl = UpdateController(app)
 
@@ -196,8 +196,8 @@ class TestUpdateControllerCheckUpdate:
         mock_fetch.assert_not_called()
 
     @patch("wenzi.controllers.update_controller._fetch_latest_release")
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_dev_version_env_override(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_dev_version_env_override(self, mock_async_loop, mock_fetch):
         mock_fetch.return_value = {
             "tag_name": "v99.0.0",
             "html_url": "https://example.com",
@@ -212,8 +212,8 @@ class TestUpdateControllerCheckUpdate:
             mock_helper.callAfter.assert_called_once()
 
     @patch("wenzi.controllers.update_controller._fetch_latest_release")
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_new_version_triggers_menu_update(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_new_version_triggers_menu_update(self, mock_async_loop, mock_fetch):
         mock_fetch.return_value = {
             "tag_name": "v99.0.0",
             "html_url": "https://github.com/Airead/WenZi/releases/tag/v99.0.0",
@@ -229,8 +229,8 @@ class TestUpdateControllerCheckUpdate:
             assert call_args[0][0] == ctrl._apply_update_menu
 
     @patch("wenzi.controllers.update_controller._fetch_latest_release")
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_same_version_no_menu_update(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_same_version_no_menu_update(self, mock_async_loop, mock_fetch):
         mock_fetch.return_value = {
             "tag_name": "v0.1.2",
             "html_url": "https://example.com",
@@ -244,8 +244,8 @@ class TestUpdateControllerCheckUpdate:
             mock_helper.callAfter.assert_not_called()
 
     @patch("wenzi.controllers.update_controller._fetch_latest_release", return_value=None)
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_fetch_failure_no_crash(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_fetch_failure_no_crash(self, mock_async_loop, mock_fetch):
         app = _make_app()
         ctrl = UpdateController(app)
 
@@ -253,8 +253,8 @@ class TestUpdateControllerCheckUpdate:
             ctrl._check_update()  # should not raise
 
     @patch("wenzi.controllers.update_controller._fetch_latest_release")
-    @patch("wenzi.controllers.update_controller.threading.Timer")
-    def test_always_schedules_next(self, mock_timer_cls, mock_fetch):
+    @patch("wenzi.controllers.update_controller.async_loop")
+    def test_always_schedules_next(self, mock_async_loop, mock_fetch):
         mock_fetch.return_value = None
         app = _make_app()
         ctrl = UpdateController(app)
@@ -262,8 +262,7 @@ class TestUpdateControllerCheckUpdate:
         with patch("wenzi.__version__", "0.1.2"):
             ctrl._check_update()
 
-        mock_timer_cls.assert_called_once()
-        mock_timer_cls.return_value.start.assert_called_once()
+        mock_async_loop.call_later.assert_called_once()
 
 
 class TestUpdateControllerMenuClick:
@@ -552,7 +551,7 @@ class TestAutoUpdateIntegration:
         }
 
         with patch("wenzi.controllers.update_controller._fetch_latest_release", return_value=release_data), \
-             patch("wenzi.controllers.update_controller.threading.Timer"), \
+             patch("wenzi.controllers.update_controller.async_loop"), \
              patch("wenzi.__version__", "0.1.2"), \
              patch("PyObjCTools.AppHelper"):
             app = _make_app()

--- a/tests/enhance/test_enhancer.py
+++ b/tests/enhance/test_enhancer.py
@@ -1734,10 +1734,11 @@ class TestTextEnhancerEnhanceStream:
                 results.append((chunk, usage, is_thinking))
 
         asyncio.run(collect())
-        # With max_retries=0, single attempt fails and yields error thinking text
-        assert len(results) == 1
-        assert results[0][2] == "retry"  # is_thinking
+        # With max_retries=0, single attempt fails and yields error + original text
+        assert len(results) == 2
+        assert results[0][2] == "retry"
         assert "all 1 attempts failed" in results[0][0]
+        assert results[1] == ("original text", None, "timeout")
 
 
 class TestEnhanceStreamYields3Tuples:
@@ -1799,7 +1800,7 @@ class TestConnectionTimeoutRetry:
         """Verify defaults when config keys are absent."""
         with patch("wenzi.enhance.enhancer.TextEnhancer._init_providers"):
             enhancer = TextEnhancer(_make_config())
-        assert enhancer._connection_timeout == 30
+        assert enhancer._connection_timeout == 10
         assert enhancer._max_retries == 2
 
     def test_enhance_stream_connection_timeout_retry_success(self):
@@ -1879,18 +1880,18 @@ class TestConnectionTimeoutRetry:
         with patch("wenzi.enhance.enhancer.asyncio.sleep", new_callable=AsyncMock):
             asyncio.run(collect())
 
-        # All yields should be retry (retry status + final error)
-        assert all(r[2] == "retry" for r in results)
-        # Should have 2 retry messages + 1 final error = 3 retry yields
-        assert len(results) == 3
+        # 2 retry messages + 1 final error + 1 timeout fallback = 4 yields
+        assert len(results) == 4
+        assert results[0][2] == "retry"
         assert "retrying in 2s" in results[0][0]
         assert "1/2" in results[0][0]
+        assert results[1][2] == "retry"
         assert "retrying in 4s" in results[1][0]
         assert "2/2" in results[1][0]
+        assert results[2][2] == "retry"
         assert "all 3 attempts failed" in results[2][0]
-        # No content yields
-        content = [r for r in results if r[2] is False]
-        assert len(content) == 0
+        # Final yield is original text as timeout fallback
+        assert results[3] == ("hello", None, "timeout")
 
 
 class TestRateLimitHandling:

--- a/tests/plugins/test_cc_sessions_scanner.py
+++ b/tests/plugins/test_cc_sessions_scanner.py
@@ -638,6 +638,14 @@ class TestProjectNameResolution:
         repo.mkdir()
         subprocess.run(["git", "init"], cwd=repo, capture_output=True, check=True)
         subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        subprocess.run(
             ["git", "remote", "add", "origin", "git@github.com:Airead/WenZi.git"],
             cwd=repo, capture_output=True, check=True,
         )

--- a/tests/scripting/test_api_hotkey.py
+++ b/tests/scripting/test_api_hotkey.py
@@ -168,7 +168,10 @@ class TestToggleLeader:
     def test_sticky_subkey_executes_and_closes(self, mock_helper, mock_exec):
         _, api = self._make_api()
         api.toggle_leader("cmd_d")
-        result = api._on_press("w")
+        # Mock Quartz so CGEventSourceFlagsState returns 0 (no modifiers held),
+        # avoiding flaky failures when real system modifier state leaks in.
+        with patch("Quartz.CGEventSourceFlagsState", return_value=0):
+            result = api._on_press("w")
         assert result is True
         assert api._active_leader is None
         assert api._sticky_leader is False

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -23,6 +23,12 @@ from wenzi.hotkey import (
 )
 
 
+def _flush():
+    """Wait for all pending hotkey executor tasks to complete."""
+    from wenzi.hotkey import _hotkey_executor
+    _hotkey_executor.submit(lambda: None).result(timeout=1.0)
+
+
 class TestNameToVk:
     def test_regular_key(self):
         assert _name_to_vk("a") == 0
@@ -611,6 +617,7 @@ class TestMultiHotkeyCancelKey:
         listener = MultiHotkeyListener(["fn"], on_press, MagicMock())
 
         listener._handle_press("fn")
+        _flush()
         result = listener._handle_press("space")
         assert on_press.call_count == 1
         assert result is False
@@ -725,6 +732,7 @@ class TestMultiHotkeyModeNav:
 
         listener._handle_press("fn")
         result = listener._handle_press("left")
+        _flush()
         on_mode_prev.assert_called_once()
         assert result is True  # swallowed
 
@@ -736,6 +744,7 @@ class TestMultiHotkeyModeNav:
 
         listener._handle_press("fn")
         result = listener._handle_press("up")
+        _flush()
         on_mode_prev.assert_called_once()
         assert result is True
 
@@ -747,6 +756,7 @@ class TestMultiHotkeyModeNav:
 
         listener._handle_press("fn")
         result = listener._handle_press("right")
+        _flush()
         on_mode_next.assert_called_once()
         assert result is True
 
@@ -758,6 +768,7 @@ class TestMultiHotkeyModeNav:
 
         listener._handle_press("fn")
         result = listener._handle_press("down")
+        _flush()
         on_mode_next.assert_called_once()
         assert result is True
 

--- a/tests/test_input.py
+++ b/tests/test_input.py
@@ -99,12 +99,12 @@ class TestPasteboardHelpers:
         assert result is False
 
     @patch("wenzi.input.time")
-    @patch("wenzi.input.threading")
+    @patch("wenzi.input.async_loop")
     @patch("wenzi.input.subprocess")
     @patch("wenzi.input._set_pasteboard_concealed", return_value=True)
     @patch("wenzi.input._get_pasteboard_string", return_value="old content")
     def test_clipboard_restore_after_paste(
-        self, mock_get, mock_set_concealed, mock_subprocess, mock_threading, mock_time
+        self, mock_get, mock_set_concealed, mock_subprocess, mock_async_loop, mock_time
     ):
         from wenzi.input import _type_via_clipboard
 
@@ -115,9 +115,10 @@ class TestPasteboardHelpers:
         assert result is True
         mock_get.assert_called_once()
         mock_set_concealed.assert_called_once_with("new text")
-        # A restore thread should be started
-        mock_threading.Thread.assert_called_once()
-        mock_threading.Thread.return_value.start.assert_called_once()
+        # Clipboard should be restored via async_loop.call_later
+        mock_async_loop.call_later.assert_called_once()
+        args = mock_async_loop.call_later.call_args[0]
+        assert args[0] == 1.0  # delay
 
 
 class TestAppleScriptSafety:

--- a/tests/test_input_context.py
+++ b/tests/test_input_context.py
@@ -209,3 +209,5 @@ class TestParseDomainFromTitle:
     def test_domain_after_chrome_strip(self):
         from wenzi.input_context import _parse_domain_from_title
         assert _parse_domain_from_title("github.com - Google Chrome") == "github.com"
+
+

--- a/tests/ui/test_streaming_overlay.py
+++ b/tests/ui/test_streaming_overlay.py
@@ -27,6 +27,7 @@ def _mock_cgeventtap(monkeypatch):
     mock_cg.kCGEventTapOptionDefault = 0
     mock_cg.kCFRunLoopDefaultMode = MagicMock(value="kCFRunLoopDefaultMode")
     mock_cg.CGEventMaskBit.side_effect = lambda t: 1 << t
+    mock_cg.CGEventGetFlags.return_value = 0
 
     _runner_ready = threading.Event()
 
@@ -145,12 +146,12 @@ class TestStreamingOverlayPanel:
         assert result is None
         on_confirm.assert_called_once()
 
-    def test_enter_does_not_close(self, _mock_cgeventtap):
+    def test_enter_closes_panel(self, _mock_cgeventtap):
         panel = _make_panel()
         panel.show(asr_text="test", on_confirm_asr=MagicMock())
         _mock_cgeventtap.wait_for_tap()
         _mock_cgeventtap.simulate_key(panel, 36)
-        assert panel._panel is not None
+        assert panel._panel is None
 
     def test_enter_passes_through_without_callback(self, _mock_cgeventtap):
         panel = _make_panel()
@@ -296,3 +297,54 @@ class TestStreamingOverlayPanel:
     def test_ai_label_without_llm_info(self):
         panel = _make_panel()
         assert panel._ai_label("") == "\u2728 AI"
+
+    def test_complete_flag_set_by_set_complete(self):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        assert not panel._complete
+        panel.set_complete({"total_tokens": 100, "prompt_tokens": 50, "completion_tokens": 50})
+        assert panel._complete
+
+    def test_any_key_closes_when_complete(self, _mock_cgeventtap):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        panel._complete = True
+        _mock_cgeventtap.wait_for_tap()
+        result = _mock_cgeventtap.simulate_key(panel, 0)  # random key
+        assert result is not None  # key passes through (not swallowed)
+
+    def test_hint_label_created(self):
+        panel = _make_panel()
+        panel.show(asr_text="test", on_confirm_asr=lambda: None)
+        assert panel._hint_label is not None
+
+    def test_hint_label_without_confirm(self):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        assert panel._hint_label is not None
+
+    @patch("wenzi.input.set_clipboard_text")
+    def test_copy_cmd_c(self, mock_set_cb, _mock_cgeventtap):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        _mock_cgeventtap.wait_for_tap()
+        _mock_cgeventtap.cg.CGEventGetFlags.return_value = 1 << 20  # Cmd
+        _mock_cgeventtap.cg.CGEventGetIntegerValueField.return_value = 8  # C key
+        mock_event = 0xCAFE
+        result = panel._key_tap_callback(
+            None, _mock_cgeventtap.cg.kCGEventKeyDown, mock_event, None,
+        )
+        assert result is None  # swallowed
+
+    def test_progress_bar_created(self):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        assert panel._progress_view is not None
+
+    def test_close_delay_constant(self):
+        from wenzi.ui.streaming_overlay import _CLOSE_DELAY
+        assert _CLOSE_DELAY == 3.0
+
+    def test_font_size_constant(self):
+        from wenzi.ui.streaming_overlay import _FONT_SIZE
+        assert _FONT_SIZE == 13

--- a/tests/ui/test_streaming_overlay.py
+++ b/tests/ui/test_streaming_overlay.py
@@ -1,4 +1,4 @@
-"""Tests for the streaming overlay panel (WebView-based)."""
+"""Tests for the streaming overlay panel (native AppKit)."""
 
 from __future__ import annotations
 
@@ -16,32 +16,9 @@ def _mock_appkit(mock_appkit_modules):
 
 
 @pytest.fixture(autouse=True)
-def _mock_webkit(monkeypatch):
-    """Mock WebKit and navigation delegate for headless testing."""
-    mock_webkit_mod = MagicMock()
-    monkeypatch.setitem(sys.modules, "WebKit", mock_webkit_mod)
-
-    mock_nav_cls = MagicMock()
-    mock_nav_delegate = MagicMock()
-    mock_nav_cls.alloc.return_value.init.return_value = mock_nav_delegate
-
-    with patch(
-        "wenzi.ui.streaming_overlay._get_nav_delegate_class",
-        return_value=mock_nav_cls,
-    ):
-        yield
-
-
-@pytest.fixture(autouse=True)
 def _mock_cgeventtap(monkeypatch):
-    """Mock wenzi._cgeventtap for headless testing.
-
-    The production code now uses ``CGEventTapRunner`` from ``_cgeventtap``.
-    We mock the module so tests can run without accessibility permissions
-    and verify the callback logic.
-    """
+    """Mock wenzi._cgeventtap for headless testing."""
     mock_cg = MagicMock()
-    # Constants used in the callback
     mock_cg.kCGEventKeyDown = 10
     mock_cg.kCGEventTapDisabledByTimeout = 0xFFFFFFFE
     mock_cg.kCGKeyboardEventKeycode = 9
@@ -54,8 +31,6 @@ def _mock_cgeventtap(monkeypatch):
     _runner_ready = threading.Event()
 
     class _MockRunner:
-        """Fake CGEventTapRunner that stores the callback without threads."""
-
         def __init__(self):
             self.tap = MagicMock()
             self._callback = None
@@ -74,7 +49,6 @@ def _mock_cgeventtap(monkeypatch):
     mock_cg.CGEventTapRunner = _MockRunner
 
     monkeypatch.setattr("wenzi._cgeventtap", mock_cg, raising=False)
-    # Also patch the import inside _register_key_tap / _remove_key_tap
     monkeypatch.setitem(sys.modules, "wenzi._cgeventtap", mock_cg)
 
     class _CGHelper:
@@ -82,13 +56,11 @@ def _mock_cgeventtap(monkeypatch):
 
         @staticmethod
         def wait_for_tap(timeout=1.0):
-            """Wait for the runner's start() to be called."""
             _runner_ready.wait(timeout)
 
         @staticmethod
         def simulate_key(panel, keycode):
-            """Simulate a keyDown event through the panel's callback method."""
-            mock_event = 0xCAFE  # raw c_void_p integer
+            mock_event = 0xCAFE
             mock_cg.CGEventGetIntegerValueField.return_value = keycode
             return panel._key_tap_callback(
                 None, mock_cg.kCGEventKeyDown, mock_event, None,
@@ -103,84 +75,98 @@ def _make_panel():
     return StreamingOverlayPanel()
 
 
-def _show_and_load(panel, **kwargs):
-    """Show a panel and simulate page load so JS calls work."""
-    panel.show(**kwargs)
-    # Simulate WKWebView finishing page load
-    panel._on_page_loaded()
-    return panel
-
-
 class TestStreamingOverlayPanel:
     def test_initial_state(self):
         panel = _make_panel()
         assert panel._panel is None
-        assert panel._webview is None
+        assert panel._vfx_view is None
         assert panel._tap_runner is None
+        assert panel._stream_text_view is None
 
-    def test_show_creates_panel(self, _mock_appkit):
+    def test_show_creates_panel(self):
         panel = _make_panel()
         panel.show(asr_text="hello")
         assert panel._panel is not None
-        assert panel._webview is not None
+        assert panel._vfx_view is not None
+        assert panel._asr_text_view is not None
+        assert panel._stream_text_view is not None
 
-    def test_show_loads_html_with_config(self, _mock_appkit):
+    def test_show_sets_model_info(self):
         panel = _make_panel()
-        panel.show(asr_text="hello", stt_info="FunASR", llm_info="gpt-4o")
-        assert panel._webview is not None
-        # Verify loadHTMLString was called
-        panel._webview.loadHTMLString_baseURL_.assert_called_once()
-        html_arg = panel._webview.loadHTMLString_baseURL_.call_args[0][0]
-        assert "FunASR" in html_arg
-        assert "gpt-4o" in html_arg
-        assert "hello" in html_arg
+        panel.show(asr_text="test", stt_info="FunASR", llm_info="gpt-4o")
+        assert panel._llm_info == "gpt-4o"
 
-    def test_close_orders_out_panel(self, _mock_appkit):
+    def test_close_cleans_up(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         mock_ns_panel = panel._panel
         panel.close()
         mock_ns_panel.orderOut_.assert_called_with(None)
         assert panel._panel is None
-        assert panel._webview is None
+        assert panel._vfx_view is None
+        assert panel._stream_text_view is None
 
-    def test_show_registers_key_tap(self, _mock_appkit, _mock_cgeventtap):
+    def test_show_registers_key_tap(self, _mock_cgeventtap):
         panel = _make_panel()
         panel.show(asr_text="test", cancel_event=threading.Event())
         _mock_cgeventtap.wait_for_tap()
         assert panel._tap_runner is not None
-        assert panel._tap_runner._callback is not None
 
-    def test_close_removes_key_tap(self, _mock_appkit, _mock_cgeventtap):
+    def test_close_removes_key_tap(self, _mock_cgeventtap):
         panel = _make_panel()
         panel.show(asr_text="test", cancel_event=threading.Event())
         _mock_cgeventtap.wait_for_tap()
         panel.close()
         assert panel._tap_runner is None
 
-    def test_esc_handler_sets_cancel_event(self, _mock_appkit, _mock_cgeventtap):
+    def test_esc_sets_cancel_event(self, _mock_cgeventtap):
         panel = _make_panel()
         cancel_event = threading.Event()
         panel.show(asr_text="test", cancel_event=cancel_event)
         _mock_cgeventtap.wait_for_tap()
-
-        result = _mock_cgeventtap.simulate_key(panel, 53)  # ESC
-        assert result is None  # swallowed
+        result = _mock_cgeventtap.simulate_key(panel, 53)
+        assert result is None
         assert cancel_event.is_set()
 
-    def test_esc_handler_calls_on_cancel(self, _mock_appkit, _mock_cgeventtap):
-        """ESC should invoke on_cancel callback before closing."""
+    def test_esc_calls_on_cancel(self, _mock_cgeventtap):
         panel = _make_panel()
         on_cancel = MagicMock()
-        panel.show(
-            asr_text="test", cancel_event=threading.Event(), on_cancel=on_cancel
-        )
+        panel.show(asr_text="test", cancel_event=threading.Event(), on_cancel=on_cancel)
         _mock_cgeventtap.wait_for_tap()
-
         _mock_cgeventtap.simulate_key(panel, 53)
         on_cancel.assert_called_once()
 
-    def test_multiple_show_close_cycles(self, _mock_appkit):
+    def test_enter_calls_on_confirm_asr(self, _mock_cgeventtap):
+        panel = _make_panel()
+        on_confirm = MagicMock()
+        panel.show(asr_text="test", on_confirm_asr=on_confirm)
+        _mock_cgeventtap.wait_for_tap()
+        result = _mock_cgeventtap.simulate_key(panel, 36)
+        assert result is None
+        on_confirm.assert_called_once()
+
+    def test_enter_does_not_close(self, _mock_cgeventtap):
+        panel = _make_panel()
+        panel.show(asr_text="test", on_confirm_asr=MagicMock())
+        _mock_cgeventtap.wait_for_tap()
+        _mock_cgeventtap.simulate_key(panel, 36)
+        assert panel._panel is not None
+
+    def test_enter_passes_through_without_callback(self, _mock_cgeventtap):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        _mock_cgeventtap.wait_for_tap()
+        result = _mock_cgeventtap.simulate_key(panel, 36)
+        assert result is not None
+
+    def test_other_keys_not_swallowed(self, _mock_cgeventtap):
+        panel = _make_panel()
+        panel.show(asr_text="test")
+        _mock_cgeventtap.wait_for_tap()
+        result = _mock_cgeventtap.simulate_key(panel, 0)
+        assert result is not None
+
+    def test_multiple_show_close_cycles(self):
         panel = _make_panel()
         for _ in range(3):
             panel.show(asr_text="test")
@@ -188,88 +174,48 @@ class TestStreamingOverlayPanel:
             panel.close()
             assert panel._panel is None
 
-    def test_close_after_close_no_crash(self, _mock_appkit):
+    def test_close_after_close_no_crash(self):
         panel = _make_panel()
         panel.close()
         panel.close()
 
-    def test_append_text_after_close_no_crash(self, _mock_appkit):
+    def test_append_text_after_close_no_crash(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         panel.close()
         panel.append_text("more text")
 
-    def test_set_status_after_close_no_crash(self, _mock_appkit):
+    def test_set_status_after_close_no_crash(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         panel.close()
         panel.set_status("done")
 
-    def test_enter_handler_calls_on_confirm_asr(self, _mock_appkit, _mock_cgeventtap):
-        """Enter should invoke on_confirm_asr callback."""
-        panel = _make_panel()
-        on_confirm_asr = MagicMock()
-        panel.show(asr_text="test", on_confirm_asr=on_confirm_asr)
-        _mock_cgeventtap.wait_for_tap()
-
-        result = _mock_cgeventtap.simulate_key(panel, 36)  # Enter/Return
-        assert result is None  # swallowed
-        on_confirm_asr.assert_called_once()
-
-    def test_enter_does_not_close_overlay(self, _mock_appkit, _mock_cgeventtap):
-        """Enter should NOT close the overlay (caller handles closing)."""
-        panel = _make_panel()
-        panel.show(asr_text="test", on_confirm_asr=MagicMock())
-        _mock_cgeventtap.wait_for_tap()
-
-        _mock_cgeventtap.simulate_key(panel, 36)
-        assert panel._panel is not None
-
-    def test_enter_passes_through_without_callback(self, _mock_appkit, _mock_cgeventtap):
-        """Enter without on_confirm_asr should pass through."""
+    def test_set_asr_text_after_close_no_crash(self):
         panel = _make_panel()
         panel.show(asr_text="test")
-        _mock_cgeventtap.wait_for_tap()
+        panel.close()
+        panel.set_asr_text("new text")
 
-        result = _mock_cgeventtap.simulate_key(panel, 36)
-        assert result is not None  # not swallowed when no callback
-
-    def test_other_keys_not_swallowed(self, _mock_appkit, _mock_cgeventtap):
-        """Non-ESC/Enter keys should pass through."""
-        panel = _make_panel()
-        panel.show(asr_text="test")
-        _mock_cgeventtap.wait_for_tap()
-
-        result = _mock_cgeventtap.simulate_key(panel, 0)  # 'A' key
-        assert result is not None  # not swallowed
-
-    def test_show_without_cancel_event(self, _mock_appkit):
+    def test_show_without_cancel_event(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         assert panel._panel is not None
         assert panel._cancel_event is None
 
-    def test_show_with_animate_from_frame(self, _mock_appkit):
-        mock_appkit_mod = _mock_appkit.appkit
+    def test_show_with_animate_from_frame(self):
         panel = _make_panel()
         mock_frame = MagicMock()
         panel.show(asr_text="test", animate_from_frame=mock_frame)
         assert panel._panel is not None
-        panel._panel.setFrame_display_.assert_called_with(mock_frame, False)
-        panel._panel.setAlphaValue_.assert_called_with(0.0)
-        mock_appkit_mod.NSAnimationContext.beginGrouping.assert_called()
+        # Panel should be created and shown regardless of animate_from_frame
+        panel._panel.setFrame_display_.assert_called()
 
-    def test_show_without_animate_from_frame(self, _mock_appkit):
+    def test_show_positions_panel(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         assert panel._panel is not None
-        panel._panel.setFrameOrigin_.assert_called()
-        panel._panel.setFrame_display_.assert_not_called()
-
-    def test_show_positions_bottom_right(self, _mock_appkit):
-        panel = _make_panel()
-        panel.show(asr_text="test")
-        panel._panel.setFrameOrigin_.assert_called_once()
+        panel._panel.setFrame_display_.assert_called()
 
     def test_loading_timer_starts_on_show(self, _mock_appkit):
         mock_foundation = _mock_appkit.foundation
@@ -278,134 +224,23 @@ class TestStreamingOverlayPanel:
         mock_foundation.NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_.assert_called()
         assert panel._loading_timer is not None
 
-    def test_append_text_stops_loading_timer(self, _mock_appkit):
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        mock_timer = panel._loading_timer
-        panel.append_text("chunk")
-        mock_timer.invalidate.assert_called()
-        assert panel._loading_timer is None
-
-    def test_close_stops_loading_timer(self, _mock_appkit):
+    def test_close_stops_loading_timer(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         mock_timer = panel._loading_timer
         panel.close()
         mock_timer.invalidate.assert_called()
 
-    def test_append_text_calls_eval_js(self, _mock_appkit):
-        """append_text should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        panel.append_text("hello ", completion_tokens=5)
-        panel._webview.evaluateJavaScript_completionHandler_.assert_called()
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "appendText" in js_call
-        assert "hello " in js_call
-
-    def test_append_thinking_text_calls_eval_js(self, _mock_appkit):
-        """append_thinking_text should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        panel.append_thinking_text("reasoning...", thinking_tokens=5)
-        panel._webview.evaluateJavaScript_completionHandler_.assert_called()
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "appendThinkingText" in js_call
-
-    def test_set_status_calls_eval_js(self, _mock_appkit):
-        """set_status should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        panel.set_status("Step 1/2: Proofread")
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "setStatus" in js_call
-        assert "Step 1/2: Proofread" in js_call
-
-    def test_set_asr_text_calls_eval_js(self, _mock_appkit):
-        """set_asr_text should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="")
-        panel.set_asr_text("transcribed text")
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "setAsrText" in js_call
-        assert "transcribed text" in js_call
-
-    def test_clear_text_calls_eval_js(self, _mock_appkit):
-        """clear_text should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        panel.clear_text()
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "clearText" in js_call
-
-    def test_set_complete_calls_eval_js(self, _mock_appkit):
-        """set_complete should evaluate JS via webview."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test", llm_info="gpt-4o")
-        usage = {"prompt_tokens": 100, "completion_tokens": 50, "total_tokens": 150}
-        panel.set_complete(usage)
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "setComplete" in js_call
-        assert "150" in js_call
-
-    def test_set_complete_without_usage(self, _mock_appkit):
-        """set_complete without usage should pass null."""
-        panel = _make_panel()
-        _show_and_load(panel, asr_text="test")
-        panel.set_complete(None)
-        js_call = panel._webview.evaluateJavaScript_completionHandler_.call_args[0][0]
-        assert "setComplete(null)" in js_call
-
-    def test_pending_js_flushed_on_page_load(self, _mock_appkit):
-        """JS calls before page load should be queued and flushed."""
-        panel = _make_panel()
-        panel.show(asr_text="test")
-        assert not panel._page_loaded
-        # Queue some calls before page load
-        panel._eval_js("setStatus('hello')")
-        panel._eval_js("setAsrText('world')")
-        assert len(panel._pending_js) == 2
-        # Simulate page load
-        panel._on_page_loaded()
-        assert panel._page_loaded
-        assert len(panel._pending_js) == 0
-        # Combined JS should have been executed
-        panel._webview.evaluateJavaScript_completionHandler_.assert_called()
-
-    def test_pending_js_capped(self, _mock_appkit):
-        """_pending_js should not grow beyond _MAX_PENDING_JS."""
-        from wenzi.ui.streaming_overlay import _MAX_PENDING_JS
-
-        panel = _make_panel()
-        panel.show(asr_text="test")
-        assert not panel._page_loaded
-
-        # Queue more than the cap
-        for i in range(_MAX_PENDING_JS + 100):
-            panel._eval_js(f"call({i})")
-
-        assert len(panel._pending_js) == _MAX_PENDING_JS
-        # Most recent call should be kept
-        assert panel._pending_js[-1] == f"call({_MAX_PENDING_JS + 99})"
-        # Oldest should be dropped
-        assert panel._pending_js[0] == "call(100)"
-
-    def test_set_cancel_event_registers_tap(self, _mock_appkit, _mock_cgeventtap):
+    def test_set_cancel_event_registers_tap(self, _mock_cgeventtap):
         panel = _make_panel()
         panel.show(asr_text="test")
         _mock_cgeventtap.wait_for_tap()
-        panel._tap_runner = None  # simulate tap not yet created
+        panel._tap_runner = None
         cancel = threading.Event()
         panel.set_cancel_event(cancel)
         _mock_cgeventtap.wait_for_tap()
         assert panel._cancel_event is cancel
         assert panel._tap_runner is not None
-
-    def test_set_asr_text_after_close_no_crash(self, _mock_appkit):
-        panel = _make_panel()
-        panel.show(asr_text="test")
-        panel.close()
-        panel.set_asr_text("new text")
 
     def test_close_with_delay_schedules_timer(self, _mock_appkit):
         mock_foundation = _mock_appkit.foundation
@@ -415,7 +250,7 @@ class TestStreamingOverlayPanel:
         mock_foundation.NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_.assert_called()
         assert panel._close_timer is not None
 
-    def test_delayed_close_fires_when_mouse_outside(self, _mock_appkit):
+    def test_delayed_close_fires_when_mouse_outside(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         with patch(
@@ -427,7 +262,7 @@ class TestStreamingOverlayPanel:
             panel._delayedCloseCheck_(None)
             mock_fade.assert_called_once()
 
-    def test_delayed_close_rechecks_when_mouse_hovering(self, _mock_appkit):
+    def test_delayed_close_rechecks_when_hovering(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         with patch(
@@ -437,7 +272,7 @@ class TestStreamingOverlayPanel:
             panel._delayedCloseCheck_(None)
             assert panel._close_timer is not None
 
-    def test_close_cancels_delayed_close(self, _mock_appkit):
+    def test_close_cancels_delayed_close(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         panel.close_with_delay()
@@ -446,18 +281,18 @@ class TestStreamingOverlayPanel:
         mock_timer.invalidate.assert_called()
         assert panel._close_timer is None
 
-    def test_close_with_delay_after_close_no_crash(self, _mock_appkit):
+    def test_close_with_delay_after_close_no_crash(self):
         panel = _make_panel()
         panel.show(asr_text="test")
         panel.close()
         panel.close_with_delay()
 
-    def test_show_with_model_info_in_html(self, _mock_appkit):
-        """show() with stt_info and llm_info should embed them in HTML config."""
+    def test_ai_label_with_llm_info(self):
         panel = _make_panel()
-        panel.show(asr_text="test", stt_info="FunASR", llm_info="openai / gpt-4o")
-        assert panel._llm_info == "openai / gpt-4o"
-        html_arg = panel._webview.loadHTMLString_baseURL_.call_args[0][0]
-        # Config should contain both model names
-        assert "FunASR" in html_arg
-        assert "openai / gpt-4o" in html_arg
+        panel._llm_info = "gpt-4o"
+        assert panel._ai_label("") == "\u2728 AI (gpt-4o)"
+        assert panel._ai_label("\u23f3 3s") == "\u2728 AI (gpt-4o)  \u23f3 3s"
+
+    def test_ai_label_without_llm_info(self):
+        panel = _make_panel()
+        assert panel._ai_label("") == "\u2728 AI"

--- a/tests/ui/test_streaming_overlay.py
+++ b/tests/ui/test_streaming_overlay.py
@@ -347,4 +347,4 @@ class TestStreamingOverlayPanel:
 
     def test_font_size_constant(self):
         from wenzi.ui.streaming_overlay import _FONT_SIZE
-        assert _FONT_SIZE == 13
+        assert _FONT_SIZE == 15.6


### PR DESCRIPTION
## Summary

- **Recording flow**: capture target app context, handle AI enhancement timeout, improve streaming overlay with waveform indicator and frosted glass
- **Memory management**: release NSVisualEffectView IOSurface (~144 MB) on panel hide; add `release_panel_surfaces` helper in `ui_helpers.py`
- **Chooser panel**: migrate from NSVisualEffectView to CSS backdrop-filter for frosted glass, simplify panel lifecycle, add reveal animation, debounce mouse hover
- **Threading**: replace per-event thread creation with shared thread pools and async_loop timers
- **Tests**: sync test suite with all source changes, add recording flow controller tests

## Commits

- `5d071c6` fix(chooser): deactivate NSVisualEffectView when hidden to reclaim ~144 MB IOSurface memory
- `793c46d` refactor(indicator): replace bars with waveform, Tahoe-style frosted glass, simplified layout
- `1374f84` fix(indicator): improve subtitle readability and widen waveform on frosted glass
- `58bf0e6` fix(memory): release NSVisualEffectView IOSurface on panel hide, improve chooser glass
- `9df4a00` feat(recording): capture target app, handle AI timeout, improve streaming overlay
- `c0c46a7` docs: add recording shortcuts dev notes
- `8a85adb` refactor(threading): replace per-event threads with shared pools and async_loop timers
- `17e723c` fix(chooser): refine glass effect, add reveal animation, debounce mouse hover
- `a586c19` refactor(chooser): simplify panel lifecycle and remove dead code
- `b4c7d20` style(ui): scale recording indicator and streaming overlay by 1.2x
- `6fc152c` fix(tests): sync tests with recent source changes

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run pytest tests/ -v --cov=wenzi` — 3828 passed, 67% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)