### PR TITLE
fix: prevent WebContent process leak in ChooserPanel recycle

### DIFF
--- a/src/wenzi/scripting/ui/chooser_panel.py
+++ b/src/wenzi/scripting/ui/chooser_panel.py
@@ -944,6 +944,26 @@ class ChooserPanel:
         """Release the webview, panel, and associated delegates."""
         from wenzi.ui.web_utils import cleanup_webview
 
+        # Cancel pending debounce timers and bump the search generation so
+        # any in-flight async callAfter results see a stale generation and
+        # become no-ops immediately.
+        self._cancel_all_debounce_timers()
+        self._search_generation += 1
+
+        # Break _panel_ref back-references to prevent retain cycles
+        # (handler/nav_delegate/panel_delegate → ChooserPanel → webview).
+        if self._message_handler is not None:
+            self._message_handler._panel_ref = None
+        if self._navigation_delegate is not None:
+            self._navigation_delegate._panel_ref = None
+        if self._panel_delegate is not None:
+            self._panel_delegate._panel_ref = None
+
+        # Remove webview from the glass view hierarchy so the ObjC
+        # superview no longer retains it (glass → webview strong ref).
+        if self._webview is not None:
+            self._webview.removeFromSuperview()
+
         cleanup_webview(self._webview, handler_name="chooser")
         if self._panel is not None:
             self._panel.setDelegate_(None)

--- a/tests/scripting/test_chooser_panel.py
+++ b/tests/scripting/test_chooser_panel.py
@@ -1894,6 +1894,50 @@ class TestDeferredRecycle:
         mock_build.assert_not_called()
         assert panel._webview is not None
 
+    def test_teardown_breaks_panel_refs(self):
+        """_teardown_webview must nil _panel_ref on all delegates."""
+        panel = _make_panel()
+        panel._webview = MagicMock()
+        panel._panel = MagicMock()
+        handler = MagicMock()
+        handler._panel_ref = panel
+        nav = MagicMock()
+        nav._panel_ref = panel
+        delegate = MagicMock()
+        delegate._panel_ref = panel
+        panel._message_handler = handler
+        panel._navigation_delegate = nav
+        panel._panel_delegate = delegate
+        panel._teardown_webview()
+        assert handler._panel_ref is None
+        assert nav._panel_ref is None
+        assert delegate._panel_ref is None
+
+    def test_teardown_removes_webview_from_superview(self):
+        """_teardown_webview must call removeFromSuperview on the webview."""
+        panel = _make_panel()
+        webview = MagicMock()
+        panel._webview = webview
+        panel._panel = MagicMock()
+        panel._message_handler = MagicMock()
+        panel._navigation_delegate = MagicMock()
+        panel._panel_delegate = MagicMock()
+        panel._teardown_webview()
+        webview.removeFromSuperview.assert_called_once()
+
+    def test_teardown_cancels_debounce_timers(self):
+        """_teardown_webview must cancel pending debounce timers."""
+        panel = _make_panel()
+        panel._webview = MagicMock()
+        panel._panel = MagicMock()
+        timer = MagicMock()
+        panel._debounce_state = {"src": MagicMock(timer=timer)}
+        gen_before = panel._search_generation
+        panel._teardown_webview()
+        timer.invalidate.assert_called_once()
+        assert panel._debounce_state == {}
+        assert panel._search_generation == gen_before + 1
+
     def test_show_reuses_hidden_preload_without_reloading_html(self):
         panel = _make_panel()
         panel._panel = MagicMock()


### PR DESCRIPTION
_teardown_webview() failed to break all ObjC retain chains, so recycled WKWebView instances were never deallocated and their WebContent XPC processes accumulated indefinitely.

Three missing cleanup steps added:
- Nil _panel_ref on message handler, navigation delegate, and panel delegate (breaks delegate → ChooserPanel → webview cycle)
- Call removeFromSuperview() on the webview (breaks glass → webview ObjC strong reference from addSubview_)
- Cancel debounce timers and bump search generation (prevents stale async callbacks from briefly retaining the panel)