### PR TITLE
feat(chooser): native NSVisualEffectView + default selection fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,21 +143,7 @@ self._panel = None
 
 When re-showing, re-activate the effect view (`setState_(1)`) **just before** `orderFront_`/`makeKeyAndOrderFront_`, so the IOSurface is only allocated while the panel is visible.
 
-**Note:** The chooser panel (`ChooserPanel`) does **not** use `NSVisualEffectView`. It uses CSS `backdrop-filter` for frosted glass — see "CSS backdrop-filter in Transparent WKWebView" below.
-
-## CSS backdrop-filter in Transparent WKWebView
-
-The chooser panel uses CSS `backdrop-filter: blur() saturate()` instead of `NSVisualEffectView` for frosted glass. This is inherently fragile in transparent WKWebViews ([WebKit #275919](https://bugs.webkit.org/show_bug.cgi?id=275919)). System events (audio playback, compositing changes) can invalidate the backdrop-filter texture, causing the panel to appear transparent.
-
-**Required architecture** (see `chooser.html`):
-
-1. **Separate compositing layer** — `backdrop-filter` must be on `body::before` (pseudo-element), NOT on `body` itself. DOM changes in the content layer must not invalidate the blur layer.
-2. **Keepalive animation** — A perpetual micro-animation (`opacity: 0.999→1`) on `body::before` forces WebKit to re-composite every frame, preventing texture reclamation.
-3. **GPU hint** — `-webkit-backface-visibility: hidden` on `body::before` to force a separate compositing layer.
-4. **Matching border-radius** — `body` must have the same `border-radius` and `overflow: hidden` as the native panel's corner radius to prevent edge artifacts.
-5. **Transparent html** — `html { background: transparent }`, only `body::before` carries the `--bg` tinted overlay.
-
-**When adding a new panel with frosted glass**, prefer `NSVisualEffectView` (stable, native). Only use CSS `backdrop-filter` if you need fine-grained control over blur radius/saturation and can tolerate the fragility.
+The chooser panel (`ChooserPanel`) uses `NSVisualEffectView` (Material Menu) with a fully transparent WKWebView on top. The VFX lifecycle is managed via `_activate_vfx()` / `_deactivate_vfx()` — see `chooser_panel.py`.
 
 ## LLM max_tokens Guard
 
@@ -178,7 +164,7 @@ Playing audio via HTML5 `new Audio(url).play()` in WKWebView triggers macOS Now 
 - **Chooser preview HTML** (no `wz` bridge): use `webkit.messageHandlers.chooser.postMessage({type: 'playAudio', url: url})`
 - The built-in handler is registered in `WebViewPanel._builtin_play_audio` and `ChooserPanel._play_audio_url`
 
-**ChooserPanel uses `AVAudioPlayer`** (AVFoundation) instead of `NSSound` (AppKit). `NSSound` operations interfere with AppKit window server compositing, which breaks CSS `backdrop-filter` in the chooser's transparent WKWebView. Download happens on a background thread; `play()` is dispatched to the main thread via `AppHelper.callAfter`.
+**ChooserPanel uses `AVAudioPlayer`** (AVFoundation) instead of `NSSound` (AppKit). `NSSound` operations interfere with AppKit window server compositing. Download happens on a background thread; `play()` is dispatched to the main thread via `AppHelper.callAfter`.
 
 ## CGEventTap — Use ctypes, Not PyObjC
 

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -189,7 +189,7 @@ class ChooserPanel:
     registered ChooserSource instances, and executes item actions.
     """
 
-    _INITIAL_WIDTH = 680
+    _INITIAL_WIDTH = 520
     _INITIAL_HEIGHT = 49  # bootstrap; JS updates after page load
     _MAX_TOTAL_RESULTS = 50
     _DEFERRED_ACTION_DELAY = 0.15  # seconds to let previous app regain focus

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -212,6 +212,7 @@ class ChooserPanel:
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
         self._webview = None
+        self._vfx_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -341,6 +342,15 @@ class ChooserPanel:
     # Panel reuse helpers
     # ------------------------------------------------------------------
 
+    _VFX_MATERIAL = 5  # NSVisualEffectMaterialMenu
+
+    def _activate_vfx(self) -> None:
+        """Re-activate the VFX view."""
+        if self._vfx_view is None:
+            return
+        self._vfx_view.setState_(1)  # NSVisualEffectStateActive
+        self._vfx_view.setMaterial_(self._VFX_MATERIAL)
+
     def _reconnect_panel_refs(self) -> None:
         """Restore ``_panel_ref`` back-references broken by :meth:`close`."""
         if self._message_handler is not None:
@@ -349,6 +359,13 @@ class ChooserPanel:
             self._navigation_delegate._panel_ref = self
         if self._panel_delegate is not None:
             self._panel_delegate._panel_ref = self
+
+    def _deactivate_vfx(self) -> None:
+        """Deactivate VFX and shrink panel to release IOSurface memory."""
+        from wenzi.ui_helpers import release_panel_surfaces
+
+        release_panel_surfaces(self._panel)
+        self._last_screen = None
 
     def _reset_panel_ui(
         self,
@@ -540,11 +557,18 @@ class ChooserPanel:
             self._build_panel()
 
     def _maybe_close(self) -> None:
-        """Close unless one of our panels (chooser or QL) is still key.
+        """Close unless QL preview or calculator mode is active.
 
         Called on a deferred schedule after either the chooser or the QL
         panel loses key-window status.  Gives macOS time to assign the
         new key window before we check.
+
+        Note: we intentionally do NOT check whether the chooser panel
+        regained key-window status.  Because the panel is a floating
+        window at NSStatusWindowLevel, macOS may route focus back to it
+        after another app activates (e.g. via a system shortcut).
+        Ignoring the regained-key case ensures the panel closes
+        reliably whenever focus is lost.
         """
         if self._closing:
             return
@@ -553,12 +577,6 @@ class ChooserPanel:
             if self._closing or self._panel is None:
                 return
             try:
-                from AppKit import NSApp
-
-                key = NSApp.keyWindow()
-                # Chooser panel regained key — do nothing
-                if key is not None and key == self._panel:
-                    return
                 # QL panel is now key — user is interacting with preview
                 if self._ql_panel is not None and self._ql_panel.is_key_window:
                     return
@@ -750,6 +768,7 @@ class ChooserPanel:
             # Hot path — reuse hidden panel.  Hide via alpha until
             # _reset_panel_ui JS completes so stale results never flash.
             self._reconnect_panel_refs()
+            self._activate_vfx()
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             self._reset_panel_ui(initial_query, placeholder)
@@ -758,6 +777,7 @@ class ChooserPanel:
             # (recycled in prebuild mode).  Load HTML — _on_page_loaded
             # will handle pending query, placeholder, and context.
             self._reconnect_panel_refs()
+            self._activate_vfx()
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             if not self._recycle_preloading:
@@ -870,8 +890,8 @@ class ChooserPanel:
             )
 
         if self._panel is not None:
+            self._deactivate_vfx()
             self._panel.orderOut_(None)
-        self._last_screen = None
 
         self._closing = False
 
@@ -924,11 +944,14 @@ class ChooserPanel:
         from wenzi.ui.web_utils import cleanup_webview
 
         cleanup_webview(self._webview, handler_name="chooser")
+        if self._vfx_view is not None:
+            self._vfx_view.setState_(0)
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._panel.orderOut_(None)
         self._panel = None
         self._webview = None
+        self._vfx_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -1892,16 +1915,7 @@ class ChooserPanel:
         # DOM/JS state alive for a fast hot-path re-show.
         if self._panel is not None:
             if was_preloading and not self._panel.isVisible():
-                from Foundation import NSMakeRect
-
-                f = self._panel.frame()
-                self._panel.setFrame_display_(
-                    NSMakeRect(f.origin.x, f.origin.y, 1, 1), False,
-                )
-                # Clear cached screen so next show() repositions correctly
-                # instead of skipping because the screen hasn't changed.
-                # The 1×1 origin is stale after the shrink.
-                self._last_screen = None
+                self._deactivate_vfx()
             else:
                 self._panel.setAlphaValue_(1.0)
 
@@ -2005,8 +2019,8 @@ class ChooserPanel:
         panel.setMovableByWindowBackground_(False)
         panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
 
-        # Transparent background — the HTML provides its own
-        from AppKit import NSColor
+        # Transparent background — NSVisualEffectView provides the frosted glass
+        from AppKit import NSColor, NSVisualEffectView
 
         panel.setBackgroundColor_(NSColor.clearColor())
 
@@ -2023,10 +2037,19 @@ class ChooserPanel:
         panel.setDelegate_(delegate)
         self._panel_delegate = delegate
 
-        # Round corners — frosted glass is handled by CSS backdrop-filter
-        panel.contentView().setWantsLayer_(True)
-        panel.contentView().layer().setCornerRadius_(18.0)
-        panel.contentView().layer().setMasksToBounds_(True)
+        # NSVisualEffectView for native frosted glass blur
+        vfx = NSVisualEffectView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, initial_width, initial_height),
+        )
+        vfx.setBlendingMode_(0)  # NSVisualEffectBlendingModeBehindWindow
+        vfx.setState_(1)  # NSVisualEffectStateActive
+        vfx.setAutoresizingMask_(0x12)  # Width + Height sizable
+        vfx.setWantsLayer_(True)
+        vfx.layer().setCornerRadius_(18.0)
+        vfx.layer().setMasksToBounds_(True)
+        panel.contentView().addSubview_(vfx)
+        self._vfx_view = vfx
+        self._activate_vfx()
 
         # Position: center-top of mouse screen (like Spotlight)
         self._panel = panel
@@ -2050,7 +2073,7 @@ class ChooserPanel:
         )
         webview.setAutoresizingMask_(0x12)  # Width + Height sizable
         webview.setValue_forKey_(False, "drawsBackground")
-        panel.contentView().addSubview_(webview)
+        vfx.addSubview_(webview)
 
         # Navigation delegate
         nav_cls = _get_navigation_delegate_class()
@@ -2067,6 +2090,7 @@ class ChooserPanel:
         self._recycle_preloading = False
 
         if not load_html:
+            self._deactivate_vfx()
             return
 
         # Load HTML from a temp file so WKWebView grants file:// access.

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -57,7 +57,7 @@ body {
     display: flex; opacity: 1;
 }
 .left-panel {
-    width: 440px; flex-shrink: 0;
+    width: 340px; flex-shrink: 0;
     display: flex; flex-direction: column;
     min-height: 0;
 }
@@ -66,7 +66,7 @@ body {
     flex: 1; display: flex; flex-direction: column;
     align-items: center; justify-content: center;
     border-left: 0.5px solid var(--border);
-    padding: 20px; overflow: hidden;
+    padding: 16px; overflow: hidden;
     min-height: 0;
     background: transparent;
 }
@@ -113,8 +113,8 @@ body {
 
 /* Search bar */
 .search-bar {
-    display: flex; align-items: center; gap: 10px;
-    padding: 16px 20px;
+    display: flex; align-items: center; gap: 8px;
+    padding: 12px 16px;
     background: var(--input-bg);
     border-bottom: 0.5px solid var(--border);
     flex-shrink: 0;
@@ -123,12 +123,12 @@ body {
 /* Subtle bottom fade instead of hard line */
 .search-bar::after {
     content: ''; position: absolute;
-    left: 20px; right: 20px; bottom: -0.5px; height: 0.5px;
+    left: 16px; right: 16px; bottom: -0.5px; height: 0.5px;
     background: linear-gradient(90deg, transparent, var(--border), transparent);
     pointer-events: none;
 }
 .search-icon {
-    width: 26px; height: 26px; flex-shrink: 0;
+    width: 22px; height: 22px; flex-shrink: 0;
     color: var(--secondary);
     cursor: grab;
 }
@@ -138,7 +138,7 @@ body {
 }
 .search-input {
     flex: 1; border: none; outline: none;
-    font-size: 22px; font-family: inherit;
+    font-size: 18px; font-family: inherit;
     background: transparent; color: var(--text);
     caret-color: var(--accent);
 }
@@ -147,7 +147,7 @@ body {
 /* Context block (Universal Action mode) */
 .context-block {
     display: none; flex-shrink: 0;
-    padding: 12px 18px;
+    padding: 10px 14px;
     background: transparent;
     border-bottom: 0.5px solid var(--border);
 }
@@ -158,7 +158,7 @@ body {
     margin-bottom: 4px;
 }
 .context-text {
-    font-size: 13px; color: var(--text);
+    font-size: 12px; color: var(--text);
     line-height: 1.5;
     display: -webkit-box;
     -webkit-line-clamp: 3;
@@ -170,7 +170,7 @@ body {
 .context-text.expanded {
     display: block;
     -webkit-line-clamp: unset;
-    max-height: 120px;
+    max-height: 90px;
     overflow-y: auto;
 }
 .context-text.expanded::-webkit-scrollbar { width: 4px; }
@@ -213,9 +213,9 @@ body {
 }
 .result-item {
     display: flex; align-items: center;
-    padding: 10px 14px; cursor: default;
+    padding: 8px 12px; cursor: default;
     transition: background 0.2s ease;
-    gap: 12px;
+    gap: 10px;
     box-sizing: border-box;
     overflow: hidden;
     border-radius: 10px;
@@ -223,16 +223,16 @@ body {
 }
 .icon-wrap {
     position: relative; flex-shrink: 0;
-    width: 40px; height: 40px;
+    width: 32px; height: 32px;
 }
 .result-item .icon {
-    width: 40px; height: 40px; flex-shrink: 0;
-    border-radius: 9px;
+    width: 32px; height: 32px; flex-shrink: 0;
+    border-radius: 7px;
     image-rendering: -webkit-optimize-contrast;
 }
 .result-item .icon-placeholder {
     background-color: var(--secondary);
-    -webkit-mask-size: 24px 24px;
+    -webkit-mask-size: 20px 20px;
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-position: center;
     opacity: 0.35;
@@ -255,7 +255,7 @@ body {
     min-width: 0; flex: 1;
 }
 .result-item .title {
-    font-size: 15px; font-weight: 500;
+    font-size: 13px; font-weight: 500;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .result-item.selected .title { color: var(--item-selected-text); }
@@ -301,7 +301,7 @@ body {
 .empty-state {
     display: flex; align-items: center; justify-content: center;
     flex: 1; color: var(--secondary); font-size: 13px;
-    padding: 20px;
+    padding: 16px;
     transition: opacity 0.2s ease;
 }
 
@@ -379,7 +379,7 @@ var _settingHistoryValue = false;
 
 // --- Virtual scrolling ---
 var ITEM_HEIGHT = 0;  // measured from first rendered row
-var ITEM_HEIGHT_DEFAULT = 60;  // fallback before measurement
+var ITEM_HEIGHT_DEFAULT = 48;  // fallback before measurement
 var BUFFER_COUNT = 5;  // extra rows above/below viewport
 
 // --- DOM ---
@@ -744,10 +744,10 @@ function updateSelection(newIndex) {
 }
 
 // --- Panel resize ---
-var PANEL_WIDTH_NARROW = 680;
-var PANEL_WIDTH_WIDE = 1040;
-var PANEL_HEIGHT_EXPANDED = 420;
-var PANEL_HEIGHT_COMPACT = 160;
+var PANEL_WIDTH_NARROW = 520;
+var PANEL_WIDTH_WIDE = 800;
+var PANEL_HEIGHT_EXPANDED = 320;
+var PANEL_HEIGHT_COMPACT = 120;
 
 var _panelExpanded = false;
 var _previewVisible = false;

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -358,6 +358,7 @@ var selectedIndex = -1;
 var itemsVersion = 0;
 var hasAnyIcon = false;  // true when at least one item has an icon
 var _lastMouseX = -1, _lastMouseY = -1;  // suppress scroll-induced hover
+var _mouseActivated = false;  // ignore mouse until user actually moves it
 var _PLACEHOLDER_SVG = "data:image/svg+xml,"
     + "%3Csvg xmlns='http://www.w3.org/2000/svg' "
     + "viewBox='0 0 24 24' fill='none' stroke='black' "
@@ -596,6 +597,7 @@ resultList.addEventListener('mousemove', function(e) {
     if (e.clientX === _lastMouseX && e.clientY === _lastMouseY) return;
     _lastMouseX = e.clientX;
     _lastMouseY = e.clientY;
+    if (!_mouseActivated) { _mouseActivated = true; return; }
     var row = e.target.closest('.result-item');
     if (!row) return;
     var idx = parseInt(row.getAttribute('data-idx'), 10);
@@ -967,6 +969,7 @@ function setResults(newItems, version, selectedIdx) {
         // New search results — reset to top
         selectedIndex = items.length > 0 ? 0 : -1;
         resultList.scrollTop = 0;
+        _mouseActivated = false;
     }
     renderItems();
     _checkPanelResize();

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 :root {
-    --bg: #fff;
+    --bg: transparent;
     --text: #1d1d1f;
     --secondary: #86868b;
     --border: rgba(0, 0, 0, 0.08);
@@ -19,7 +19,7 @@
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --bg: #323237;
+        --bg: transparent;
         --text: #e5e5e7;
         --secondary: #98989d;
         --border: rgba(255, 255, 255, 0.10);
@@ -46,14 +46,6 @@ body {
     background: transparent;
     border-radius: 18px;
     overflow: hidden;
-}
-body::before {
-    content: '';
-    position: fixed; inset: 0;
-    border-radius: 18px;
-    background: var(--bg);
-    z-index: -1;
-    pointer-events: none;
 }
 
 /* Main content: left panel + preview */

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -932,50 +932,42 @@ class TestQuickLookIntegration:
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        mock_nsapp = MagicMock()
-        # Return something other than chooser panel so first check doesn't match
-        mock_nsapp.keyWindow.return_value = MagicMock()
-
         with patch("PyObjCTools.AppHelper.callLater") as mock_later:
             panel._maybe_close()
             check_fn = mock_later.call_args[0][1]
 
-        with patch("AppKit.NSApp", mock_nsapp):
-            check_fn()
+        check_fn()
         panel.close.assert_not_called()
 
-    def test_maybe_close_keeps_open_when_chooser_is_key(self):
-        """_maybe_close should not close when chooser panel is the key window."""
+    def test_maybe_close_closes_even_when_chooser_regained_key(self):
+        """_maybe_close should close even if the chooser panel regained key.
+
+        Floating panels at NSStatusWindowLevel can recapture key-window
+        status after another app activates (e.g. via a system shortcut).
+        The panel must still close to avoid stealing focus back.
+        """
         panel = _make_panel()
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        mock_nsapp = MagicMock()
-        mock_nsapp.keyWindow.return_value = panel._panel
-
         with patch("PyObjCTools.AppHelper.callLater") as mock_later:
             panel._maybe_close()
             check_fn = mock_later.call_args[0][1]
 
-        with patch("AppKit.NSApp", mock_nsapp):
-            check_fn()
-        panel.close.assert_not_called()
+        check_fn()
+        panel.close.assert_called_once()
 
-    def test_maybe_close_closes_when_neither_panel_is_key(self):
-        """_maybe_close should close when neither panel is key."""
+    def test_maybe_close_closes_when_no_ql_panel(self):
+        """_maybe_close should close when no QL panel is active."""
         panel = _make_panel()
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        mock_nsapp = MagicMock()
-        mock_nsapp.keyWindow.return_value = MagicMock()  # some other window
-
         with patch("PyObjCTools.AppHelper.callLater") as mock_later:
             panel._maybe_close()
             check_fn = mock_later.call_args[0][1]
 
-        with patch("AppKit.NSApp", mock_nsapp):
-            check_fn()
+        check_fn()
         panel.close.assert_called_once()
 
 
@@ -1775,6 +1767,18 @@ class TestDeferredRecycle:
         )
         assert panel._recycle_timer is not None
 
+    def test_close_releases_hidden_panel_surfaces(self):
+        panel = _make_panel()
+        panel._panel = MagicMock()
+        panel._webview = MagicMock()
+        with patch.object(panel, "_deactivate_vfx") as mock_release, \
+             patch("PyObjCTools.AppHelper.callLater"), \
+             patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)), \
+             patch("wenzi.scripting.ui.chooser_panel.reactivate_app"):
+            panel.close()
+        mock_release.assert_called_once_with()
+        panel._panel.orderOut_.assert_called_once_with(None)
+
     def test_close_without_webview_skips_recycle(self):
         panel = _make_panel()
         panel._webview = None
@@ -1828,6 +1832,18 @@ class TestDeferredRecycle:
         timer.cancel.assert_called_once()
         assert panel._recycle_timer is None
 
+    def test_destroy_deactivates_vfx_during_close(self):
+        panel = _make_panel()
+        panel._panel = MagicMock()
+        panel._webview = MagicMock()
+        with patch.object(panel, "_deactivate_vfx") as mock_deactivate, \
+             patch("wenzi.ui.web_utils.cleanup_webview"), \
+             patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)), \
+             patch("wenzi.scripting.ui.chooser_panel.reactivate_app"):
+            panel.destroy()
+        # close() deactivates; _teardown_webview() does inline setState_(0)
+        mock_deactivate.assert_called_once()
+
     def test_do_recycle_rebuilds_panel(self):
         panel = _make_panel()
         panel._webview = MagicMock()
@@ -1853,6 +1869,17 @@ class TestDeferredRecycle:
             panel._do_recycle()
         mock_build.assert_not_called()
         assert panel._webview is None
+
+    def test_do_recycle_prebuild_mode_builds_blank_panel(self):
+        panel = _make_panel()
+        panel._webview = MagicMock()
+        panel._panel = MagicMock()
+        panel._panel.isVisible.return_value = False
+        panel.set_recycle_mode("prebuild")
+        with patch.object(panel, "_build_panel") as mock_build:
+            panel._do_recycle()
+        mock_build.assert_called_once_with(load_html=False)
+        assert panel._recycle_preloading is False
 
     def test_do_recycle_preload_html_mode_builds_loaded_panel(self):
         panel = _make_panel()
@@ -1904,3 +1931,17 @@ class TestDeferredRecycle:
         panel._reload_chooser_html.assert_not_called()
         panel._panel.makeKeyAndOrderFront_.assert_called_once_with(None)
         mock_nsapp.activateIgnoringOtherApps_.assert_called_once_with(True)
+
+    def test_on_page_loaded_preload_releases_hidden_panel_surfaces(self):
+        panel = _make_panel()
+        panel._panel = MagicMock()
+        panel._panel.isVisible.return_value = False
+        panel._webview = MagicMock()
+        panel._page_loaded = False
+        panel._recycle_preloading = True
+        panel._pending_js = []
+        with patch.object(panel, "_inject_i18n"), \
+             patch.object(panel, "_eval_js"), \
+             patch.object(panel, "_deactivate_vfx") as mock_release:
+            panel._on_page_loaded()
+        mock_release.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Replace CSS backdrop-filter with native NSVisualEffectView for the chooser panel blur effect, eliminating WKWebView compositing issues and reducing memory overhead
- Fix chooser to select the first item by default and defer mouse hover tracking to avoid unintended selection changes on open
- Update CLAUDE.md with NSVisualEffectView lifecycle documentation

## Test plan
- [x] Tests updated in tests/scripting/test_chooser_panel.py
- [ ] Verify chooser blur effect renders correctly on macOS
- [ ] Verify first item is selected by default when chooser opens
- [ ] Verify mouse hover does not change selection until mouse actually moves