### PR TITLE
perf(snippet): speed up expansion and add debounce to avoid unintended triggers

### DIFF
--- a/src/wenzi/scripting/snippet_expander.py
+++ b/src/wenzi/scripting/snippet_expander.py
@@ -22,8 +22,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Backspace virtual keycode on macOS
+# Virtual keycodes on macOS
 _VK_DELETE = 51
+_VK_V = 9
 
 # Maximum buffer length — keywords longer than this are not supported
 _MAX_BUFFER = 128
@@ -45,6 +46,10 @@ _CLEAR_KEYCODES = {
     126,  # up arrow
 }
 
+
+# Debounce delay: wait this long after keyword match before expanding.
+# If the user keeps typing within this window, expansion is cancelled.
+_EXPANSION_DELAY = 0.2
 
 _carbon = ctypes.cdll.LoadLibrary(ctypes.util.find_library("Carbon"))
 
@@ -83,12 +88,14 @@ class SnippetExpander:
         self._runner = None
         self._expanding = False  # Guard against re-entrance during expansion
         self._suppressed = False  # True while our own panels are key
+        self._pending_timer: threading.Timer | None = None
 
     # -- public API ----------------------------------------------------------
 
     def suppress(self) -> None:
         """Temporarily suppress expansion (e.g. while launcher is open)."""
         self._suppressed = True
+        self._cancel_pending()
         with self._lock:
             self._buffer = ""
 
@@ -108,12 +115,20 @@ class SnippetExpander:
 
     def stop(self) -> None:
         """Stop listening."""
+        self._cancel_pending()
         if self._runner is not None:
             self._runner.stop()
             self._runner = None
         with self._lock:
             self._buffer = ""
         logger.info("SnippetExpander stopped")
+
+    def _cancel_pending(self) -> None:
+        """Cancel a pending debounced expansion, if any."""
+        timer = self._pending_timer
+        if timer is not None:
+            timer.cancel()
+            self._pending_timer = None
 
     # -- internals -----------------------------------------------------------
 
@@ -130,6 +145,9 @@ class SnippetExpander:
 
             if self._expanding or self._suppressed:
                 return None
+
+            # Any keystroke cancels a pending debounced expansion
+            self._cancel_pending()
 
             keycode = cg.CGEventGetIntegerValueField(
                 event, cg.kCGKeyboardEventKeycode,
@@ -198,16 +216,20 @@ class SnippetExpander:
                 # Clear the buffer before expanding
                 with self._lock:
                     self._buffer = ""
-                # Run expansion in a separate thread to avoid blocking the tap
-                threading.Thread(
-                    target=self._expand,
+                # Debounce: wait before expanding so continued typing cancels it
+                timer = threading.Timer(
+                    _EXPANSION_DELAY,
+                    self._expand,
                     args=(keyword, content, raw),
-                    daemon=True,
-                ).start()
+                )
+                timer.daemon = True
+                timer.start()
+                self._pending_timer = timer
                 return
 
     def _expand(self, keyword: str, content: str, raw: bool = False) -> None:
         """Delete the keyword text and paste the snippet content."""
+        self._pending_timer = None
         self._expanding = True
         try:
             if raw:
@@ -221,24 +243,15 @@ class SnippetExpander:
 
             # Send backspace keys to delete the keyword
             self._send_backspaces(len(keyword))
-            time.sleep(0.05)
+            time.sleep(0.02)
 
             # Paste the snippet content
             from wenzi.input import _set_pasteboard_concealed
 
             _set_pasteboard_concealed(expanded)
-            time.sleep(0.05)
+            time.sleep(0.02)
 
-            import subprocess
-
-            subprocess.run(
-                [
-                    "osascript", "-e",
-                    'tell application "System Events" to keystroke "v" '
-                    "using command down",
-                ],
-                capture_output=True, timeout=5,
-            )
+            self._send_cmd_v()
         except Exception:
             logger.exception("Failed to expand snippet %r", keyword)
             try:
@@ -267,4 +280,18 @@ class SnippetExpander:
             up = cg.CGEventCreateKeyboardEvent(None, _VK_DELETE, False)
             cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, up)
             cg.CFRelease(up)
-            time.sleep(0.01)
+            time.sleep(0.002)
+
+    @staticmethod
+    def _send_cmd_v() -> None:
+        """Send Cmd+V keystroke via CGEvent."""
+        from wenzi import _cgeventtap as cg
+
+        down = cg.CGEventCreateKeyboardEvent(None, _VK_V, True)
+        cg.CGEventSetFlags(down, cg.kCGEventFlagMaskCommand)
+        cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, down)
+        cg.CFRelease(down)
+        up = cg.CGEventCreateKeyboardEvent(None, _VK_V, False)
+        cg.CGEventSetFlags(up, cg.kCGEventFlagMaskCommand)
+        cg.CGEventPost(cg.kCGAnnotatedSessionEventTap, up)
+        cg.CFRelease(up)

--- a/tests/scripting/test_snippet_expander.py
+++ b/tests/scripting/test_snippet_expander.py
@@ -48,15 +48,15 @@ class TestBufferAndMatching:
             _write_snippet(d, "lsof", "/lsof/", "sudo lsof -iTCP -sTCP:LISTEN -n -P")
 
         expander = self._make_expander(setup)
-        expand_mock = MagicMock()
-        with patch.object(expander, "_expand", expand_mock):
-            expander._check_expansion("some text /lsof/")
+        expander._check_expansion("some text /lsof/")
 
-        expand_mock.assert_called_once()
-        args = expand_mock.call_args[0]
+        # Debounced: a pending timer should be set with the correct args
+        assert expander._pending_timer is not None
+        args = expander._pending_timer.args
         assert args[0] == "/lsof/"
         assert "lsof" in args[1]
         assert args[2] is False  # raw defaults to False
+        expander._cancel_pending()
 
     def test_check_expansion_no_match(self):
         def setup(d):
@@ -79,6 +79,20 @@ class TestBufferAndMatching:
             expander._check_expansion("anything")
 
         expand_mock.assert_not_called()
+
+    def test_continued_typing_cancels_expansion(self):
+        def setup(d):
+            _write_snippet(d, "email", "@@e", "user@example.com")
+
+        expander = self._make_expander(setup)
+        expander._check_expansion("hello @@e")
+
+        # A pending timer should be set
+        assert expander._pending_timer is not None
+
+        # Simulate continued typing — cancels the pending expansion
+        expander._cancel_pending()
+        assert expander._pending_timer is None
 
     def test_check_expansion_clears_buffer(self):
         def setup(d):
@@ -107,12 +121,11 @@ class TestBufferAndMatching:
             _write_snippet(d, "ab", ";;ab", "content-ab")
 
         expander = self._make_expander(setup)
-        expand_mock = MagicMock()
-        with patch.object(expander, "_expand", expand_mock):
-            expander._check_expansion("text ;;ab")
+        expander._check_expansion("text ;;ab")
 
         # One of them should match (whichever comes first in iteration)
-        expand_mock.assert_called_once()
+        assert expander._pending_timer is not None
+        expander._cancel_pending()
 
     def test_check_expansion_skips_auto_expand_false(self):
         def setup(d):
@@ -132,11 +145,10 @@ class TestBufferAndMatching:
             _write_snippet(d, "email", "@@e", "e@x.com")
 
         expander = self._make_expander(setup)
-        expand_mock = MagicMock()
-        with patch.object(expander, "_expand", expand_mock):
-            expander._check_expansion("text @@e")
+        expander._check_expansion("text @@e")
 
-        expand_mock.assert_called_once()
+        assert expander._pending_timer is not None
+        expander._cancel_pending()
 
     def test_expanding_flag_prevents_reentrance(self):
         def setup(d):
@@ -169,13 +181,13 @@ class TestExpand:
                 return_value="expanded content",
             ),
             patch("wenzi.input._set_pasteboard_concealed") as mock_paste,
-            patch("subprocess.run") as mock_run,
+            patch.object(expander, "_send_cmd_v") as mock_cmd_v,
         ):
             expander._expand(";;test", "raw content")
 
         mock_bs.assert_called_once_with(len(";;test"))
         mock_paste.assert_called_once_with("expanded content")
-        mock_run.assert_called_once()
+        mock_cmd_v.assert_called_once()
 
     def test_expand_resets_expanding_flag_on_error(self):
         store = _make_store()
@@ -206,7 +218,7 @@ class TestExpand:
                 return_value="2026-03-16",
             ) as mock_ep,
             patch("wenzi.input._set_pasteboard_concealed"),
-            patch("subprocess.run"),
+            patch.object(expander, "_send_cmd_v"),
         ):
             expander._expand(";;d", "{date}")
 
@@ -222,7 +234,7 @@ class TestExpand:
                 "wenzi.scripting.sources.snippet_source._expand_placeholders",
             ) as mock_ep,
             patch("wenzi.input._set_pasteboard_concealed") as mock_paste,
-            patch("subprocess.run"),
+            patch.object(expander, "_send_cmd_v"),
         ):
             expander._expand(";;tpl", "Today is {date}", raw=True)
 
@@ -256,30 +268,26 @@ class TestRandomExpansion:
         expander = self._make_expander(setup)
 
         # Verify expansion picks a variant via random.choice
-        expand_mock = MagicMock()
-        with (
-            patch.object(expander, "_expand", expand_mock),
-            patch("random.choice", return_value="Thank you!"),
-        ):
+        with patch("random.choice", return_value="Thank you!"):
             expander._check_expansion("hello thx ")
 
-        expand_mock.assert_called_once()
-        args = expand_mock.call_args[0]
+        assert expander._pending_timer is not None
+        args = expander._pending_timer.args
         assert args[0] == "thx "
         assert args[1] == "Thank you!"
+        expander._cancel_pending()
 
     def test_non_random_snippet_uses_content(self):
         def setup(d):
             _write_snippet(d, "email", "@@e", "user@example.com")
 
         expander = self._make_expander(setup)
-        expand_mock = MagicMock()
-        with patch.object(expander, "_expand", expand_mock):
-            expander._check_expansion("text @@e")
+        expander._check_expansion("text @@e")
 
-        expand_mock.assert_called_once()
-        args = expand_mock.call_args[0]
+        assert expander._pending_timer is not None
+        args = expander._pending_timer.args
         assert args[1] == "user@example.com"
+        expander._cancel_pending()
 
 
 class TestGetUnicodeString:
@@ -335,7 +343,10 @@ class TestExpandNotification:
                 return_value="content",
             ),
             patch("wenzi.input._set_pasteboard_concealed"),
-            patch("subprocess.run", side_effect=Exception("osascript failed")),
+            patch.object(
+                expander, "_send_cmd_v",
+                side_effect=Exception("CGEvent failed"),
+            ),
             patch("wenzi.statusbar.send_notification") as mock_notify,
         ):
             expander._expand(";;test", "content")


### PR DESCRIPTION
- Replace osascript subprocess with CGEvent for Cmd+V (~70ms saved)
- Reduce backspace inter-key delay from 10ms to 2ms
- Reduce sync sleeps from 50ms to 20ms
- Add 200ms debounce: continued typing after keyword match cancels expansion
- Cancel pending expansion on suppress() and stop()