### PR TITLE
fix: release IOSurface backing store on panel close to prevent 72MB+ …

### DIFF
--- a/src/wenzi/audio/recording_indicator.py
+++ b/src/wenzi/audio/recording_indicator.py
@@ -409,6 +409,9 @@ class RecordingIndicatorPanel:
             self._clear_view_backref()
 
             if self._panel is not None:
+                from wenzi.ui_helpers import release_panel_surfaces
+
+                release_panel_surfaces(self._panel)
                 self._panel.orderOut_(None)
                 self._panel = None
 
@@ -441,6 +444,10 @@ class RecordingIndicatorPanel:
         self._clear_view_backref()
 
         new_height = self._panel_height()
+
+        from wenzi.ui_helpers import release_panel_surfaces
+
+        release_panel_surfaces(self._panel)
         glass = self._make_glass_view(_PANEL_WIDTH, new_height)
         indicator = self._indicator_view.create_view(_PANEL_WIDTH, new_height)
         glass.setContentView_(indicator)

--- a/src/wenzi/ui/history_browser_window_web.py
+++ b/src/wenzi/ui/history_browser_window_web.py
@@ -160,6 +160,9 @@ class HistoryBrowserPanel:
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._close_delegate = None
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
         cleanup_webview(self._webview)

--- a/src/wenzi/ui/result_window_web.py
+++ b/src/wenzi/ui/result_window_web.py
@@ -1016,6 +1016,9 @@ class ResultPreviewPanel:
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._close_delegate = None
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
         cleanup_webview(self._webview)

--- a/src/wenzi/ui/settings_window_web.py
+++ b/src/wenzi/ui/settings_window_web.py
@@ -145,6 +145,9 @@ class SettingsWebPanel:
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._close_delegate = None
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
         from wenzi.ui.web_utils import cleanup_webview

--- a/src/wenzi/ui/stats_panel.py
+++ b/src/wenzi/ui/stats_panel.py
@@ -159,6 +159,9 @@ class StatsChartPanel:
                 if self._close_delegate is not None:
                     self._close_delegate._panel_ref = None
                 self._close_delegate = None
+                from wenzi.ui_helpers import release_panel_surfaces
+
+                release_panel_surfaces(self._panel)
                 self._panel.orderOut_(None)
                 self._panel = None
         except Exception:

--- a/src/wenzi/ui/streaming_overlay.py
+++ b/src/wenzi/ui/streaming_overlay.py
@@ -955,6 +955,9 @@ class StreamingOverlayPanel:
             self._recalc_timer = None
 
         if self._panel is not None:
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
 

--- a/src/wenzi/ui/vocab_manager_window.py
+++ b/src/wenzi/ui/vocab_manager_window.py
@@ -136,6 +136,9 @@ class VocabManagerPanel:
         if self._panel is not None:
             self._panel.setDelegate_(None)
             self._close_delegate = None
+            from wenzi.ui_helpers import release_panel_surfaces
+
+            release_panel_surfaces(self._panel)
             self._panel.orderOut_(None)
             self._panel = None
         cleanup_webview(self._webview)


### PR DESCRIPTION
…memory leak

orderOut_ alone does not release the CA Whippet Drawable IOSurface (~72 MB at retina). Call release_panel_surfaces() before orderOut_ to shrink the panel to 1×1 and deactivate glass, forcing Core Animation to free the GPU-backed compositing surface.