### PR TITLE
feat: consolidate hotkey listeners into SharedHotkeyTap

### DIFF
--- a/src/wenzi/_cgeventtap.py
+++ b/src/wenzi/_cgeventtap.py
@@ -250,7 +250,7 @@ class CGEventTapRunner:
             self._loop = CFRunLoopGetCurrent()
             CFRunLoopAddSource(self._loop, source, kCFRunLoopDefaultMode.value)
             CGEventTapEnable(tap, True)
-            _runner_logger.debug("CGEventTap started")
+            _runner_logger.info("CGEventTap created (tap=%#x, option=%d, mask=0x%x)", tap, option, mask)
             self._ready.set()
             CFRunLoopRun()
 

--- a/src/wenzi/app.py
+++ b/src/wenzi/app.py
@@ -42,7 +42,7 @@ from .controllers.universal_action_controller import UniversalActionController
 from .controllers.update_controller import UpdateController
 from .enhance.conversation_history import ConversationHistory
 from .enhance.enhancer import MODE_OFF, create_enhancer
-from .hotkey import MultiHotkeyListener, TapHotkeyListener, _is_fn_key
+from .hotkey import MultiHotkeyListener, SharedHotkeyTap, _is_fn_key
 from .i18n import t
 from .statusbar import (
     StatusBarApp,
@@ -440,8 +440,9 @@ class WenZiApp(StatusBarApp):
         self._screenshot_item = StatusMenuItem(
             "Screenshot", callback=self._on_screenshot
         )
-        self._screenshot_hotkey_listener = None
-        self._clipboard_hotkey_listener = None
+        self._app_hotkey_tap = SharedHotkeyTap()
+        self._screenshot_hotkey_key = None
+        self._clipboard_hotkey_key = None
         self._screenshot_annotation = None
 
         # Feedback toggle items
@@ -1144,10 +1145,7 @@ class WenZiApp(StatusBarApp):
             self._script_engine.stop()
         if self._hotkey_listener:
             self._hotkey_listener.stop()
-        if self._clipboard_hotkey_listener:
-            self._clipboard_hotkey_listener.stop()
-        if self._screenshot_hotkey_listener:
-            self._screenshot_hotkey_listener.stop()
+        self._app_hotkey_tap.stop()
         if self._settings_panel.is_visible:
             self._settings_panel.close()
         if self._vocab_controller is not None:
@@ -1543,23 +1541,19 @@ class WenZiApp(StatusBarApp):
                 self._refresh_status_bar
             )
 
-        # Start clipboard enhance hotkey listener if configured
+        # Start clipboard enhance hotkey if configured
         clip_hotkey = self._config.get("clipboard_enhance", {}).get("hotkey", "")
         if clip_hotkey:
-            self._clipboard_hotkey_listener = TapHotkeyListener(
-                hotkey_str=clip_hotkey,
-                on_activate=self._preview_controller.on_clipboard_enhance,
+            self._clipboard_hotkey_key = self._app_hotkey_tap.add(
+                clip_hotkey, self._preview_controller.on_clipboard_enhance,
             )
-            self._clipboard_hotkey_listener.start()
 
-        # Start screenshot hotkey listener if configured
+        # Start screenshot hotkey if configured
         ss_cfg = self._config.get("screenshot", {})
         if ss_cfg.get("enabled", False) and ss_cfg.get("hotkey", ""):
-            self._screenshot_hotkey_listener = TapHotkeyListener(
-                hotkey_str=ss_cfg["hotkey"],
-                on_activate=self._on_screenshot,
+            self._screenshot_hotkey_key = self._app_hotkey_tap.add(
+                ss_cfg["hotkey"], self._on_screenshot,
             )
-            self._screenshot_hotkey_listener.start()
 
         # Schedule warmup after the event loop starts to pre-create heavy
         # objects (WKWebView, NSSound) so the first user interaction is snappy.

--- a/src/wenzi/config.py
+++ b/src/wenzi/config.py
@@ -339,7 +339,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "interval_hours": 6,
     },
     "logging": {
-        "level": "INFO",
+        "level": "DEBUG",
     },
     "scripting": {
         "enabled": False,

--- a/src/wenzi/controllers/config_controller.py
+++ b/src/wenzi/controllers/config_controller.py
@@ -182,7 +182,6 @@ class ConfigController:
     def on_reload_config(self, _) -> None:
         """Reload configuration from disk and apply changes."""
         from wenzi.enhance.enhancer import MODE_OFF
-        from wenzi.hotkey import TapHotkeyListener
 
         app = self._app
 
@@ -264,19 +263,13 @@ class ConfigController:
         # Clipboard enhance hotkey
         clip_cfg = new_config.get("clipboard_enhance", {})
         new_clip_hotkey = clip_cfg.get("hotkey", "")
-        old_clip_hotkey = ""
-        if app._clipboard_hotkey_listener:
-            old_clip_hotkey = app._clipboard_hotkey_listener._hotkey_str
-        if new_clip_hotkey != old_clip_hotkey:
-            if app._clipboard_hotkey_listener:
-                app._clipboard_hotkey_listener.stop()
-                app._clipboard_hotkey_listener = None
-            if new_clip_hotkey:
-                app._clipboard_hotkey_listener = TapHotkeyListener(
-                    hotkey_str=new_clip_hotkey,
-                    on_activate=app._preview_controller.on_clipboard_enhance,
-                )
-                app._clipboard_hotkey_listener.start()
+        if app._clipboard_hotkey_key is not None:
+            app._app_hotkey_tap.remove(app._clipboard_hotkey_key)
+            app._clipboard_hotkey_key = None
+        if new_clip_hotkey:
+            app._clipboard_hotkey_key = app._app_hotkey_tap.add(
+                new_clip_hotkey, app._preview_controller.on_clipboard_enhance,
+            )
 
         logger.info("Configuration reloaded successfully")
         send_notification(t("app.name"), t("notification.config.reloaded"), t("notification.config.reloaded.subtitle"))

--- a/src/wenzi/controllers/settings_controller.py
+++ b/src/wenzi/controllers/settings_controller.py
@@ -1882,21 +1882,17 @@ class SettingsController:
         ss_cfg["enabled"] = enabled
         self._save_and_reload()
 
-        # Start or stop the hotkey listener
+        # Start or stop the hotkey
         if enabled:
             hotkey = ss_cfg.get("hotkey", "")
-            if hotkey and not app._screenshot_hotkey_listener:
-                from wenzi.hotkey import TapHotkeyListener
-
-                app._screenshot_hotkey_listener = TapHotkeyListener(
-                    hotkey_str=hotkey,
-                    on_activate=app._on_screenshot,
+            if hotkey and app._screenshot_hotkey_key is None:
+                app._screenshot_hotkey_key = app._app_hotkey_tap.add(
+                    hotkey, app._on_screenshot,
                 )
-                app._screenshot_hotkey_listener.start()
         else:
-            if app._screenshot_hotkey_listener:
-                app._screenshot_hotkey_listener.stop()
-                app._screenshot_hotkey_listener = None
+            if app._screenshot_hotkey_key is not None:
+                app._app_hotkey_tap.remove(app._screenshot_hotkey_key)
+                app._screenshot_hotkey_key = None
 
         logger.info("Screenshot set to: %s", enabled)
 
@@ -1911,17 +1907,13 @@ class SettingsController:
         ss_cfg["hotkey"] = recorded_key
         self._save_and_reload()
 
-        # Rebind the hotkey listener if screenshot is enabled
+        # Rebind the hotkey if screenshot is enabled
         if ss_cfg.get("enabled", False):
-            if app._screenshot_hotkey_listener:
-                app._screenshot_hotkey_listener.stop()
-            from wenzi.hotkey import TapHotkeyListener
-
-            app._screenshot_hotkey_listener = TapHotkeyListener(
-                hotkey_str=recorded_key,
-                on_activate=app._on_screenshot,
+            if app._screenshot_hotkey_key is not None:
+                app._app_hotkey_tap.remove(app._screenshot_hotkey_key)
+            app._screenshot_hotkey_key = app._app_hotkey_tap.add(
+                recorded_key, app._on_screenshot,
             )
-            app._screenshot_hotkey_listener.start()
 
         app._settings_panel.update_screenshot_hotkey(recorded_key)
         logger.info("Screenshot hotkey recorded: %s", recorded_key)
@@ -1933,9 +1925,9 @@ class SettingsController:
         ss_cfg["hotkey"] = ""
         self._save_and_reload()
 
-        if app._screenshot_hotkey_listener:
-            app._screenshot_hotkey_listener.stop()
-            app._screenshot_hotkey_listener = None
+        if app._screenshot_hotkey_key is not None:
+            app._app_hotkey_tap.remove(app._screenshot_hotkey_key)
+            app._screenshot_hotkey_key = None
 
         app._settings_panel.update_screenshot_hotkey("")
         logger.info("Screenshot hotkey cleared")

--- a/src/wenzi/hotkey.py
+++ b/src/wenzi/hotkey.py
@@ -393,6 +393,142 @@ class TapHotkeyListener:
 
 
 # ---------------------------------------------------------------------------
+# SharedHotkeyTap — single CGEventTap for many hotkey combinations
+# ---------------------------------------------------------------------------
+
+class SharedHotkeyTap:
+    """Single CGEventTap that multiplexes multiple hotkey combinations.
+
+    Replaces per-hotkey TapHotkeyListener instances with one shared tap,
+    reducing the number of CGEventTaps from N to 1.
+    """
+
+    def __init__(self) -> None:
+        self._bindings: dict[tuple[int, int], dict[int, Callable[[], None]]] = {}
+        self._tokens: dict[int, tuple[int, int]] = {}
+        self._next_token = 0
+        self._runner = None  # CGEventTapRunner | None
+        self._cg = None  # cached _cgeventtap module
+        self._lock = threading.Lock()
+
+    def add(self, hotkey_str: str, on_activate: Callable[[], None]) -> int:
+        """Register a hotkey. Returns a unique token for later removal.
+
+        Starts the underlying tap automatically on the first add().
+        """
+        mod_flags, keycode = _parse_hotkey_for_quartz(hotkey_str)
+        key = (mod_flags, keycode)
+        with self._lock:
+            token = self._next_token
+            self._next_token += 1
+            callbacks = self._bindings.setdefault(key, {})
+            callbacks[token] = on_activate
+            self._tokens[token] = key
+            if self._runner is None:
+                self._start_tap()
+        logger.debug("SharedHotkeyTap: added %s (flags=0x%x kc=%d, token=%d)",
+                     hotkey_str, mod_flags, keycode, token)
+        return token
+
+    def remove(self, token: int) -> None:
+        """Unregister a hotkey by its registration token.
+
+        When the last binding is removed the tap is auto-stopped.
+        """
+        with self._lock:
+            key = self._tokens.pop(token, None)
+            if key is None:
+                return
+
+            callbacks = self._bindings.get(key)
+            if callbacks is None:
+                return
+
+            callbacks.pop(token, None)
+            if not callbacks:
+                self._bindings.pop(key, None)
+            if not self._bindings:
+                self._stop_tap_locked()
+
+    def stop(self) -> None:
+        """Stop the tap and remove all bindings."""
+        with self._lock:
+            self._bindings.clear()
+            self._tokens.clear()
+            self._stop_tap_locked()
+        logger.info("SharedHotkeyTap stopped")
+
+    def _stop_tap_locked(self) -> None:
+        """Stop the underlying tap. Caller must hold *_lock*."""
+        if self._runner is not None:
+            self._runner.stop()
+            self._runner = None
+
+    def _start_tap(self) -> None:
+        """Create and start the CGEventTap.  Caller must hold *_lock*."""
+        from wenzi import _cgeventtap as cg
+
+        self._cg = cg
+        mask = cg.CGEventMaskBit(cg.kCGEventKeyDown)
+        self._runner = cg.CGEventTapRunner()
+        self._runner.start(mask, self._callback)
+        logger.info("SharedHotkeyTap: CGEventTap created (bindings=%d)", len(self._bindings))
+
+    def _callback(self, proxy, event_type, event, refcon):
+        cg = self._cg
+
+        try:
+            if event_type == cg.kCGEventTapDisabledByTimeout:
+                logger.warning("SharedHotkeyTap disabled by timeout, re-enabling")
+                if self._runner is not None and self._runner.tap is not None:
+                    cg.CGEventTapEnable(self._runner.tap, True)
+                return event
+
+            if event_type != cg.kCGEventKeyDown:
+                return event
+
+            keycode = cg.CGEventGetIntegerValueField(
+                event, cg.kCGKeyboardEventKeycode
+            )
+            flags = cg.CGEventGetFlags(event) & _MOD_MASK
+            key = (flags, keycode)
+
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug("SharedHotkeyTap: keydown flags=0x%x kc=%d (%s)",
+                             flags, keycode, _VK_TO_NAME.get(keycode, "?"))
+
+            d = self._bindings.get(key)
+            if d is None:
+                return event
+
+            with self._lock:
+                callbacks = tuple(d.values())
+
+            if callbacks:
+                logger.info("SharedHotkeyTap matched: %s",
+                            _format_hotkey(flags, keycode))
+                for callback in callbacks:
+                    _submit_callback(callback)
+                return None  # Swallow the event
+
+            return event
+        except Exception:
+            logger.warning("[SharedHotkeyTap] callback exception", exc_info=True)
+            return event
+
+
+# Ordered list for _format_hotkey — iterate instead of hard-coding each flag.
+_MOD_DISPLAY_ORDER = ("cmd", "ctrl", "alt", "shift")
+
+
+def _format_hotkey(flags: int, keycode: int) -> str:
+    """Format modifier flags + keycode into a human-readable string."""
+    parts = [name for name in _MOD_DISPLAY_ORDER if flags & _MOD_FLAGS[name]]
+    parts.append(_VK_TO_NAME.get(keycode, f"vk{keycode}"))
+    return "+".join(parts)
+
+
+# ---------------------------------------------------------------------------
 # KeyRemapListener — remap one key to another via CGEventTap
 # ---------------------------------------------------------------------------
 

--- a/src/wenzi/scripting/api/hotkey.py
+++ b/src/wenzi/scripting/api/hotkey.py
@@ -20,6 +20,7 @@ class HotkeyAPI:
         self._registry = registry
         self._leader_alert = LeaderAlertPanel()
         self._listener = None  # _QuartzAllKeysListener
+        self._shared_tap = None  # SharedHotkeyTap
         self._active_leader: LeaderConfig | None = None
         self._leader_triggered: bool = False
         self._sticky_leader: bool = False
@@ -51,7 +52,11 @@ class HotkeyAPI:
 
     def unbind(self, hotkey_str: str) -> None:
         """Remove and stop a hotkey binding."""
-        self._registry.unregister_hotkey(hotkey_str)
+        removed = self._registry.unregister_hotkey(hotkey_str)
+        if self._shared_tap:
+            for binding in removed:
+                if binding.tap_key is not None:
+                    self._shared_tap.remove(binding.tap_key)
 
     def remap(self, source: str, target: str) -> None:
         """Remap one key to another.
@@ -146,10 +151,11 @@ class HotkeyAPI:
         if self._listener:
             self._listener.stop()
             self._listener = None
+        if self._shared_tap:
+            self._shared_tap.stop()
+            self._shared_tap = None
         for binding in self._registry.hotkeys:
-            if binding.listener:
-                binding.listener.stop()
-                binding.listener = None
+            binding.tap_key = None
         # Stop remap listener
         if self._registry.remap_listener:
             self._registry.remap_listener.stop()
@@ -186,21 +192,24 @@ class HotkeyAPI:
         )
 
     def _start_hotkey_listeners(self) -> None:
-        """Start individual TapHotkeyListener for each registered hotkey."""
-        from wenzi.hotkey import TapHotkeyListener
+        """Register all hotkeys on a single shared CGEventTap."""
+        if not self._registry.hotkeys:
+            return
+
+        from wenzi.hotkey import SharedHotkeyTap
+
+        if self._shared_tap is None:
+            self._shared_tap = SharedHotkeyTap()
 
         for binding in self._registry.hotkeys:
-            if binding.listener is not None:
+            if binding.tap_key is not None:
                 continue
             try:
-                listener = TapHotkeyListener(
-                    hotkey_str=binding.hotkey_str,
-                    on_activate=binding.callback,
+                binding.tap_key = self._shared_tap.add(
+                    binding.hotkey_str, binding.callback,
                 )
-                listener.start()
-                binding.listener = listener
             except Exception as exc:
-                logger.error("Failed to start hotkey %s: %s", binding.hotkey_str, exc)
+                logger.error("Failed to add hotkey %s: %s", binding.hotkey_str, exc)
 
     def _start_remap_listener(self, new_entry: RemapEntry | None = None) -> None:
         """Start (or update) the shared KeyRemapListener for registered remaps.

--- a/src/wenzi/scripting/registry.py
+++ b/src/wenzi/scripting/registry.py
@@ -39,7 +39,7 @@ class HotkeyBinding:
 
     hotkey_str: str
     callback: Callable
-    listener: Any = None  # TapHotkeyListener instance, set at start time
+    tap_key: int | None = None  # SharedHotkeyTap registration token, set at start time
 
 
 @dataclass
@@ -132,18 +132,18 @@ class ScriptingRegistry:
         self._hotkeys.append(HotkeyBinding(hotkey_str=hotkey_str, callback=callback))
         logger.info("Registered hotkey: %s", hotkey_str)
 
-    def unregister_hotkey(self, hotkey_str: str) -> None:
-        """Remove and stop a hotkey binding by its hotkey string."""
+    def unregister_hotkey(self, hotkey_str: str) -> list[HotkeyBinding]:
+        """Remove a hotkey binding by its hotkey string.
+
+        Returns the removed bindings so the caller can clean up the
+        shared tap.
+        """
         to_remove = [b for b in self._hotkeys if b.hotkey_str == hotkey_str]
         for binding in to_remove:
-            if binding.listener:
-                try:
-                    binding.listener.stop()
-                except Exception:
-                    pass
             self._hotkeys.remove(binding)
         if to_remove:
             logger.info("Unregistered hotkey: %s", hotkey_str)
+        return to_remove
 
     def register_remap(self, entry: RemapEntry) -> None:
         """Register a key remap."""
@@ -231,13 +231,7 @@ class ScriptingRegistry:
                 if entry._timer:
                     entry._timer.cancel()
             self._timers.clear()
-        # Stop hotkey listeners
-        for binding in self._hotkeys:
-            if binding.listener:
-                try:
-                    binding.listener.stop()
-                except Exception:
-                    pass
+        # Hotkey bindings only — HotkeyAPI owns the tap lifecycle.
         self._hotkeys.clear()
         self._leaders.clear()
         # Stop remap listener

--- a/tests/controllers/test_config_controller.py
+++ b/tests/controllers/test_config_controller.py
@@ -51,7 +51,8 @@ def mock_app():
     app._visual_indicator_item = MagicMock()
     app._sound_manager = MagicMock()
     app._recording_indicator = MagicMock()
-    app._clipboard_hotkey_listener = None
+    app._app_hotkey_tap = MagicMock()
+    app._clipboard_hotkey_key = None
     app._menu_builder = MagicMock()
     app._preview_controller = MagicMock()
     return app
@@ -157,7 +158,8 @@ class TestOnReloadConfig:
         mock_app._preview_item = MagicMock()
         mock_app._sound_feedback_item = MagicMock()
         mock_app._visual_indicator_item = MagicMock()
-        mock_app._clipboard_hotkey_listener = None
+        mock_app._app_hotkey_tap = MagicMock()
+        mock_app._clipboard_hotkey_key = None
 
         ctrl.on_reload_config(None)
 
@@ -172,6 +174,24 @@ class TestOnReloadConfig:
         mock_notify.assert_called_once()
         subtitle = mock_notify.call_args[0][1]
         assert "Reload Failed" in subtitle or "reload_failed" in subtitle
+
+    @patch("wenzi.controllers.config_controller.send_notification")
+    @patch("wenzi.controllers.config_controller.load_config")
+    def test_reload_removes_clipboard_hotkey_when_token_is_zero(self, mock_load, mock_notify, ctrl, mock_app):
+        mock_load.return_value = ({
+            "output": {"method": "type", "append_newline": False, "preview": True},
+            "logging": {"level": "INFO"},
+            "ai_enhance": {"enabled": True, "mode": "proofread"},
+            "feedback": {"sound_enabled": True, "sound_volume": 0.4, "visual_indicator": True},
+            "clipboard_enhance": {"hotkey": ""},
+        }, None)
+        mock_app._clipboard_hotkey_key = 0
+
+        ctrl.on_reload_config(None)
+
+        mock_app._app_hotkey_tap.remove.assert_called_once_with(0)
+        assert mock_app._clipboard_hotkey_key is None
+        mock_notify.assert_called_once()
 
 
 class TestOnBrowseHistory:
@@ -189,4 +209,3 @@ class TestOnBrowseHistory:
         mock_app._history_browser = MagicMock()
         ctrl.on_browse_history(None)
         mock_app._history_browser.show.assert_called_once()
-

--- a/tests/controllers/test_settings_controller.py
+++ b/tests/controllers/test_settings_controller.py
@@ -17,6 +17,7 @@ def mock_app():
         "hotkeys": {"fn": True, "ctrl": False},
         "feedback": {"sound_enabled": True, "visual_indicator": True},
         "output": {"method": "type", "append_newline": False, "preview": True},
+        "screenshot": {"enabled": True, "hotkey": "ctrl+cmd+5"},
         "asr": {
             "backend": "funasr",
             "preset": "funasr-zh",
@@ -78,6 +79,10 @@ def mock_app():
     app._asr_remove_provider_items = {}
     app._llm_remove_provider_items = {}
     app._settings_panel = MagicMock()
+    app._app_hotkey_tap = MagicMock()
+    app._screenshot_hotkey_key = None
+    app._on_screenshot = MagicMock()
+    app.record_combo_hotkey_modal = MagicMock()
     return app
 
 
@@ -217,6 +222,42 @@ class TestPreviewToggle:
         assert mock_app._preview_item.state == 0
         assert mock_app._config["output"]["preview"] is False
         mock_save.assert_called_once()
+
+
+class TestScreenshotHotkey:
+    def test_record_rebinds_existing_token_zero(self, ctrl, mock_app):
+        mock_app._screenshot_hotkey_key = 0
+        mock_app.record_combo_hotkey_modal.return_value = "ctrl+cmd+6"
+        mock_app._app_hotkey_tap.add.return_value = 1
+
+        with patch.object(ctrl, "_save_and_reload") as mock_reload:
+            ctrl.screenshot_hotkey_record()
+
+        mock_reload.assert_called_once()
+        mock_app._app_hotkey_tap.remove.assert_called_once_with(0)
+        mock_app._app_hotkey_tap.add.assert_called_once_with(
+            "ctrl+cmd+6", mock_app._on_screenshot,
+        )
+        assert mock_app._screenshot_hotkey_key == 1
+
+    def test_clear_removes_existing_token_zero(self, ctrl, mock_app):
+        mock_app._screenshot_hotkey_key = 0
+
+        with patch.object(ctrl, "_save_and_reload") as mock_reload:
+            ctrl.screenshot_hotkey_clear()
+
+        mock_reload.assert_called_once()
+        mock_app._app_hotkey_tap.remove.assert_called_once_with(0)
+        assert mock_app._screenshot_hotkey_key is None
+
+    def test_enable_does_not_duplicate_when_token_zero_already_bound(self, ctrl, mock_app):
+        mock_app._screenshot_hotkey_key = 0
+
+        with patch.object(ctrl, "_save_and_reload") as mock_reload:
+            ctrl.screenshot_toggle(True)
+
+        mock_reload.assert_called_once()
+        mock_app._app_hotkey_tap.add.assert_not_called()
 
 
 class TestSttSelect:

--- a/tests/scripting/test_api_hotkey.py
+++ b/tests/scripting/test_api_hotkey.py
@@ -24,6 +24,18 @@ class TestHotkeyAPI:
         assert len(reg.hotkeys) == 1
         assert reg.hotkeys[0].hotkey_str == "ctrl+cmd+v"
 
+    def test_unbind_removes_shared_tap_binding_when_token_is_zero(self):
+        reg = ScriptingRegistry()
+        api = HotkeyAPI(reg)
+        api.bind("ctrl+cmd+v", lambda: None)
+        reg.hotkeys[0].tap_key = 0
+        api._shared_tap = MagicMock()
+
+        api.unbind("ctrl+cmd+v")
+
+        api._shared_tap.remove.assert_called_once_with(0)
+        assert reg.hotkeys == []
+
     @patch("wenzi.scripting.api.hotkey.AppHelper", create=True)
     def test_leader_press_activates(self, mock_helper):
         _, api = self._make_api()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -406,7 +406,7 @@ class TestValidateConfig:
     def test_invalid_log_level(self):
         config = self._make_config({"logging.level": "TRACE"})
         validate_config(config)
-        assert config["logging"]["level"] == "INFO"
+        assert config["logging"]["level"] == "DEBUG"
 
     def test_volume_out_of_range(self):
         config = self._make_config({"feedback.sound_volume": 1.5})

--- a/tests/test_hotkey.py
+++ b/tests/test_hotkey.py
@@ -14,6 +14,7 @@ from wenzi.hotkey import (
     HoldHotkeyListener,
     KeyRemapListener,
     MultiHotkeyListener,
+    SharedHotkeyTap,
     TapHotkeyListener,
     _is_fn_key,
     _name_to_vk,
@@ -330,6 +331,191 @@ class TestTapHotkeyListener:
 
         mock_runner.stop.assert_called_once()
         assert listener._runner is None
+
+
+class TestSharedHotkeyTap:
+    def test_add_parses_and_stores(self):
+        tap = SharedHotkeyTap()
+        cb = MagicMock()
+        token = tap.add("ctrl+cmd+v", cb)
+        key = (_MOD_FLAGS["ctrl"] | _MOD_FLAGS["cmd"], _KEYCODE_MAP["v"])
+        assert token in tap._bindings[key]
+        assert tap._bindings[key][token] is cb
+        assert tap._tokens[token] == key
+        # Cleanup — stop the auto-started runner
+        tap.stop()
+
+    def test_remove(self):
+        tap = SharedHotkeyTap()
+        cb = MagicMock()
+        token = tap.add("cmd+space", cb)
+        key = (_MOD_FLAGS["cmd"], _SPECIAL_VK["space"])
+        assert token in tap._bindings[key]
+        tap.remove(token)
+        assert key not in tap._bindings
+        tap.stop()
+
+    def test_remove_nonexistent_key_is_noop(self):
+        tap = SharedHotkeyTap()
+        tap.remove(999)  # no error
+
+    def test_stop_clears_bindings_and_runner(self):
+        tap = SharedHotkeyTap()
+        tap.add("cmd+a", MagicMock())
+        assert tap._runner is not None
+        tap.stop()
+        assert tap._bindings == {}
+        assert tap._tokens == {}
+        assert tap._runner is None
+
+    def test_callback_matches_and_dispatches(self):
+        """Simulate a kCGEventKeyDown event and verify callback dispatch."""
+        import time
+
+        tap = SharedHotkeyTap()
+        cb = MagicMock()
+        tap.add("cmd+v", cb)
+
+        from wenzi import _cgeventtap as cg
+
+        # Build a fake event: cmd (0x100000) + v (keycode 9)
+        mock_event = 0xDEAD  # non-zero sentinel
+        get_field_orig = cg.CGEventGetIntegerValueField
+        get_flags_orig = cg.CGEventGetFlags
+
+        def fake_get_field(event, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 9  # 'v'
+            return 0
+
+        def fake_get_flags(event):
+            return 0x100000  # cmd
+
+        cg.CGEventGetIntegerValueField = fake_get_field
+        cg.CGEventGetFlags = fake_get_flags
+        try:
+            result = tap._callback(None, cg.kCGEventKeyDown, mock_event, None)
+            assert result is None  # swallowed
+            # Wait for _submit_callback dispatch
+            for _ in range(50):
+                if cb.called:
+                    break
+                time.sleep(0.01)
+            cb.assert_called_once()
+        finally:
+            cg.CGEventGetIntegerValueField = get_field_orig
+            cg.CGEventGetFlags = get_flags_orig
+            tap.stop()
+
+    def test_callback_passes_through_non_matching(self):
+        tap = SharedHotkeyTap()
+        tap.add("cmd+v", MagicMock())
+
+        from wenzi import _cgeventtap as cg
+
+        mock_event = 0xBEEF
+        get_field_orig = cg.CGEventGetIntegerValueField
+        get_flags_orig = cg.CGEventGetFlags
+
+        def fake_get_field(event, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 0  # 'a', not 'v'
+            return 0
+
+        def fake_get_flags(event):
+            return 0x100000  # cmd
+
+        cg.CGEventGetIntegerValueField = fake_get_field
+        cg.CGEventGetFlags = fake_get_flags
+        try:
+            result = tap._callback(None, cg.kCGEventKeyDown, mock_event, None)
+            assert result == mock_event  # passed through
+        finally:
+            cg.CGEventGetIntegerValueField = get_field_orig
+            cg.CGEventGetFlags = get_flags_orig
+            tap.stop()
+
+    def test_multiple_hotkeys_single_tap(self):
+        """Multiple add() calls should share one runner."""
+        tap = SharedHotkeyTap()
+        tap.add("cmd+a", MagicMock())
+        runner1 = tap._runner
+        tap.add("cmd+b", MagicMock())
+        assert tap._runner is runner1  # same runner, not recreated
+        assert len(tap._bindings) == 2
+        tap.stop()
+
+    def test_duplicate_hotkeys_get_distinct_tokens(self):
+        tap = SharedHotkeyTap()
+        cb1 = MagicMock()
+        cb2 = MagicMock()
+
+        token1 = tap.add("cmd+a", cb1)
+        token2 = tap.add("cmd+a", cb2)
+
+        key = (_MOD_FLAGS["cmd"], _KEYCODE_MAP["a"])
+        assert token1 != token2
+        assert set(tap._bindings[key]) == {token1, token2}
+
+        tap.remove(token1)
+        assert set(tap._bindings[key]) == {token2}
+        assert token1 not in tap._tokens
+        assert tap._runner is not None
+
+        tap.remove(token2)
+        assert key not in tap._bindings
+        assert token2 not in tap._tokens
+        assert tap._runner is None
+
+    def test_duplicate_hotkeys_dispatch_all_callbacks(self):
+        import time
+
+        tap = SharedHotkeyTap()
+        cb1 = MagicMock()
+        cb2 = MagicMock()
+        tap.add("cmd+v", cb1)
+        tap.add("cmd+v", cb2)
+
+        from wenzi import _cgeventtap as cg
+
+        mock_event = 0xDEAD
+        get_field_orig = cg.CGEventGetIntegerValueField
+        get_flags_orig = cg.CGEventGetFlags
+
+        def fake_get_field(event, field):
+            if field == cg.kCGKeyboardEventKeycode:
+                return 9
+            return 0
+
+        def fake_get_flags(event):
+            return 0x100000
+
+        cg.CGEventGetIntegerValueField = fake_get_field
+        cg.CGEventGetFlags = fake_get_flags
+        try:
+            result = tap._callback(None, cg.kCGEventKeyDown, mock_event, None)
+            assert result is None
+            for _ in range(50):
+                if cb1.called and cb2.called:
+                    break
+                time.sleep(0.01)
+            cb1.assert_called_once()
+            cb2.assert_called_once()
+        finally:
+            cg.CGEventGetIntegerValueField = get_field_orig
+            cg.CGEventGetFlags = get_flags_orig
+            tap.stop()
+
+    def test_remove_last_binding_stops_runner(self):
+        tap = SharedHotkeyTap()
+        runner = MagicMock()
+        tap._runner = runner
+        token = tap.add("cmd+a", MagicMock())
+
+        tap.remove(token)
+
+        runner.stop.assert_called_once()
+        assert tap._runner is None
 
 
 class TestMultiHotkeyListener:


### PR DESCRIPTION
Replace per-hotkey TapHotkeyListener instances with a single SharedHotkeyTap that multiplexes all hotkey combinations through one CGEventTap, reducing the number of system event taps from N to 1.

- Add SharedHotkeyTap class with add/remove/stop API and auto start/stop lifecycle
- Migrate app.py, config_controller, settings_controller, and scripting HotkeyAPI to use SharedHotkeyTap
- Change HotkeyBinding.listener to tap_key (int token)
- Return removed bindings from unregister_hotkey for caller cleanup
- Change default log level to DEBUG