### PR TITLE
fix: correct _adaptiveAppearance enum for macOS 26 NSGlassEffectView

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,35 +31,33 @@ The minimum supported macOS version is **macOS 26 (Tahoe)**. Do not add backward
 
 NSGlassEffectView is **adaptive by default**: it continuously samples the brightness of content behind the window and auto-switches between light and dark rendering, **ignoring the system dark/light mode setting**. This means a dark-mode panel over a white background will render as light glass.
 
-The public `setAppearance_()` API does **not** fix this — the glass material's own rendering pipeline ignores it. You must use the private `_adaptiveAppearance` property:
+The public `setAppearance_()` API does **not** fix this by itself — you must
+also disable the glass view's private adaptive backdrop sampling.
 
-- **0** = Light (force light)
-- **1** = Dark (force dark)
-- **2** = Auto (default — adapts to behind-window brightness)
+On macOS 26, runtime inspection shows `_adaptiveAppearance` maps as:
+
+- **0** = automatic
+- **1** = off
+- **2** = on
 
 ```python
 from AppKit import NSApp, NSAppearance, NSGlassEffectView
 
 glass = NSGlassEffectView.alloc().initWithFrame_(frame)
 
-# Detect system theme
 sys_appearance = NSApp.effectiveAppearance()
-name = sys_appearance.bestMatchFromAppearancesWithNames_(
-    ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-)
-is_dark = name is not None and "Dark" in str(name)
 
 # Public API — cascade to subviews (labels, text fields, etc.)
 glass.setAppearance_(sys_appearance)
 
-# Private API — lock the glass material itself
+# Private API — disable adaptive backdrop sampling on the glass material itself
 if glass.respondsToSelector_(b"set_adaptiveAppearance:"):
-    glass.set_adaptiveAppearance_(1 if is_dark else 0)
+    glass.set_adaptiveAppearance_(1)
 ```
 
 **Every** `NSGlassEffectView` instance in the project must apply this pattern. Without it, small panels (like the recording indicator) over bright/dark backgrounds will visually contradict the system theme. See `recording_indicator.py:_make_glass_view()` for the reference implementation.
 
-**Note:** `_adaptiveAppearance` is a private API (discovered via [qt-liquid-glass](https://github.com/fsalinas26/qt-liquid-glass)). Always guard with `respondsToSelector_`.
+**Note:** `_adaptiveAppearance` is a private API. Older reverse-engineering notes often describe it as `0=light, 1=dark, 2=auto`, but that mapping does not match macOS 26 runtime behavior. Always guard with `respondsToSelector_`.
 
 ## Test Safety — Never Use Real User Data Paths
 

--- a/dev/liquid-glass-api.md
+++ b/dev/liquid-glass-api.md
@@ -71,13 +71,13 @@ container.contentView = holderView  // holderView 包含多个 NSGlassEffectView
 
 ## 锁定自适应外观（关键！）
 
-NSGlassEffectView 默认持续采样背后内容亮度来自动切换 light/dark 渲染，忽略系统主题和 `setAppearance_`。必须用私有属性 `_adaptiveAppearance` 锁定：
+NSGlassEffectView 默认持续采样背后内容亮度来自动切换 light/dark 渲染，忽略系统主题和 `setAppearance_`。在 macOS 26 上，需要用私有属性 `_adaptiveAppearance` **关闭**自适应，再用 `setAppearance_` 指定 light/dark：
 
 | 值 | 含义 |
 |----|------|
-| 0 | 强制 Light |
-| 1 | 强制 Dark |
-| 2 | Auto（默认，根据背后内容亮度自适应） |
+| 0 | automatic |
+| 1 | off |
+| 2 | on |
 
 项目中已封装为 `configure_glass_appearance(glass)`（见 `ui_helpers.py`），所有 NSGlassEffectView 实例必须调用：
 
@@ -89,7 +89,7 @@ glass.setCornerRadius_(12)
 configure_glass_appearance(glass)
 ```
 
-来源：[qt-liquid-glass](https://github.com/fsalinas26/qt-liquid-glass) 逆向发现，私有 API 需 `respondsToSelector_` 保护。
+说明：旧的逆向资料常把 `_adaptiveAppearance` 记成 `0=Light, 1=Dark, 2=Auto`，但这与 macOS 26 runtime inspection 不符。项目内验证结果是 `1=off`，这也是当前需要使用的值。私有 API 需 `respondsToSelector_` 保护。
 
 ### 其他私有属性
 

--- a/src/wenzi/ui_helpers.py
+++ b/src/wenzi/ui_helpers.py
@@ -80,7 +80,7 @@ def configure_glass_appearance(glass) -> None:
     brightness and auto-switches light/dark, ignoring the system setting.
     This helper forces it to follow the system appearance via
     ``setAppearance_`` (public) and ``set_adaptiveAppearance_`` (private;
-    0=Light, 1=Dark, 2=Auto).
+    0=automatic, 1=off, 2=on).
 
     See CLAUDE.md "NSGlassEffectView — Lock Adaptive Appearance" for details.
     """
@@ -88,14 +88,16 @@ def configure_glass_appearance(glass) -> None:
         from AppKit import NSApp
 
         sys_appearance = NSApp.effectiveAppearance()
-        name = sys_appearance.bestMatchFromAppearancesWithNames_(
-            ["NSAppearanceNameAqua", "NSAppearanceNameDarkAqua"]
-        )
-        is_dark = name is not None and "Dark" in str(name)
-
         glass.setAppearance_(sys_appearance)
         if glass.respondsToSelector_(b"set_adaptiveAppearance:"):
-            glass.set_adaptiveAppearance_(1 if is_dark else 0)
+            # On macOS 26, the private enum does not map to light/dark modes.
+            # Runtime inspection shows:
+            #   0 = automatic
+            #   1 = off
+            #   2 = on
+            # Disable adaptive backdrop sampling, then let NSAppearance choose
+            # whether the glass should render in light or dark mode.
+            glass.set_adaptiveAppearance_(1)
     except Exception:
         logger.debug("Failed to lock glass appearance", exc_info=True)
 

--- a/tests/test_ui_helpers.py
+++ b/tests/test_ui_helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 from unittest.mock import MagicMock, patch
 
 from wenzi.ui_helpers import reactivate_app
@@ -67,3 +69,44 @@ class TestReactivateApp:
         with patch("PyObjCTools.AppHelper") as mock_helper:
             reactivate_app(mock_running_app)
             mock_helper.callAfter.assert_called_once()
+
+
+class TestConfigureGlassAppearance:
+    """Tests for configure_glass_appearance()."""
+
+    def _run_case(self, appearance_name: str):
+        mock_sys_appearance = MagicMock()
+        mock_sys_appearance.bestMatchFromAppearancesWithNames_.return_value = appearance_name
+
+        mock_app = MagicMock()
+        mock_app.effectiveAppearance.return_value = mock_sys_appearance
+
+        mock_appkit = MagicMock(NSApp=mock_app)
+        glass = MagicMock()
+        glass.respondsToSelector_.return_value = True
+
+        original = sys.modules.get("AppKit")
+        with patch.dict(sys.modules, {"AppKit": mock_appkit}):
+            import wenzi.ui_helpers as mod
+
+            importlib.reload(mod)
+            mod.configure_glass_appearance(glass)
+
+        if original is not None:
+            sys.modules["AppKit"] = original
+        else:
+            sys.modules.pop("AppKit", None)
+
+        return glass, mock_sys_appearance
+
+    def test_disables_adaptive_sampling_for_light_mode(self):
+        glass, mock_sys_appearance = self._run_case("NSAppearanceNameAqua")
+
+        glass.setAppearance_.assert_called_once_with(mock_sys_appearance)
+        glass.set_adaptiveAppearance_.assert_called_once_with(1)
+
+    def test_disables_adaptive_sampling_for_dark_mode(self):
+        glass, mock_sys_appearance = self._run_case("NSAppearanceNameDarkAqua")
+
+        glass.setAppearance_.assert_called_once_with(mock_sys_appearance)
+        glass.set_adaptiveAppearance_.assert_called_once_with(1)


### PR DESCRIPTION
The old mapping (0=Light, 1=Dark, 2=Auto) from qt-liquid-glass does not match macOS 26 runtime behavior. Actual values: 0=automatic, 1=off, 2=on. We were passing 0 thinking it forced Light, but it meant automatic — leaving adaptive sampling fully active. Now unconditionally pass 1 (off) and let setAppearance_() handle light/dark cascading.