### PR TITLE
feat: migrate all panels to NSGlassEffectView (Liquid Glass)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,44 @@ When adding new modules, place them in the appropriate subpackage. Subpackage `_
 
 Cross-package imports from controllers/ui should use absolute paths (`from wenzi.config import ...`), not relative imports to parent package.
 
+## Minimum Deployment Target — macOS 26
+
+The minimum supported macOS version is **macOS 26 (Tahoe)**. Do not add backwards-compatibility code for older systems. APIs available only in macOS 26+ (e.g. `NSGlassEffectView`) can be used unconditionally without version checks or fallbacks.
+
+## NSGlassEffectView — Lock Adaptive Appearance to System Theme
+
+NSGlassEffectView is **adaptive by default**: it continuously samples the brightness of content behind the window and auto-switches between light and dark rendering, **ignoring the system dark/light mode setting**. This means a dark-mode panel over a white background will render as light glass.
+
+The public `setAppearance_()` API does **not** fix this — the glass material's own rendering pipeline ignores it. You must use the private `_adaptiveAppearance` property:
+
+- **0** = Light (force light)
+- **1** = Dark (force dark)
+- **2** = Auto (default — adapts to behind-window brightness)
+
+```python
+from AppKit import NSApp, NSAppearance, NSGlassEffectView
+
+glass = NSGlassEffectView.alloc().initWithFrame_(frame)
+
+# Detect system theme
+sys_appearance = NSApp.effectiveAppearance()
+name = sys_appearance.bestMatchFromAppearancesWithNames_(
+    ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
+)
+is_dark = name is not None and "Dark" in str(name)
+
+# Public API — cascade to subviews (labels, text fields, etc.)
+glass.setAppearance_(sys_appearance)
+
+# Private API — lock the glass material itself
+if glass.respondsToSelector_(b"set_adaptiveAppearance:"):
+    glass.set_adaptiveAppearance_(1 if is_dark else 0)
+```
+
+**Every** `NSGlassEffectView` instance in the project must apply this pattern. Without it, small panels (like the recording indicator) over bright/dark backgrounds will visually contradict the system theme. See `recording_indicator.py:_make_glass_view()` for the reference implementation.
+
+**Note:** `_adaptiveAppearance` is a private API (discovered via [qt-liquid-glass](https://github.com/fsalinas26/qt-liquid-glass)). Always guard with `respondsToSelector_`.
+
 ## Test Safety — Never Use Real User Data Paths
 
 When writing tests that instantiate classes with default paths pointing to real user directories (e.g. `~/.config/WenZi/`), **always override those paths with `tmp_path`** to prevent tests from reading, modifying, or deleting real user data.
@@ -123,27 +161,35 @@ All UI must support macOS dark mode. Follow these rules when writing UI code:
 - **Avoid deprecated `colorWithCalibratedRed_green_blue_alpha_`** — use `colorWithSRGBRed_green_blue_alpha_` or system semantic colors.
 - See `ui/result_window_web.py` for a good reference implementation of dark mode support.
 
-## NSVisualEffectView Memory Management
+## Blur Panels — Use NSGlassEffectView (Liquid Glass), Never NSVisualEffectView
 
-`NSVisualEffectView` with `NSVisualEffectBlendingModeBehindWindow` causes macOS to allocate a **full-screen IOSurface** (~72 MB at retina) for desktop content capture used by the blur effect. This memory is **not released** by `orderOut_` alone.
+**Minimum deployment target is macOS 26.** Do not add compatibility shims for older systems.
 
-When hiding or closing any panel that contains an `NSVisualEffectView`, call the shared helper **before or after** `orderOut_`:
+When a panel needs a blur/frosted-glass background, use **NSGlassEffectView** (Liquid Glass). **Never use NSVisualEffectView** for new panels — it is deprecated in this project. If you encounter an existing `NSVisualEffectView`, migrate it to `NSGlassEffectView`. If a panel does not need blur, use a plain NSView/NSPanel with a normal background color.
+
+Every NSGlassEffectView must call the shared helper to lock its appearance to the system theme:
 
 ```python
-from wenzi.ui_helpers import release_panel_surfaces
+from wenzi.ui_helpers import configure_glass_appearance
 
-release_panel_surfaces(self._panel)   # deactivate VFX + shrink to 1×1
-self._panel.orderOut_(None)
-self._panel = None
+glass = NSGlassEffectView.alloc().initWithFrame_(frame)
+glass.setCornerRadius_(12)
+configure_glass_appearance(glass)
 ```
 
-`release_panel_surfaces(panel)` handles both steps automatically:
-1. Walks the content view and its direct subviews, deactivates any `NSVisualEffectView` (`setState_(0)`)
-2. Shrinks the panel to 1×1 to force Core Animation to release the backing store
+### IOSurface Memory Management
 
-When re-showing, re-activate the effect view (`setState_(1)`) **just before** `orderFront_`/`makeKeyAndOrderFront_`, so the IOSurface is only allocated while the panel is visible.
+NSGlassEffectView allocates a GPU-backed IOSurface (~72 MB+ at retina) for behind-window compositing. This memory is **not released** by `orderOut_` alone. When hiding a panel, shrink it to 1×1 to force Core Animation to release the backing store:
 
-The chooser panel (`ChooserPanel`) uses `NSVisualEffectView` (Material Menu) with a fully transparent WKWebView on top. The VFX lifecycle is managed via `_activate_vfx()` / `_deactivate_vfx()` — see `chooser_panel.py`.
+```python
+from Foundation import NSMakeRect
+
+f = panel.frame()
+panel.setFrame_display_(NSMakeRect(f.origin.x, f.origin.y, 1, 1), False)
+panel.orderOut_(None)
+```
+
+The chooser panel (`ChooserPanel`) manages this via `_deactivate_glass()` / `_activate_glass()` — see `chooser_panel.py`.
 
 ## LLM max_tokens Guard
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,10 @@ self._restore_accessory()
 
 `send_notification()` (from `statusbar.py`) may fail with `Info.plist` / `CFBundleIdentifier` errors when running directly from the terminal (`uv run`) without app bundling. This is expected during development — the function catches exceptions internally and logs them. In a packaged app notifications work normally.
 
+## Notifications — Prefer `wz.alert` Over System Notifications
+
+When code needs to notify the user of a transient event (success, warning, status change), use `wz.alert(text)` — a lightweight floating overlay that auto-dismisses. Do **not** use `send_notification()` (macOS system notification) unless the user explicitly asks for it. System notifications are heavyweight: they persist in Notification Center, require `Info.plist` / bundle setup, and are disruptive for frequent or low-importance events.
+
 ## WKWebView Development Reference
 
 When developing or modifying WKWebView-based panels, read `dev/wkwebview-pitfalls.md` first. It documents critical pitfalls including event handling, page load races, and state management.

--- a/dev/liquid-glass-api.md
+++ b/dev/liquid-glass-api.md
@@ -1,0 +1,122 @@
+# NSGlassEffectView — Liquid Glass API Reference
+
+Apple's Liquid Glass design (macOS 26+) — 折射+反射+流体动画，替代传统 NSVisualEffectView 的静态模糊。
+
+## 核心属性
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `contentView` | NSView | 内容嵌入点，AppKit 自动处理文字可读性。**只有 contentView 内的内容保证正确渲染**，任意 subview 可能 z-order 异常 |
+| `cornerRadius` | CGFloat | 一等属性，直接设圆角，不需要 maskImage hack |
+| `tintColor` | NSColor | 背景着色，建议 alpha 0.2-0.3 |
+| `style` | `.regular` / `.clear` | regular 通用；clear 仅用于媒体密集内容上方 |
+
+## 基本用法
+
+```swift
+let glass = NSGlassEffectView(frame: rect)
+glass.cornerRadius = 20
+glass.style = .regular
+glass.tintColor = NSColor.systemBlue.withAlphaComponent(0.3)
+glass.contentView = myView
+
+// NSPanel/NSWindow 必须设 clear 背景，否则窗口背景遮住 glass
+window.backgroundColor = .clear
+window.contentView = glass
+```
+
+### PyObjC 用法
+
+```python
+from AppKit import NSGlassEffectView
+
+glass = NSGlassEffectView.alloc().initWithFrame_(frame)
+glass.setCornerRadius_(18)
+glass.setContentView_(webview)
+```
+
+## NSGlassEffectContainerView
+
+多个 glass 元素的容器，控制液态融合效果。
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `contentView` | NSView | 放置多个 NSGlassEffectView 的容器 view |
+| `spacing` | CGFloat | glass 元素距离 < spacing 时自动液态合并 |
+
+```swift
+let container = NSGlassEffectContainerView(frame: rect)
+container.spacing = 40.0
+container.contentView = holderView  // holderView 包含多个 NSGlassEffectView
+```
+
+### 为什么需要 Container
+
+- Glass 不能采样 glass — 多个独立 glass 元素叠加会视觉异常
+- Container 内元素共享一个采样区域，保证一致性
+- 性能更好（减少渲染 pass）
+
+## NSGlassEffectView vs NSVisualEffectView
+
+| | NSVisualEffectView | NSGlassEffectView |
+|---|---|---|
+| 最低版本 | macOS 10.10 | macOS 26 |
+| 视觉效果 | 静态高斯模糊 | 动态折射+反射+流体动画 |
+| 圆角 | 需要 `setMaskImage:` | 内置 `cornerRadius` 属性 |
+| 内容嵌入 | `addSubview` | `contentView` 属性 |
+| 多元素融合 | 不支持 | `NSGlassEffectContainerView` |
+| tint | 靠 material 枚举 | `tintColor` 任意颜色 |
+
+**NSVisualEffectView 在本项目中已废弃。** 新 panel 如需 blur 必须用 NSGlassEffectView，不需要 blur 的用普通 NSView。
+
+## 锁定自适应外观（关键！）
+
+NSGlassEffectView 默认持续采样背后内容亮度来自动切换 light/dark 渲染，忽略系统主题和 `setAppearance_`。必须用私有属性 `_adaptiveAppearance` 锁定：
+
+| 值 | 含义 |
+|----|------|
+| 0 | 强制 Light |
+| 1 | 强制 Dark |
+| 2 | Auto（默认，根据背后内容亮度自适应） |
+
+项目中已封装为 `configure_glass_appearance(glass)`（见 `ui_helpers.py`），所有 NSGlassEffectView 实例必须调用：
+
+```python
+from wenzi.ui_helpers import configure_glass_appearance
+
+glass = NSGlassEffectView.alloc().initWithFrame_(frame)
+glass.setCornerRadius_(12)
+configure_glass_appearance(glass)
+```
+
+来源：[qt-liquid-glass](https://github.com/fsalinas26/qt-liquid-glass) 逆向发现，私有 API 需 `respondsToSelector_` 保护。
+
+### 其他私有属性
+
+| 属性 | 值 | 说明 |
+|------|-----|------|
+| `_variant` | 0-23 | 材质变体（2=dock, 9=通知中心, 16=sidebar） |
+| `_scrimState` | 0/1/2 | 遮罩层（0=无, 1=light, 2=dark） |
+| `_subduedState` | 0/1 | 降低饱和度 |
+| `_contentLensing` | int | 折射强度 |
+| `_interactionState` | 0/1 | 悬停高亮（≥2 会 crash） |
+
+## 性能注意
+
+- GPU 开销显著高于 NSVisualEffectView
+- Apple 建议限制 5-10 个 glass 元素
+- 频繁 show/hide 或高频重绘场景（如 recording indicator 20Hz）需评估
+
+## 已迁移的 Panel
+
+- Recording indicator — `recording_indicator.py:_make_glass_view()`
+- Streaming overlay — `streaming_overlay.py`
+- Chooser panel — `chooser_panel.py:_build_panel()`
+
+## 参考资料
+
+- [NSGlassEffectView — Apple Developer](https://developer.apple.com/documentation/appkit/nsglasseffectview)
+- [NSGlassEffectContainerView — Apple Developer](https://developer.apple.com/documentation/appkit/nsglasseffectcontainerview)
+- [WWDC25 Session 310 — Build an AppKit app with the new design](https://developer.apple.com/videos/play/wwdc2025/310/)
+- [Xcode 26 Liquid Glass 实现指南](https://github.com/artemnovichkov/xcode-26-system-prompts/blob/main/AdditionalDocumentation/AppKit-Implementing-Liquid-Glass-Design.md)
+- [NSWindow glass 圆角实践](https://github.com/onmyway133/blog/issues/1025)

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -36,11 +36,6 @@ _FONT_WEIGHT_MEDIUM = 0.23  # NSFontWeightMedium
 # Background
 _BG_CORNER_RADIUS = 12
 
-# NSVisualEffectView constants (avoid AppKit import at module level)
-_VFX_MATERIAL_HUD = 13       # NSVisualEffectMaterialHUDWindow
-_VFX_BLENDING_BEHIND = 0     # NSVisualEffectBlendingModeBehindWindow
-_VFX_STATE_ACTIVE = 1        # NSVisualEffectStateActive
-
 
 class RecordingIndicatorView:
     """Custom NSView that draws the recording indicator."""
@@ -97,7 +92,7 @@ class RecordingIndicatorView:
     def draw(self, rect: object) -> None:
         """Draw the indicator contents.
 
-        Background is provided by NSVisualEffectView — this method only draws
+        Background is provided by NSGlassEffectView — this method only draws
         the pulsing dot, waveform, and optional subtitle label.
         """
         from AppKit import (
@@ -279,40 +274,26 @@ class RecordingIndicatorPanel:
         self._show_device_name = value
 
     @staticmethod
-    def _make_vfx_view(width: int, height: int):
-        """Create an NSVisualEffectView with frosted-glass HUD appearance."""
-        from AppKit import NSBezierPath, NSColor, NSImage, NSVisualEffectView
+    def _make_glass_view(width: int, height: int):
+        """Create an NSGlassEffectView with Liquid Glass appearance."""
+        from AppKit import NSColor, NSGlassEffectView
         from Foundation import NSMakeRect
 
-        vfx = NSVisualEffectView.alloc().initWithFrame_(
+        glass = NSGlassEffectView.alloc().initWithFrame_(
             NSMakeRect(0, 0, width, height)
         )
-        vfx.setMaterial_(_VFX_MATERIAL_HUD)
-        vfx.setBlendingMode_(_VFX_BLENDING_BEHIND)
-        vfx.setState_(_VFX_STATE_ACTIVE)
-
-        # Use maskImage instead of layer cornerRadius — the latter leaves
-        # white corners because NSVisualEffectView's private blur sublayers
-        # don't respect CALayer masksToBounds.
-        r = _BG_CORNER_RADIUS
-        mask = NSImage.alloc().initWithSize_((width, height))
-        mask.lockFocus()
-        NSColor.blackColor().setFill()
-        NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
-            NSMakeRect(0, 0, width, height), r, r,
-        ).fill()
-        mask.unlockFocus()
-        mask.setCapInsets_((r, r, r, r))
-        vfx.setMaskImage_(mask)
-
-        return vfx
+        glass.setCornerRadius_(_BG_CORNER_RADIUS)
+        glass.setTintColor_(
+            NSColor.colorWithSRGBRed_green_blue_alpha_(1.0, 1.0, 1.0, 0.15)
+        )
+        return glass
 
     def _panel_height(self) -> int:
         """Compute current panel height based on whether a subtitle is shown."""
         has_sub = _build_subtitle(self._mode_name, self._device_name) is not None
         return _PANEL_HEIGHT + (_LABEL_HEIGHT if has_sub else 0)
 
-    def show(self, device_name: str | None = None) -> None:
+    def show(self, device_name: str | None = None, mode_name: str | None = None) -> None:
         """Create and show the floating indicator panel."""
         if not self._enabled:
             return
@@ -330,7 +311,7 @@ class RecordingIndicatorPanel:
                 self.hide()
 
             self._smoothed_level = 0.0
-            self._mode_name = None
+            self._mode_name = mode_name
             self._device_name = device_name
             self._indicator_view = RecordingIndicatorView()
             self._update_subtitle()
@@ -362,11 +343,11 @@ class RecordingIndicatorPanel:
                 y = sf.origin.y + (sf.size.height - panel_height) / 2.0
                 panel.setFrameOrigin_((x, y))
 
-            # Frosted-glass background + indicator drawing view
-            vfx = self._make_vfx_view(_PANEL_WIDTH, panel_height)
+            # Liquid Glass background + indicator drawing view
+            glass = self._make_glass_view(_PANEL_WIDTH, panel_height)
             indicator = self._indicator_view.create_view(_PANEL_WIDTH, panel_height)
-            vfx.addSubview_(indicator)
-            panel.setContentView_(vfx)
+            glass.setContentView_(indicator)
+            panel.setContentView_(glass)
 
             panel.orderFront_(None)
 
@@ -406,8 +387,6 @@ class RecordingIndicatorPanel:
     def hide(self) -> None:
         """Hide and clean up the indicator panel."""
         try:
-            from wenzi.ui_helpers import release_panel_surfaces
-
             if self._timer is not None:
                 self._timer.invalidate()
                 self._timer = None
@@ -415,7 +394,6 @@ class RecordingIndicatorPanel:
             self._clear_view_backref()
 
             if self._panel is not None:
-                release_panel_surfaces(self._panel)
                 self._panel.orderOut_(None)
                 self._panel = None
 
@@ -448,12 +426,12 @@ class RecordingIndicatorPanel:
         self._clear_view_backref()
 
         new_height = self._panel_height()
-        vfx = self._make_vfx_view(_PANEL_WIDTH, new_height)
+        glass = self._make_glass_view(_PANEL_WIDTH, new_height)
         indicator = self._indicator_view.create_view(_PANEL_WIDTH, new_height)
-        vfx.addSubview_(indicator)
+        glass.setContentView_(indicator)
 
         self._panel.setContentSize_((float(_PANEL_WIDTH), float(new_height)))
-        self._panel.setContentView_(vfx)
+        self._panel.setContentView_(glass)
 
         # Re-centre on screen
         from AppKit import NSScreen
@@ -557,9 +535,6 @@ class RecordingIndicatorPanel:
             panel = self._panel
 
             def _on_complete():
-                from wenzi.ui_helpers import release_panel_surfaces
-
-                release_panel_surfaces(panel)
                 panel.orderOut_(None)
                 self._clear_view_backref()
                 self._panel = None

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -281,7 +281,7 @@ class RecordingIndicatorPanel:
     @staticmethod
     def _make_vfx_view(width: int, height: int):
         """Create an NSVisualEffectView with frosted-glass HUD appearance."""
-        from AppKit import NSVisualEffectView
+        from AppKit import NSBezierPath, NSColor, NSImage, NSVisualEffectView
         from Foundation import NSMakeRect
 
         vfx = NSVisualEffectView.alloc().initWithFrame_(
@@ -290,9 +290,21 @@ class RecordingIndicatorPanel:
         vfx.setMaterial_(_VFX_MATERIAL_HUD)
         vfx.setBlendingMode_(_VFX_BLENDING_BEHIND)
         vfx.setState_(_VFX_STATE_ACTIVE)
-        vfx.setWantsLayer_(True)
-        vfx.layer().setCornerRadius_(_BG_CORNER_RADIUS)
-        vfx.layer().setMasksToBounds_(True)
+
+        # Use maskImage instead of layer cornerRadius — the latter leaves
+        # white corners because NSVisualEffectView's private blur sublayers
+        # don't respect CALayer masksToBounds.
+        r = _BG_CORNER_RADIUS
+        mask = NSImage.alloc().initWithSize_((width, height))
+        mask.lockFocus()
+        NSColor.blackColor().setFill()
+        NSBezierPath.bezierPathWithRoundedRect_xRadius_yRadius_(
+            NSMakeRect(0, 0, width, height), r, r,
+        ).fill()
+        mask.unlockFocus()
+        mask.setCapInsets_((r, r, r, r))
+        vfx.setMaskImage_(mask)
+
         return vfx
 
     def _panel_height(self) -> int:

--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -21,11 +21,11 @@ _LABEL_HEIGHT = 17  # height added for subtitle row
 _REFRESH_INTERVAL = 0.05
 
 # Waveform visual parameters
-_WAVE_POINTS = 50       # sample points for smooth curve
-_WAVE_WIDTH = 180.0     # horizontal extent
-_WAVE_MAX_AMP = 9.6     # max amplitude from centre line
-_WAVE_LINE_W = 2.4      # primary wave stroke width
-_WAVE_LINE_W2 = 1.8     # secondary wave stroke width
+_WAVE_POINTS = 50  # sample points for smooth curve
+_WAVE_WIDTH = 180.0  # horizontal extent
+_WAVE_MAX_AMP = 9.6  # max amplitude from centre line
+_WAVE_LINE_W = 2.4  # primary wave stroke width
+_WAVE_LINE_W2 = 1.8  # secondary wave stroke width
 
 # Status dot parameters
 _DOT_RADIUS = 5.4
@@ -81,9 +81,7 @@ class RecordingIndicatorView:
         from AppKit import NSColor
 
         def _provider(appearance):
-            name = appearance.bestMatchFromAppearancesWithNames_(
-                ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-            )
+            name = appearance.bestMatchFromAppearancesWithNames_(["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"])
             rgba = dark_rgba if name and "Dark" in str(name) else light_rgba
             return NSColor.colorWithSRGBRed_green_blue_alpha_(*rgba)
 
@@ -129,8 +127,10 @@ class RecordingIndicatorView:
             self._dot_color_inactive.setFill()
 
         dot_rect = NSMakeRect(
-            dot_x - _DOT_RADIUS, dot_y - _DOT_RADIUS,
-            _DOT_RADIUS * 2, _DOT_RADIUS * 2,
+            dot_x - _DOT_RADIUS,
+            dot_y - _DOT_RADIUS,
+            _DOT_RADIUS * 2,
+            _DOT_RADIUS * 2,
         )
         NSBezierPath.bezierPathWithOvalInRect_(dot_rect).fill()
 
@@ -155,7 +155,7 @@ class RecordingIndicatorView:
 
             path = NSBezierPath.alloc().init()
             path.setLineWidth_(_WAVE_LINE_W if wave_idx == 0 else _WAVE_LINE_W2)
-            path.setLineCapStyle_(1)   # NSLineCapStyleRound
+            path.setLineCapStyle_(1)  # NSLineCapStyleRound
             path.setLineJoinStyle_(1)  # NSLineJoinStyleRound
 
             for i in range(_WAVE_POINTS + 1):
@@ -207,7 +207,8 @@ class RecordingIndicatorView:
                 self._subtitle_ns_str = NSString.stringWithString_(self._subtitle)
             label_rect = NSMakeRect(33.6, 6, 180, _LABEL_HEIGHT)
             self._subtitle_ns_str.drawInRect_withAttributes_(
-                label_rect, self._subtitle_attrs,
+                label_rect,
+                self._subtitle_attrs,
             )
 
 
@@ -276,16 +277,14 @@ class RecordingIndicatorPanel:
     @staticmethod
     def _make_glass_view(width: int, height: int):
         """Create an NSGlassEffectView with Liquid Glass appearance."""
-        from AppKit import NSColor, NSGlassEffectView
+        from AppKit import NSGlassEffectView
         from Foundation import NSMakeRect
 
-        glass = NSGlassEffectView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, width, height)
-        )
+        from wenzi.ui_helpers import configure_glass_appearance
+
+        glass = NSGlassEffectView.alloc().initWithFrame_(NSMakeRect(0, 0, width, height))
         glass.setCornerRadius_(_BG_CORNER_RADIUS)
-        glass.setTintColor_(
-            NSColor.colorWithSRGBRed_green_blue_alpha_(1.0, 1.0, 1.0, 0.15)
-        )
+        configure_glass_appearance(glass)
         return glass
 
     def _panel_height(self) -> int:
@@ -374,11 +373,7 @@ class RecordingIndicatorPanel:
 
     def _clear_view_backref(self) -> None:
         """Clear the _indicator back-reference on the NSView to break the cycle."""
-        if (
-            self._indicator_view
-            and hasattr(self._indicator_view, "_view")
-            and self._indicator_view._view
-        ):
+        if self._indicator_view and hasattr(self._indicator_view, "_view") and self._indicator_view._view:
             try:
                 self._indicator_view._view._indicator = None
             except Exception:
@@ -565,8 +560,6 @@ class RecordingIndicatorPanel:
         response without jitter.
         """
         alpha = _EMA_ATTACK if level > self._smoothed_level else _EMA_RELEASE
-        self._smoothed_level = (
-            alpha * level + (1 - alpha) * self._smoothed_level
-        )
+        self._smoothed_level = alpha * level + (1 - alpha) * self._smoothed_level
         if self._indicator_view is not None:
             self._indicator_view.set_level(self._smoothed_level)

--- a/src/wenzi/controllers/recording_flow.py
+++ b/src/wenzi/controllers/recording_flow.py
@@ -237,8 +237,10 @@ class RecordingFlow:
                 if app._recording_indicator.show_device_name
                 else None
             )
-            AppHelper.callAfter(app._recording_indicator.show, initial_dev)
-            self._show_mode_on_indicator()
+            initial_mode = self._get_mode_label()
+            AppHelper.callAfter(
+                app._recording_indicator.show, initial_dev, initial_mode,
+            )
 
             if app._transcriber.supports_streaming:
                 AppHelper.callAfter(self._show_live_overlay, False)
@@ -1311,21 +1313,27 @@ class RecordingFlow:
             "Mode nav %s → %s", "prev" if delta < 0 else "next", new_mode
         )
 
-    def _show_mode_on_indicator(self) -> None:
+    def _get_mode_label(self) -> str | None:
+        """Return the current enhance-mode label, or None if not applicable."""
         if self._no_preview_override:
-            return
-        from PyObjCTools import AppHelper
-
+            return None
         modes = self._build_mode_list()
         if len(modes) <= 1:
-            return
+            return None
         current = self._app._enhance_mode
         idx = next(
             (i for i, (mid, _) in enumerate(modes) if mid == current), -1
         )
         if idx < 0:
+            return None
+        return modes[idx][1]
+
+    def _show_mode_on_indicator(self) -> None:
+        label = self._get_mode_label()
+        if label is None:
             return
-        label = modes[idx][1]
+        from PyObjCTools import AppHelper
+
         AppHelper.callAfter(
             self._app._recording_indicator.update_mode,
             label,

--- a/src/wenzi/screenshot/annotation.py
+++ b/src/wenzi/screenshot/annotation.py
@@ -158,6 +158,15 @@ class AnnotationLayer:
         self._panel.on_close(self._on_panel_closed)
         self._panel.show()
 
+        # screencapture hands focus back to the previous app when it exits.
+        # Re-activate our app so the annotation window comes to front.
+        from AppKit import NSApp
+
+        ns_panel = self._panel._panel
+        if ns_panel is not None:
+            NSApp.activate()
+            ns_panel.makeKeyAndOrderFront_(None)
+
         logger.debug(
             "Annotation layer shown: %dx%d window=%d (image %dx%d, scale %.2f)",
             canvas_w, canvas_h + _TOOLBAR_HEIGHT, window_w, img_w, img_h, scale,

--- a/src/wenzi/scripting/api/alert.py
+++ b/src/wenzi/scripting/api/alert.py
@@ -1,11 +1,11 @@
-"""vt.alert — floating on-screen alert overlay (HUD-style)."""
+"""wz.alert — floating on-screen alert overlay with Liquid Glass styling."""
 
 from __future__ import annotations
 
 import logging
 
 from wenzi.async_loop import call_later
-from wenzi.ui_helpers import release_panel_surfaces
+from wenzi.ui_helpers import dynamic_color, release_panel_surfaces
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,10 @@ _V_PADDING = 12
 _MAX_WIDTH = 600
 _MIN_WIDTH = 160
 _FADE_DURATION = 0.35
+
+# Cached dynamic colors for highlight / outline decorations
+_HIGHLIGHT_COLOR = dynamic_color((1.0, 1.0, 1.0, 0.16), (1.0, 1.0, 1.0, 0.08))
+_OUTLINE_COLOR = dynamic_color((1.0, 1.0, 1.0, 0.26), (1.0, 1.0, 1.0, 0.14))
 
 
 def _measure_text(text: str, font):
@@ -61,15 +65,17 @@ def _show_alert(text: str, duration: float) -> None:
         NSColor,
         NSFont,
         NSFontWeightMedium,
+        NSGlassEffectView,
         NSMakeRect,
         NSPanel,
         NSScreen,
         NSStatusWindowLevel,
         NSTextAlignmentCenter,
         NSTextField,
-        NSVisualEffectMaterialHUDWindow,
-        NSVisualEffectView,
+        NSView,
     )
+
+    from wenzi.ui_helpers import configure_glass_appearance
 
     # Close existing alert immediately (no fade)
     if _current_panel is not None:
@@ -103,16 +109,31 @@ def _show_alert(text: str, duration: float) -> None:
     panel.setHidesOnDeactivate_(False)
     panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
 
-    # Vibrancy background (macOS frosted glass)
-    vibrancy = NSVisualEffectView.alloc().initWithFrame_(
+    # Liquid Glass background
+    glass = NSGlassEffectView.alloc().initWithFrame_(
         NSMakeRect(0, 0, panel_width, panel_height)
     )
-    vibrancy.setMaterial_(NSVisualEffectMaterialHUDWindow)
-    vibrancy.setState_(1)  # NSVisualEffectStateActive — always active
-    vibrancy.setWantsLayer_(True)
-    vibrancy.layer().setCornerRadius_(panel_height / 2)  # pill shape
-    vibrancy.layer().setMasksToBounds_(True)
-    panel.contentView().addSubview_(vibrancy)
+    glass.setCornerRadius_(panel_height / 2)  # pill shape
+    glass.setWantsLayer_(True)
+    glass.layer().setMasksToBounds_(True)
+    configure_glass_appearance(glass)
+    panel.setContentView_(glass)
+
+    # Add a subtle highlight band and crisp outline so the glass reads
+    # more clearly than the default material alone.
+    highlight = NSView.alloc().initWithFrame_(
+        NSMakeRect(1, panel_height * 0.50, panel_width - 2, panel_height * 0.38)
+    )
+    highlight.setWantsLayer_(True)
+    highlight.layer().setBackgroundColor_(_HIGHLIGHT_COLOR.CGColor())
+    highlight.layer().setCornerRadius_(panel_height * 0.19)
+    glass.addSubview_(highlight)
+
+    outline = NSView.alloc().initWithFrame_(NSMakeRect(0, 0, panel_width, panel_height))
+    outline.setWantsLayer_(True)
+    outline.layer().setCornerRadius_(panel_height / 2)
+    outline.layer().setBorderWidth_(1.0)
+    outline.layer().setBorderColor_(_OUTLINE_COLOR.CGColor())
 
     # Text label
     label = NSTextField.labelWithString_(text)
@@ -126,12 +147,13 @@ def _show_alert(text: str, duration: float) -> None:
     label.setBezeled_(False)
     label.setEditable_(False)
     label.setSelectable_(False)
-    vibrancy.addSubview_(label)
+    glass.addSubview_(label)
+    glass.addSubview_(outline)
 
     # Position: center-top of main screen
     screen = NSScreen.mainScreen()
     if screen:
-        sf = screen.frame()
+        sf = screen.visibleFrame()
         x = sf.origin.x + (sf.size.width - panel_width) / 2
         y = sf.origin.y + sf.size.height - panel_height - 100
         panel.setFrameOrigin_((x, y))

--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -212,7 +212,7 @@ class ChooserPanel:
     def __init__(self, usage_tracker=None) -> None:
         self._panel = None
         self._webview = None
-        self._vfx_view = None
+        self._glass_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -343,14 +343,16 @@ class ChooserPanel:
     # Panel reuse helpers
     # ------------------------------------------------------------------
 
-    _VFX_MATERIAL = 5  # NSVisualEffectMaterialMenu
+    def _activate_glass(self) -> None:
+        """Re-lock glass appearance to the current system theme.
 
-    def _activate_vfx(self) -> None:
-        """Re-activate the VFX view."""
-        if self._vfx_view is None:
-            return
-        self._vfx_view.setState_(1)  # NSVisualEffectStateActive
-        self._vfx_view.setMaterial_(self._VFX_MATERIAL)
+        The panel is reused across open/close cycles, so the system theme
+        may have changed since the panel was built.
+        """
+        if self._glass_view is not None:
+            from wenzi.ui_helpers import configure_glass_appearance
+
+            configure_glass_appearance(self._glass_view)
 
     def _reconnect_panel_refs(self) -> None:
         """Restore ``_panel_ref`` back-references broken by :meth:`close`."""
@@ -361,12 +363,23 @@ class ChooserPanel:
         if self._panel_delegate is not None:
             self._panel_delegate._panel_ref = self
 
-    def _deactivate_vfx(self) -> None:
-        """Deactivate VFX and shrink panel to release IOSurface memory."""
-        from wenzi.ui_helpers import release_panel_surfaces
+    def _deactivate_glass(self) -> None:
+        """Shrink the hidden panel to 1x1 to force Core Animation to release
+        the NSGlassEffectView IOSurface backing store (~72 MB+ at retina).
 
-        release_panel_surfaces(self._panel)
+        ``orderOut_`` alone does not release these surfaces.
+        """
         self._last_screen = None
+        if self._panel is not None:
+            try:
+                from Foundation import NSMakeRect
+
+                f = self._panel.frame()
+                self._panel.setFrame_display_(
+                    NSMakeRect(f.origin.x, f.origin.y, 1, 1), False
+                )
+            except Exception:
+                pass
 
     def _reset_panel_ui(
         self,
@@ -560,40 +573,27 @@ class ChooserPanel:
     def _maybe_close(self) -> None:
         """Close unless QL preview or calculator mode is active.
 
-        Called on a deferred schedule after either the chooser or the QL
-        panel loses key-window status.  Gives macOS time to assign the
-        new key window before we check.
-
-        Note: we intentionally do NOT check whether the chooser panel
-        regained key-window status.  Because the panel is a floating
-        window at NSStatusWindowLevel, macOS may route focus back to it
-        after another app activates (e.g. via a system shortcut).
-        Ignoring the regained-key case ensures the panel closes
-        reliably whenever focus is lost.
+        Called synchronously from ``windowDidResignKey_``.  We must NOT
+        defer this check — the floating panel at NSStatusWindowLevel can
+        re-acquire key-window status within milliseconds, causing the
+        chooser to "grab focus back" from the app the user switched to.
         """
-        if self._closing:
+        if self._closing or self._panel is None:
             return
 
-        def _check():
-            if self._closing or self._panel is None:
+        try:
+            # QL panel is now key — user is interacting with preview
+            if self._ql_panel is not None and self._ql_panel.is_key_window:
                 return
-            try:
-                # QL panel is now key — user is interacting with preview
-                if self._ql_panel is not None and self._ql_panel.is_key_window:
-                    return
-            except Exception:
-                pass
+        except Exception:
+            pass
 
-            # Calculator mode: keep panel visible, listen for ESC
-            if self._should_pin_for_calc():
-                self._enter_calc_mode()
-                return
+        # Calculator mode: keep panel visible, listen for ESC
+        if self._should_pin_for_calc():
+            self._enter_calc_mode()
+            return
 
-            self.close()
-
-        from PyObjCTools import AppHelper
-
-        AppHelper.callLater(0.1, _check)
+        self.close()
 
     # ------------------------------------------------------------------
     # Calculator pin mode
@@ -769,7 +769,7 @@ class ChooserPanel:
             # Hot path — reuse hidden panel.  Hide via alpha until
             # _reset_panel_ui JS completes so stale results never flash.
             self._reconnect_panel_refs()
-            self._activate_vfx()
+            self._activate_glass()
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             self._reset_panel_ui(initial_query, placeholder)
@@ -778,7 +778,7 @@ class ChooserPanel:
             # (recycled in prebuild mode).  Load HTML — _on_page_loaded
             # will handle pending query, placeholder, and context.
             self._reconnect_panel_refs()
-            self._activate_vfx()
+            self._activate_glass()
             self._position_on_mouse_screen()
             self._panel.setAlphaValue_(0.0)
             if not self._recycle_preloading:
@@ -891,7 +891,7 @@ class ChooserPanel:
             )
 
         if self._panel is not None:
-            self._deactivate_vfx()
+            self._deactivate_glass()
             self._panel.orderOut_(None)
 
         self._closing = False
@@ -945,14 +945,12 @@ class ChooserPanel:
         from wenzi.ui.web_utils import cleanup_webview
 
         cleanup_webview(self._webview, handler_name="chooser")
-        if self._vfx_view is not None:
-            self._vfx_view.setState_(0)
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._panel.orderOut_(None)
         self._panel = None
         self._webview = None
-        self._vfx_view = None
+        self._glass_view = None
         self._message_handler = None
         self._navigation_delegate = None
         self._panel_delegate = None
@@ -1914,12 +1912,11 @@ class ChooserPanel:
 
         # Reveal the panel if it was hidden (alpha=0) during the warm-start
         # path.  This is a no-op on the cold path where alpha is already 1.
-        # For recycle preloads (panel not on screen), shrink to 1×1 instead
-        # to release IOSurface compositing layer buffers while keeping
-        # DOM/JS state alive for a fast hot-path re-show.
+        # For recycle preloads (panel not on screen), deactivate glass to
+        # release IOSurface memory while keeping DOM/JS state alive.
         if self._panel is not None:
             if was_preloading and not self._panel.isVisible():
-                self._deactivate_vfx()
+                self._deactivate_glass()
             else:
                 self._panel.setAlphaValue_(1.0)
 
@@ -2023,8 +2020,8 @@ class ChooserPanel:
         panel.setMovableByWindowBackground_(False)
         panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
 
-        # Transparent background — NSVisualEffectView provides the frosted glass
-        from AppKit import NSColor, NSVisualEffectView
+        # Transparent background — NSGlassEffectView provides the Liquid Glass
+        from AppKit import NSColor, NSGlassEffectView
 
         panel.setBackgroundColor_(NSColor.clearColor())
 
@@ -2041,19 +2038,20 @@ class ChooserPanel:
         panel.setDelegate_(delegate)
         self._panel_delegate = delegate
 
-        # NSVisualEffectView for native frosted glass blur
-        vfx = NSVisualEffectView.alloc().initWithFrame_(
+        # NSGlassEffectView for Liquid Glass background (subview, not contentView,
+        # to preserve NSPanel's focus / responder-chain management)
+        from wenzi.ui_helpers import configure_glass_appearance
+
+        glass = NSGlassEffectView.alloc().initWithFrame_(
             NSMakeRect(0, 0, initial_width, initial_height),
         )
-        vfx.setBlendingMode_(0)  # NSVisualEffectBlendingModeBehindWindow
-        vfx.setState_(1)  # NSVisualEffectStateActive
-        vfx.setAutoresizingMask_(0x12)  # Width + Height sizable
-        vfx.setWantsLayer_(True)
-        vfx.layer().setCornerRadius_(18.0)
-        vfx.layer().setMasksToBounds_(True)
-        panel.contentView().addSubview_(vfx)
-        self._vfx_view = vfx
-        self._activate_vfx()
+        glass.setCornerRadius_(18.0)
+        glass.setWantsLayer_(True)
+        glass.layer().setMasksToBounds_(True)  # clip webview to rounded corners
+        glass.setAutoresizingMask_(0x12)  # Width + Height sizable
+        configure_glass_appearance(glass)
+        panel.contentView().addSubview_(glass)
+        self._glass_view = glass
 
         # Position: center-top of mouse screen (like Spotlight)
         self._panel = panel
@@ -2077,7 +2075,7 @@ class ChooserPanel:
         )
         webview.setAutoresizingMask_(0x12)  # Width + Height sizable
         webview.setValue_forKey_(False, "drawsBackground")
-        vfx.addSubview_(webview)
+        glass.addSubview_(webview)
 
         # Navigation delegate
         nav_cls = _get_navigation_delegate_class()
@@ -2094,7 +2092,7 @@ class ChooserPanel:
         self._recycle_preloading = False
 
         if not load_html:
-            self._deactivate_vfx()
+            self._deactivate_glass()
             return
 
         # Load HTML from a temp file so WKWebView grants file:// access.

--- a/src/wenzi/scripting/ui/leader_alert.py
+++ b/src/wenzi/scripting/ui/leader_alert.py
@@ -1,7 +1,7 @@
-"""Leader-key floating alert panel (HUD-style).
+"""Leader-key floating alert panel with Liquid Glass styling.
 
 Displays available sub-key mappings when a leader trigger key is held.
-Uses NSVisualEffectView for native macOS vibrancy with fade animations.
+Uses NSGlassEffectView for native macOS glass with fade animations.
 """
 
 from __future__ import annotations
@@ -17,14 +17,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 # Layout constants
-_PANEL_WIDTH = 360
-_PADDING = 20
-_TITLE_HEIGHT = 26
-_ROW_HEIGHT = 28
-_BADGE_SIZE = 22
-_BADGE_CORNER = 6
-_GAP_AFTER_TITLE = 10
-_GAP_AFTER_SEP = 8
+_PANEL_WIDTH = 320
+_PADDING = 16
+_TITLE_HEIGHT = 22
+_ROW_HEIGHT = 26
+_BADGE_SIZE = 19
+_BADGE_CORNER = 5
+_GAP_AFTER_TITLE = 6
 _CORNER_RADIUS = 14
 _FADE_IN = 0.15
 _FADE_OUT = 0.2
@@ -55,6 +54,7 @@ class LeaderAlertPanel:
             NSFont,
             NSFontWeightMedium,
             NSFontWeightSemibold,
+            NSGlassEffectView,
             NSMakeRect,
             NSPanel,
             NSScreen,
@@ -62,9 +62,9 @@ class LeaderAlertPanel:
             NSTextAlignmentCenter,
             NSTextField,
             NSView,
-            NSVisualEffectMaterialHUDWindow,
-            NSVisualEffectView,
         )
+
+        from wenzi.ui_helpers import configure_glass_appearance
 
         if self._panel is not None:
             self.close()
@@ -74,8 +74,6 @@ class LeaderAlertPanel:
             _PADDING
             + _TITLE_HEIGHT
             + _GAP_AFTER_TITLE
-            + 1  # separator
-            + _GAP_AFTER_SEP
             + num_rows * _ROW_HEIGHT
             + _PADDING
         )
@@ -96,16 +94,21 @@ class LeaderAlertPanel:
         panel.setHidesOnDeactivate_(False)
         panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))  # canJoinAllSpaces | stationary | fullScreenAuxiliary
 
-        # --- Vibrancy background ---
-        vibrancy = NSVisualEffectView.alloc().initWithFrame_(
+        # --- Liquid Glass background ---
+        glass = NSGlassEffectView.alloc().initWithFrame_(
             NSMakeRect(0, 0, _PANEL_WIDTH, panel_height)
         )
-        vibrancy.setMaterial_(NSVisualEffectMaterialHUDWindow)
-        vibrancy.setState_(1)  # NSVisualEffectStateActive
-        vibrancy.setWantsLayer_(True)
-        vibrancy.layer().setCornerRadius_(_CORNER_RADIUS)
-        vibrancy.layer().setMasksToBounds_(True)
-        panel.contentView().addSubview_(vibrancy)
+        glass.setCornerRadius_(_CORNER_RADIUS)
+        glass.setWantsLayer_(True)
+        glass.layer().setMasksToBounds_(True)
+        configure_glass_appearance(glass)
+        panel.setContentView_(glass)
+
+        container = NSView.alloc().initWithFrame_(
+            NSMakeRect(0, 0, _PANEL_WIDTH, panel_height)
+        )
+        container.setAutoresizingMask_(0x12)  # Width + Height sizable
+        glass.setContentView_(container)
 
         # --- Title ---
         title_font = NSFont.systemFontOfSize_weight_(15.0, NSFontWeightSemibold)
@@ -115,22 +118,13 @@ class LeaderAlertPanel:
             NSMakeRect(_PADDING, y_cursor, _PANEL_WIDTH - _PADDING * 2, _TITLE_HEIGHT)
         )
         title.setFont_(title_font)
-        title.setTextColor_(NSColor.labelColor())
+        title.setTextColor_(NSColor.secondaryLabelColor())
         title.setBackgroundColor_(NSColor.clearColor())
         title.setBezeled_(False)
         title.setEditable_(False)
         title.setSelectable_(False)
-        vibrancy.addSubview_(title)
-
-        # --- Separator ---
+        container.addSubview_(title)
         y_cursor -= _GAP_AFTER_TITLE
-        sep = NSView.alloc().initWithFrame_(
-            NSMakeRect(_PADDING, y_cursor, _PANEL_WIDTH - _PADDING * 2, 1)
-        )
-        sep.setWantsLayer_(True)
-        sep.layer().setBackgroundColor_(NSColor.separatorColor().CGColor())
-        vibrancy.addSubview_(sep)
-        y_cursor -= 1 + _GAP_AFTER_SEP
 
         # --- Mapping rows ---
         key_font = NSFont.monospacedSystemFontOfSize_weight_(12.0, NSFontWeightMedium)
@@ -139,7 +133,7 @@ class LeaderAlertPanel:
             0.5, 0.5, 0.5, 0.15
         ).CGColor()
         badge_x = _PADDING
-        desc_x = _PADDING + _BADGE_SIZE + 12
+        desc_x = _PADDING + _BADGE_SIZE + 10
         desc_width = _PANEL_WIDTH - desc_x - _PADDING
 
         for m in mappings:
@@ -153,7 +147,7 @@ class LeaderAlertPanel:
             badge.setWantsLayer_(True)
             badge.layer().setBackgroundColor_(badge_bg_cg)
             badge.layer().setCornerRadius_(_BADGE_CORNER)
-            vibrancy.addSubview_(badge)
+            container.addSubview_(badge)
 
             # Badge key letter
             key_label = NSTextField.labelWithString_(m.key.upper())
@@ -177,14 +171,19 @@ class LeaderAlertPanel:
             desc_label.setBezeled_(False)
             desc_label.setEditable_(False)
             desc_label.setSelectable_(False)
-            vibrancy.addSubview_(desc_label)
+            try:
+                desc_label.setUsesSingleLineMode_(True)
+                desc_label.cell().setLineBreakMode_(4)  # NSLineBreakByTruncatingTail
+            except Exception:
+                pass
+            container.addSubview_(desc_label)
 
             y_cursor = row_y
 
         # --- Position ---
         screen = NSScreen.mainScreen()
         if screen:
-            sf = screen.frame()
+            sf = screen.visibleFrame()
             x, y = self._calculate_origin(
                 position, _PANEL_WIDTH, panel_height, sf, NSEvent,
             )

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -1,6 +1,6 @@
 """Floating overlay panel for Direct mode streaming AI enhancement output.
 
-Uses native AppKit views (NSVisualEffectView + NSTextView) for instant
+Uses native AppKit views (NSGlassEffectView + NSTextView) for instant
 rendering, dynamic height, and seamless visual transition from the
 recording indicator.
 """
@@ -38,11 +38,6 @@ _CLOSE_DELAY = 3.0
 _HOVER_RECHECK_INTERVAL = 0.5
 _FADE_OUT_DURATION = 0.3
 
-# NSVisualEffectView constants
-_VFX_MATERIAL_HUD = 13
-_VFX_BLENDING_BEHIND = 0
-_VFX_STATE_ACTIVE = 1
-
 # Height recalc debounce
 _RECALC_DEBOUNCE = 0.05
 
@@ -57,7 +52,7 @@ class StreamingOverlayPanel:
 
     def __init__(self) -> None:
         self._panel: object = None
-        self._vfx_view: object = None
+        self._content_box: object = None
         self._asr_title_label: object = None
         self._asr_text_view: object = None
         self._asr_scroll: object = None
@@ -169,10 +164,10 @@ class StreamingOverlayPanel:
         try:
             from AppKit import (
                 NSColor,
+                NSGlassEffectView,
                 NSPanel,
                 NSScreen,
                 NSStatusWindowLevel,
-                NSVisualEffectView,
             )
             from Foundation import NSMakeRect
 
@@ -250,32 +245,38 @@ class StreamingOverlayPanel:
                 (1 << 0) | (1 << 4) | (1 << 8)
             )
 
-            # -- VFX background --
-            vfx = NSVisualEffectView.alloc().initWithFrame_(
+            # -- Liquid Glass background --
+            glass = NSGlassEffectView.alloc().initWithFrame_(
                 NSMakeRect(0, 0, _PANEL_WIDTH, init_h)
             )
-            vfx.setMaterial_(_VFX_MATERIAL_HUD)
-            vfx.setBlendingMode_(_VFX_BLENDING_BEHIND)
-            vfx.setState_(_VFX_STATE_ACTIVE)
-            vfx.setWantsLayer_(True)
-            vfx.layer().setCornerRadius_(_CORNER_RADIUS)
-            vfx.layer().setMasksToBounds_(True)
-            vfx.setAutoresizingMask_(0x12)  # flex W+H
-            panel.setContentView_(vfx)
-            self._vfx_view = vfx
+            glass.setCornerRadius_(_CORNER_RADIUS)
+            glass.setTintColor_(
+                NSColor.colorWithSRGBRed_green_blue_alpha_(1.0, 1.0, 1.0, 0.2)
+            )
+            panel.setContentView_(glass)
+
+            # Container for subviews inside glass
+            from AppKit import NSView as _NSView
+
+            box = _NSView.alloc().initWithFrame_(
+                NSMakeRect(0, 0, _PANEL_WIDTH, init_h)
+            )
+            box.setAutoresizingMask_(0x12)  # flex W+H
+            glass.setContentView_(box)
+            self._content_box = box
 
             self._panel = panel
 
             # -- Add subviews once (repositioned by _layout_subviews) --
-            vfx.addSubview_(self._asr_title_label)
-            vfx.addSubview_(self._asr_scroll)
-            vfx.addSubview_(self._separator)
-            vfx.addSubview_(self._status_label)
-            vfx.addSubview_(self._stream_scroll)
+            box.addSubview_(self._asr_title_label)
+            box.addSubview_(self._asr_scroll)
+            box.addSubview_(self._separator)
+            box.addSubview_(self._status_label)
+            box.addSubview_(self._stream_scroll)
             if self._hint_label is not None:
-                vfx.addSubview_(self._hint_label)
+                box.addSubview_(self._hint_label)
             if self._progress_view is not None:
-                vfx.addSubview_(self._progress_view)
+                box.addSubview_(self._progress_view)
 
             # -- Position at screen centre --
             screen = NSScreen.mainScreen()
@@ -326,7 +327,7 @@ class StreamingOverlayPanel:
         """
         from Foundation import NSMakeRect
 
-        if self._vfx_view is None:
+        if self._content_box is None:
             return
 
         cw = _PANEL_WIDTH - _PADDING_H * 2
@@ -433,11 +434,6 @@ class StreamingOverlayPanel:
         def _after_resize():
             try:
                 self._layout_subviews(new_h)
-                self._vfx_view.setFrame_(
-                    self._panel.contentView().bounds()
-                    if self._panel
-                    else self._vfx_view.frame()
-                )
             except Exception:
                 logger.error("After-resize completion error", exc_info=True)
 
@@ -922,13 +918,10 @@ class StreamingOverlayPanel:
             self._recalc_timer = None
 
         if self._panel is not None:
-            from wenzi.ui_helpers import release_panel_surfaces
-
-            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
 
-        self._vfx_view = None
+        self._content_box = None
         self._asr_title_label = None
         self._asr_text_view = None
         self._asr_scroll = None

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -46,7 +46,7 @@ class StreamingOverlayPanel:
     """Non-interactive floating overlay that displays streaming AI enhancement.
 
     Shows ASR original text at top, streaming enhanced text below.
-    Uses native AppKit views with NSVisualEffectView for frosted-glass
+    Uses native AppKit views with NSGlassEffectView for Liquid Glass
     appearance matching the recording indicator.
     """
 
@@ -116,18 +116,14 @@ class StreamingOverlayPanel:
         )
         from Foundation import NSMakeRect
 
-        scroll = NSScrollView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, width, 20)
-        )
+        scroll = NSScrollView.alloc().initWithFrame_(NSMakeRect(0, 0, width, 20))
         scroll.setHasVerticalScroller_(True)
         scroll.setHasHorizontalScroller_(False)
         scroll.setAutohidesScrollers_(True)
         scroll.setDrawsBackground_(False)
         scroll.setBorderType_(0)  # NSNoBorder
 
-        tv = NSTextView.alloc().initWithFrame_(
-            NSMakeRect(0, 0, width, 20)
-        )
+        tv = NSTextView.alloc().initWithFrame_(NSMakeRect(0, 0, width, 20))
         tv.setEditable_(False)
         tv.setSelectable_(True)
         tv.setDrawsBackground_(False)
@@ -196,7 +192,8 @@ class StreamingOverlayPanel:
                 self._transcribing = False
             else:
                 self._set_text(
-                    self._asr_text_view, "Transcribing",
+                    self._asr_text_view,
+                    "Transcribing",
                     italic=True,
                 )
                 self._transcribing = True
@@ -206,9 +203,7 @@ class StreamingOverlayPanel:
 
             sep = _NSView.alloc().initWithFrame_(NSMakeRect(0, 0, content_w, 1))
             sep.setWantsLayer_(True)
-            sep.layer().setBackgroundColor_(
-                NSColor.separatorColor().CGColor()
-            )
+            sep.layer().setBackgroundColor_(NSColor.separatorColor().CGColor())
             sep.layer().setOpacity_(0.4)
             self._separator = sep
 
@@ -233,7 +228,9 @@ class StreamingOverlayPanel:
             init_h = self._compute_height()
             panel = NSPanel.alloc().initWithContentRect_styleMask_backing_defer_(
                 NSMakeRect(0, 0, _PANEL_WIDTH, init_h),
-                0, 2, False,
+                0,
+                2,
+                False,
             )
             panel.setLevel_(NSStatusWindowLevel + 1)
             panel.setOpaque_(False)
@@ -241,26 +238,20 @@ class StreamingOverlayPanel:
             panel.setIgnoresMouseEvents_(False)
             panel.setHasShadow_(True)
             panel.setHidesOnDeactivate_(False)
-            panel.setCollectionBehavior_(
-                (1 << 0) | (1 << 4) | (1 << 8)
-            )
+            panel.setCollectionBehavior_((1 << 0) | (1 << 4) | (1 << 8))
 
             # -- Liquid Glass background --
-            glass = NSGlassEffectView.alloc().initWithFrame_(
-                NSMakeRect(0, 0, _PANEL_WIDTH, init_h)
-            )
+            from wenzi.ui_helpers import configure_glass_appearance
+
+            glass = NSGlassEffectView.alloc().initWithFrame_(NSMakeRect(0, 0, _PANEL_WIDTH, init_h))
             glass.setCornerRadius_(_CORNER_RADIUS)
-            glass.setTintColor_(
-                NSColor.colorWithSRGBRed_green_blue_alpha_(1.0, 1.0, 1.0, 0.2)
-            )
+            configure_glass_appearance(glass)
             panel.setContentView_(glass)
 
             # Container for subviews inside glass
             from AppKit import NSView as _NSView
 
-            box = _NSView.alloc().initWithFrame_(
-                NSMakeRect(0, 0, _PANEL_WIDTH, init_h)
-            )
+            box = _NSView.alloc().initWithFrame_(NSMakeRect(0, 0, _PANEL_WIDTH, init_h))
             box.setAutoresizingMask_(0x12)  # flex W+H
             glass.setContentView_(box)
             self._content_box = box
@@ -295,6 +286,7 @@ class StreamingOverlayPanel:
                 panel.orderFront_(None)
                 self._layout_subviews(init_h)  # layout for target size
                 from AppKit import NSAnimationContext
+
                 NSAnimationContext.beginGrouping()
                 ctx = NSAnimationContext.currentContext()
                 ctx.setDuration_(0.25)
@@ -334,9 +326,7 @@ class StreamingOverlayPanel:
         y = panel_h - _PADDING_V  # start from top
 
         y -= _LABEL_HEIGHT
-        self._asr_title_label.setFrame_(
-            NSMakeRect(_PADDING_H, y, cw, _LABEL_HEIGHT)
-        )
+        self._asr_title_label.setFrame_(NSMakeRect(_PADDING_H, y, cw, _LABEL_HEIGHT))
 
         y -= 2  # small gap
         asr_h = min(self._text_content_height(self._asr_text_view), _ASR_MAX_HEIGHT)
@@ -361,20 +351,17 @@ class StreamingOverlayPanel:
         # Stream text fills remaining space
         y -= 2
         stream_h = max(y - bottom_for_stream, 16)
-        self._stream_scroll.setFrame_(
-            NSMakeRect(_PADDING_H, bottom_for_stream, cw, stream_h)
-        )
+        self._stream_scroll.setFrame_(NSMakeRect(_PADDING_H, bottom_for_stream, cw, stream_h))
 
         if self._progress_view is not None:
             pw = self._progress_view.frame().size.width
-            self._progress_view.setFrame_(
-                NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, pw, _PROGRESS_HEIGHT)
-            )
+            self._progress_view.setFrame_(NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, pw, _PROGRESS_HEIGHT))
 
     def _compute_height(self) -> float:
         """Compute ideal panel height from content."""
         asr_h = min(
-            self._text_content_height(self._asr_text_view), _ASR_MAX_HEIGHT,
+            self._text_content_height(self._asr_text_view),
+            _ASR_MAX_HEIGHT,
         )
         asr_h = max(asr_h, 16)
         stream_h = self._text_content_height(self._stream_text_view)
@@ -382,10 +369,17 @@ class StreamingOverlayPanel:
 
         total = (
             _PADDING_V
-            + _LABEL_HEIGHT + 2 + asr_h
-            + _SECTION_SPACING + 1 + _SECTION_SPACING
-            + _LABEL_HEIGHT + 2 + stream_h
-            + _LABEL_HEIGHT + _HINT_GAP
+            + _LABEL_HEIGHT
+            + 2
+            + asr_h
+            + _SECTION_SPACING
+            + 1
+            + _SECTION_SPACING
+            + _LABEL_HEIGHT
+            + 2
+            + stream_h
+            + _LABEL_HEIGHT
+            + _HINT_GAP
             + _PADDING_V
         )
         return max(_MIN_HEIGHT, min(total, _MAX_HEIGHT))
@@ -396,8 +390,13 @@ class StreamingOverlayPanel:
             return
         try:
             from Foundation import NSTimer
+
             self._recalc_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                _RECALC_DEBOUNCE, self, b"_doRecalcHeight:", None, False,
+                _RECALC_DEBOUNCE,
+                self,
+                b"_doRecalcHeight:",
+                None,
+                False,
             )
         except Exception:
             self._do_recalculate_height()
@@ -463,7 +462,8 @@ class StreamingOverlayPanel:
 
     @staticmethod
     def _set_text(
-        text_view, text: str,
+        text_view,
+        text: str,
         secondary: bool = False,
         italic: bool = False,
     ) -> None:
@@ -477,8 +477,9 @@ class StreamingOverlayPanel:
         attrs = NSMutableDictionary.dictionary()
         if italic:
             attrs["NSFont"] = NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
-                    NSFont.systemFontOfSize_(_FONT_SIZE), 1,  # NSItalicFontMask
-                )
+                NSFont.systemFontOfSize_(_FONT_SIZE),
+                1,  # NSItalicFontMask
+            )
         else:
             attrs["NSFont"] = NSFont.systemFontOfSize_(_FONT_SIZE)
         if secondary:
@@ -487,7 +488,8 @@ class StreamingOverlayPanel:
             attrs["NSColor"] = NSColor.labelColor()
 
         astr = NSAttributedString.alloc().initWithString_attributes_(
-            text, attrs,
+            text,
+            attrs,
         )
         text_view.textStorage().setAttributedString_(astr)
 
@@ -497,7 +499,8 @@ class StreamingOverlayPanel:
         from Foundation import NSAttributedString, NSMakeRange
 
         astr = NSAttributedString.alloc().initWithString_attributes_(
-            text, attrs,
+            text,
+            attrs,
         )
         ts = text_view.textStorage()
         ts.appendAttributedString_(astr)
@@ -529,7 +532,8 @@ class StreamingOverlayPanel:
                 return event
 
             keycode = cg.CGEventGetIntegerValueField(
-                event, cg.kCGKeyboardEventKeycode,
+                event,
+                cg.kCGKeyboardEventKeycode,
             )
 
             if keycode == _ESC_KEY_CODE:
@@ -550,6 +554,7 @@ class StreamingOverlayPanel:
 
             if keycode == 8 and (flags & cg.kCGEventFlagMaskCommand):  # Cmd+C
                 from PyObjCTools import AppHelper
+
                 AppHelper.callAfter(self._copy_stream_text)
                 return None
 
@@ -566,6 +571,7 @@ class StreamingOverlayPanel:
 
             if self._complete:
                 from PyObjCTools import AppHelper
+
                 AppHelper.callAfter(self._do_close)
                 return event  # close panel but let the key through
 
@@ -581,6 +587,7 @@ class StreamingOverlayPanel:
         if not text.strip():
             return
         from wenzi.input import set_clipboard_text
+
         set_clipboard_text(text)
         if self._status_label is not None:
             self._status_label.setStringValue_("\u2713 Copied to clipboard")
@@ -602,10 +609,12 @@ class StreamingOverlayPanel:
         try:
             from Foundation import NSTimer
 
-            self._loading_timer = (
-                NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                    0.5, self, b"tickLoadingTimer:", None, True,
-                )
+            self._loading_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                0.5,
+                self,
+                b"tickLoadingTimer:",
+                None,
+                True,
             )
         except Exception:
             logger.error("Failed to start loading timer", exc_info=True)
@@ -626,7 +635,8 @@ class StreamingOverlayPanel:
             if self._transcribing and self._asr_text_view is not None:
                 dots = "." * ((self._tick_count % 3) + 1)
                 self._set_text(
-                    self._asr_text_view, f"Transcribing{dots}",
+                    self._asr_text_view,
+                    f"Transcribing{dots}",
                     italic=True,
                 )
 
@@ -634,9 +644,7 @@ class StreamingOverlayPanel:
             if self._tick_count % 2 == 0:
                 self._loading_seconds += 1
                 if self._status_label is not None:
-                    self._status_label.setStringValue_(
-                        self._ai_label(f"\u23f3 {self._loading_seconds}s")
-                    )
+                    self._status_label.setStringValue_(self._ai_label(f"\u23f3 {self._loading_seconds}s"))
         except Exception:
             logger.error("Loading timer tick error", exc_info=True)
 
@@ -662,19 +670,16 @@ class StreamingOverlayPanel:
 
             if self._has_thinking:
                 from Foundation import NSAttributedString, NSMakeRange
+
                 astr = NSAttributedString.alloc().initWithString_attributes_(chunk, attrs)
                 ts = self._stream_text_view.textStorage()
-                ts.replaceCharactersInRange_withAttributedString_(
-                    NSMakeRange(0, ts.length()), astr
-                )
+                ts.replaceCharactersInRange_withAttributedString_(NSMakeRange(0, ts.length()), astr)
                 self._has_thinking = False
             else:
                 self._append_attributed(self._stream_text_view, chunk, attrs)
 
             if completion_tokens and self._status_label:
-                self._status_label.setStringValue_(
-                    self._ai_label(f"Chars: \u2193{completion_tokens}")
-                )
+                self._status_label.setStringValue_(self._ai_label(f"Chars: \u2193{completion_tokens}"))
 
             self._recalculate_height()
 
@@ -694,16 +699,15 @@ class StreamingOverlayPanel:
             self._has_thinking = True
             attrs = {
                 "NSFont": NSFontManager.sharedFontManager().convertFont_toHaveTrait_(
-                    NSFont.systemFontOfSize_(_FONT_SIZE), 1,  # NSItalicFontMask
+                    NSFont.systemFontOfSize_(_FONT_SIZE),
+                    1,  # NSItalicFontMask
                 ),
                 "NSColor": NSColor.tertiaryLabelColor(),
             }
             self._append_attributed(self._stream_text_view, chunk, attrs)
 
             if thinking_tokens and self._status_label:
-                self._status_label.setStringValue_(
-                    self._ai_label(f"\u25b6 Thinking: {thinking_tokens} chars")
-                )
+                self._status_label.setStringValue_(self._ai_label(f"\u25b6 Thinking: {thinking_tokens} chars"))
 
             self._recalculate_height()
 
@@ -757,17 +761,12 @@ class StreamingOverlayPanel:
                 prompt = usage.get("prompt_tokens", 0)
                 completion = usage.get("completion_tokens", 0)
                 total = usage["total_tokens"]
-                cached = usage.get("prompt_tokens_details", {}).get(
-                    "cached_tokens", 0
-                )
+                cached = usage.get("prompt_tokens_details", {}).get("cached_tokens", 0)
                 if cached:
                     up = f"\u2191{cached}+{prompt - cached}"
                 else:
                     up = f"\u2191{prompt}"
-                label = (
-                    f"{self._ai_label('')}  "
-                    f"Tokens: {total} ({up} \u2193{completion})"
-                )
+                label = f"{self._ai_label('')}  Tokens: {total} ({up} \u2193{completion})"
             else:
                 label = self._ai_label("")
             self._status_label.setStringValue_(label)
@@ -782,18 +781,18 @@ class StreamingOverlayPanel:
             if self._progress_view is None or self._panel is None or total <= 0:
                 return
             from Foundation import NSMakeRect
+
             w = _PANEL_WIDTH * (step / total)
             try:
                 panel_h = float(self._panel.frame().size.height)
             except (TypeError, ValueError):
                 return
             from AppKit import NSAnimationContext
+
             NSAnimationContext.beginGrouping()
             ctx = NSAnimationContext.currentContext()
             ctx.setDuration_(0.2)
-            self._progress_view.animator().setFrame_(
-                NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, w, _PROGRESS_HEIGHT)
-            )
+            self._progress_view.animator().setFrame_(NSMakeRect(0, panel_h - _PROGRESS_HEIGHT, w, _PROGRESS_HEIGHT))
             NSAnimationContext.endGrouping()
 
         AppHelper.callAfter(_update)
@@ -807,9 +806,7 @@ class StreamingOverlayPanel:
                 return
             from Foundation import NSAttributedString
 
-            self._stream_text_view.textStorage().setAttributedString_(
-                NSAttributedString.alloc().init()
-            )
+            self._stream_text_view.textStorage().setAttributedString_(NSAttributedString.alloc().init())
             self._has_thinking = False
             self._recalculate_height()
 
@@ -828,10 +825,12 @@ class StreamingOverlayPanel:
             try:
                 from Foundation import NSTimer
 
-                self._close_timer = (
-                    NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                        delay, self, b"_delayedCloseCheck:", None, False,
-                    )
+                self._close_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                    delay,
+                    self,
+                    b"_delayedCloseCheck:",
+                    None,
+                    False,
                 )
             except Exception:
                 logger.error("Failed to schedule delayed close", exc_info=True)
@@ -848,11 +847,12 @@ class StreamingOverlayPanel:
                 try:
                     from Foundation import NSTimer
 
-                    self._close_timer = (
-                        NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
-                            _HOVER_RECHECK_INTERVAL,
-                            self, b"_delayedCloseCheck:", None, False,
-                        )
+                    self._close_timer = NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
+                        _HOVER_RECHECK_INTERVAL,
+                        self,
+                        b"_delayedCloseCheck:",
+                        None,
+                        False,
                     )
                 except Exception:
                     self._do_close()
@@ -880,11 +880,13 @@ class StreamingOverlayPanel:
             NSAnimationContext.beginGrouping()
             ctx = NSAnimationContext.currentContext()
             ctx.setDuration_(_FADE_OUT_DURATION)
+
             def _safe_close():
                 try:
                     self._do_close()
                 except Exception:
                     logger.error("Fade-out close error", exc_info=True)
+
             ctx.setCompletionHandler_(_safe_close)
             self._panel.animator().setAlphaValue_(0.0)
             NSAnimationContext.endGrouping()

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -109,14 +109,13 @@ body {
 .search-bar {
     display: flex; align-items: center; gap: 8px;
     padding: 12px 16px;
-    border-bottom: 0.5px solid var(--border);
     flex-shrink: 0;
     position: relative;
 }
-/* Subtle bottom fade instead of hard line */
+/* Subtle bottom fade — inset so it never exceeds the panel's rounded corners */
 .search-bar::after {
     content: ''; position: absolute;
-    left: 16px; right: 16px; bottom: -0.5px; height: 0.5px;
+    left: 16px; right: 16px; bottom: 0; height: 0.5px;
     background: linear-gradient(90deg, transparent, var(--border), transparent);
     pointer-events: none;
 }

--- a/src/wenzi/ui/templates/chooser.html
+++ b/src/wenzi/ui/templates/chooser.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <style>
 :root {
-    --bg: transparent;
     --text: #1d1d1f;
     --secondary: #86868b;
     --border: rgba(0, 0, 0, 0.08);
@@ -13,14 +12,11 @@
     --item-hover: rgba(0, 0, 0, 0.06);
     --item-selected: rgba(0, 122, 255, 0.16);
     --item-selected-text: #003d99;
-    --input-bg: transparent;
-    --shadow: rgba(0, 0, 0, 0.06);
     --glass-badge: rgba(0, 0, 0, 0.06);
     --mark-bg: rgba(255, 204, 0, 0.35);
 }
 @media (prefers-color-scheme: dark) {
     :root {
-        --bg: transparent;
         --text: #e5e5e7;
         --secondary: #98989d;
         --border: rgba(255, 255, 255, 0.10);
@@ -28,8 +24,6 @@
         --item-hover: rgba(255, 255, 255, 0.08);
         --item-selected: rgba(10, 132, 255, 0.25);
         --item-selected-text: #64d2ff;
-        --input-bg: transparent;
-        --shadow: rgba(0, 0, 0, 0.3);
         --glass-badge: rgba(255, 255, 255, 0.10);
         --mark-bg: rgba(255, 214, 10, 0.30);
     }
@@ -41,13 +35,8 @@ html, body {
     color: var(--text);
     -webkit-user-select: none; user-select: none;
 }
-html { background: transparent; }
 body {
     display: flex; flex-direction: column;
-    position: relative;
-    background: transparent;
-    border-radius: 18px;
-    overflow: hidden;
 }
 
 /* Main content: left panel + preview */
@@ -70,7 +59,6 @@ body {
     border-left: 0.5px solid var(--border);
     padding: 16px; overflow: hidden;
     min-height: 0;
-    background: transparent;
 }
 .preview-panel.hidden { display: none; }
 .preview-panel.empty {
@@ -121,7 +109,6 @@ body {
 .search-bar {
     display: flex; align-items: center; gap: 8px;
     padding: 12px 16px;
-    background: var(--input-bg);
     border-bottom: 0.5px solid var(--border);
     flex-shrink: 0;
     position: relative;
@@ -154,7 +141,6 @@ body {
 .context-block {
     display: none; flex-shrink: 0;
     padding: 10px 14px;
-    background: transparent;
     border-bottom: 0.5px solid var(--border);
 }
 .context-block.visible { display: block; }
@@ -222,10 +208,8 @@ body {
     padding: 8px 12px; cursor: default;
     transition: background 0.2s ease;
     gap: 10px;
-    box-sizing: border-box;
     overflow: hidden;
     border-radius: 10px;
-    margin: 0 0;
 }
 .icon-wrap {
     position: relative; flex-shrink: 0;

--- a/src/wenzi/ui_helpers.py
+++ b/src/wenzi/ui_helpers.py
@@ -49,6 +49,33 @@ def release_panel_surfaces(panel) -> None:
         pass
 
 
+def configure_glass_appearance(glass) -> None:
+    """Lock an NSGlassEffectView to the current system light/dark theme.
+
+    By default NSGlassEffectView is *adaptive* — it samples behind-window
+    brightness and auto-switches light/dark, ignoring the system setting.
+    This helper forces it to follow the system appearance via
+    ``setAppearance_`` (public) and ``set_adaptiveAppearance_`` (private;
+    0=Light, 1=Dark, 2=Auto).
+
+    See CLAUDE.md "NSGlassEffectView — Lock Adaptive Appearance" for details.
+    """
+    try:
+        from AppKit import NSApp
+
+        sys_appearance = NSApp.effectiveAppearance()
+        name = sys_appearance.bestMatchFromAppearancesWithNames_(
+            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
+        )
+        is_dark = name is not None and "Dark" in str(name)
+
+        glass.setAppearance_(sys_appearance)
+        if glass.respondsToSelector_(b"set_adaptiveAppearance:"):
+            glass.set_adaptiveAppearance_(1 if is_dark else 0)
+    except Exception:
+        logger.debug("Failed to lock glass appearance", exc_info=True)
+
+
 def activate_for_dialog() -> None:
     """Set activation policy so modal dialogs can show from non-bundled process.
 

--- a/src/wenzi/ui_helpers.py
+++ b/src/wenzi/ui_helpers.py
@@ -15,27 +15,34 @@ logger = logging.getLogger(__name__)
 
 
 def release_panel_surfaces(panel) -> None:
-    """Deactivate NSVisualEffectView(s) and shrink panel to release IOSurface memory.
+    """Deactivate glass surfaces and shrink panel to release IOSurface memory.
 
     Call before or after ``orderOut_`` when hiding any panel that uses
-    ``NSVisualEffectView`` with behind-window blending.  See CLAUDE.md
-    "NSVisualEffectView Memory Management" for why this is needed.
+    ``NSGlassEffectView`` with behind-window blending. See CLAUDE.md
+    "Blur Panels — Use NSGlassEffectView" for why this is needed.
 
-    Safe to call on any NSPanel/NSWindow — no-ops gracefully if no VFX view.
+    Safe to call on any NSPanel/NSWindow — no-ops gracefully if no glass view.
     """
     if panel is None:
         return
-    # Deactivate all NSVisualEffectViews (content view itself or direct subviews)
+    # Deactivate all glass views (content view itself or direct subviews).
     try:
-        from AppKit import NSVisualEffectView
+        from AppKit import NSGlassEffectView
 
         cv = panel.contentView()
-        if isinstance(cv, NSVisualEffectView):
-            cv.setState_(0)  # NSVisualEffectStateInactive
+
+        if isinstance(cv, NSGlassEffectView):
+            try:
+                cv.setState_(0)  # inactive
+            except Exception:
+                pass
         if cv is not None:
             for sv in cv.subviews():
-                if isinstance(sv, NSVisualEffectView):
-                    sv.setState_(0)
+                if isinstance(sv, NSGlassEffectView):
+                    try:
+                        sv.setState_(0)
+                    except Exception:
+                        pass
     except Exception:
         pass
     # Shrink to 1×1 to force Core Animation to release the CA Whippet
@@ -47,6 +54,23 @@ def release_panel_surfaces(panel) -> None:
         panel.setFrame_display_(NSMakeRect(f.origin.x, f.origin.y, 1, 1), False)
     except Exception:
         pass
+
+
+def dynamic_color(light_rgba, dark_rgba):
+    """Create a dynamic NSColor that adapts to the system light/dark theme.
+
+    Each argument is an (r, g, b, a) tuple in the sRGB colour space.
+    """
+    from AppKit import NSColor
+
+    def _provider(appearance):
+        name = appearance.bestMatchFromAppearancesWithNames_(
+            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
+        )
+        rgba = dark_rgba if name and "Dark" in str(name) else light_rgba
+        return NSColor.colorWithSRGBRed_green_blue_alpha_(*rgba)
+
+    return NSColor.colorWithName_dynamicProvider_("dynamicColor", _provider)
 
 
 def configure_glass_appearance(glass) -> None:

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -71,7 +71,6 @@ class TestSourceRegistration:
         assert panel._usage_tracker is None
         assert panel._query_history is None
 
-
 class TestSearchLogic:
     def test_empty_query_returns_no_results(self):
         panel = _make_panel()
@@ -932,11 +931,7 @@ class TestQuickLookIntegration:
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            check_fn = mock_later.call_args[0][1]
-
-        check_fn()
+        panel._maybe_close()
         panel.close.assert_not_called()
 
     def test_maybe_close_closes_even_when_chooser_regained_key(self):
@@ -950,11 +945,7 @@ class TestQuickLookIntegration:
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            check_fn = mock_later.call_args[0][1]
-
-        check_fn()
+        panel._maybe_close()
         panel.close.assert_called_once()
 
     def test_maybe_close_closes_when_no_ql_panel(self):
@@ -963,11 +954,7 @@ class TestQuickLookIntegration:
         panel._panel = MagicMock()
         panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            check_fn = mock_later.call_args[0][1]
-
-        check_fn()
+        panel._maybe_close()
         panel.close.assert_called_once()
 
 
@@ -1244,15 +1231,12 @@ class TestCalcMode:
         panel._panel = MagicMock()
         panel._current_items = [_make_calc_item()]
         panel._start_esc_tap = MagicMock()
+        panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            # Extract and run the deferred _check callback
-            _check = mock_later.call_args[0][1]
-            _check()
+        panel._maybe_close()
 
         assert panel._calc_mode is True
-        panel.close = MagicMock()  # Should NOT have been called
+        panel.close.assert_not_called()
 
     def test_maybe_close_closes_without_calc_results(self):
         """_maybe_close should close normally without calc results."""
@@ -1261,10 +1245,7 @@ class TestCalcMode:
         panel._current_items = [ChooserItem(title="Safari")]
         panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            _check = mock_later.call_args[0][1]
-            _check()
+        panel._maybe_close()
 
         panel.close.assert_called_once()
 
@@ -1352,13 +1333,12 @@ class TestCalcMode:
         panel._current_items = []  # No calc results
         panel._calc_sticky = True  # But sticky from previous calc
         panel._start_esc_tap = MagicMock()
+        panel.close = MagicMock()
 
-        with patch("PyObjCTools.AppHelper.callLater") as mock_later:
-            panel._maybe_close()
-            _check = mock_later.call_args[0][1]
-            _check()
+        panel._maybe_close()
 
         assert panel._calc_mode is True
+        panel.close.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -1771,7 +1751,7 @@ class TestDeferredRecycle:
         panel = _make_panel()
         panel._panel = MagicMock()
         panel._webview = MagicMock()
-        with patch.object(panel, "_deactivate_vfx") as mock_release, \
+        with patch.object(panel, "_deactivate_glass") as mock_release, \
              patch("PyObjCTools.AppHelper.callLater"), \
              patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)), \
              patch("wenzi.scripting.ui.chooser_panel.reactivate_app"):
@@ -1832,11 +1812,11 @@ class TestDeferredRecycle:
         timer.cancel.assert_called_once()
         assert panel._recycle_timer is None
 
-    def test_destroy_deactivates_vfx_during_close(self):
+    def test_destroy_deactivates_glass_during_close(self):
         panel = _make_panel()
         panel._panel = MagicMock()
         panel._webview = MagicMock()
-        with patch.object(panel, "_deactivate_vfx") as mock_deactivate, \
+        with patch.object(panel, "_deactivate_glass") as mock_deactivate, \
              patch("wenzi.ui.web_utils.cleanup_webview"), \
              patch("PyObjCTools.AppHelper.callAfter", side_effect=lambda fn, *a, **kw: fn(*a, **kw)), \
              patch("wenzi.scripting.ui.chooser_panel.reactivate_app"):
@@ -1942,6 +1922,6 @@ class TestDeferredRecycle:
         panel._pending_js = []
         with patch.object(panel, "_inject_i18n"), \
              patch.object(panel, "_eval_js"), \
-             patch.object(panel, "_deactivate_vfx") as mock_release:
+             patch.object(panel, "_deactivate_glass") as mock_release:
             panel._on_page_loaded()
         mock_release.assert_called_once_with()

--- a/tests/ui/test_streaming_overlay.py
+++ b/tests/ui/test_streaming_overlay.py
@@ -80,7 +80,7 @@ class TestStreamingOverlayPanel:
     def test_initial_state(self):
         panel = _make_panel()
         assert panel._panel is None
-        assert panel._vfx_view is None
+        assert panel._content_box is None
         assert panel._tap_runner is None
         assert panel._stream_text_view is None
 
@@ -88,7 +88,7 @@ class TestStreamingOverlayPanel:
         panel = _make_panel()
         panel.show(asr_text="hello")
         assert panel._panel is not None
-        assert panel._vfx_view is not None
+        assert panel._content_box is not None
         assert panel._asr_text_view is not None
         assert panel._stream_text_view is not None
 
@@ -104,7 +104,7 @@ class TestStreamingOverlayPanel:
         panel.close()
         mock_ns_panel.orderOut_.assert_called_with(None)
         assert panel._panel is None
-        assert panel._vfx_view is None
+        assert panel._content_box is None
         assert panel._stream_text_view is None
 
     def test_show_registers_key_tap(self, _mock_cgeventtap):


### PR DESCRIPTION
## Summary

- Migrate recording indicator, streaming overlay, alert panels, and chooser panel to `NSGlassEffectView` (Liquid Glass), replacing `NSVisualEffectView`
- Extract `configure_glass_appearance()` helper in `ui_helpers.py` to lock adaptive appearance to the system theme
- Extract `dynamic_color()` helper for light/dark mode aware custom colors
- Fix annotation window not activating on show; inset chooser search-bar separator

## Test plan

- [x] All 3833 tests pass
- [x] Lint clean (`ruff check`)
- [ ] Verify Liquid Glass rendering on panels in both light and dark mode
- [ ] Confirm recording indicator, streaming overlay, and alert panels display correctly over varying backgrounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)